### PR TITLE
Fix/chore

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -32,6 +32,13 @@ module.exports = function override(/** @type{import("webpack").Configuration} */
     config.module.exprContextCritical = false
     config.module.unknownContextCritical = false
 
+    // Prevent all other chunks from being injected to index.html
+    config.plugins.forEach(p => {
+        if (p.constructor.name !== 'HtmlWebpackPlugin') return
+        const {devtools, app, ...exclude} = config.entry
+        Object.keys(exclude).forEach(e => p.options.excludeChunks.push(e))
+    })
+
     config.plugins.push(
         new (require('write-file-webpack-plugin'))({
             test: /(webp|jpg|png|shim|polyfill|js\/.*|index\.html|manifest\.json|_locales)/,

--- a/src/components/Welcomes/1a1a.tsx
+++ b/src/components/Welcomes/1a1a.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
 }))
 export default function Welcome({ next, identities, didntFindAccount }: Props) {
     const classes = useStyles()
-    const [selected, setSelect] = useState<Person[]>([identities[0]])
+    const [selected, setSelect] = useState<Person[]>(identities[0] ? identities : [])
     return (
         <WelcomeContainer className={classes.paper}>
             <Typography variant="h5">{geti18nString('welcome_1a1_title')}</Typography>


### PR DESCRIPTION
This PR solves the following issues:

+ html-webpack-plugin inject unnecessary chunks into index.html (which prevents popup from being loaded)
+ throws on `[undefined]` when no identity is found.