### PR TITLE
fix: bring copy polyfills back

### DIFF
--- a/config-overrides/index.js
+++ b/config-overrides/index.js
@@ -7,8 +7,13 @@ const pkg = require('../package.json')
 
 const src = file => path.join(__dirname, '../', file)
 const argv = require('yargs').argv
+const polyfills = [
+    'node_modules/webextension-polyfill/dist/browser-polyfill.min.js',
+    'node_modules/webextension-polyfill/dist/browser-polyfill.min.js.map',
+].map(src)
 
 const publicDir = src('./public')
+const publicPolyfill = src('./public/polyfill')
 const dist = src('./dist')
 
 process.env.BROWSER = 'none'
@@ -126,9 +131,16 @@ function override(config, env) {
     config.plugins.push(
         new (require('copy-webpack-plugin'))([{ from: publicDir, to: dist }], { ignore: ['index.html'] }),
     )
+    if (!fs.existsSync(publicPolyfill)) {
+        fs.mkdirSync(publicPolyfill)
+        polyfills.map(x => void fs.copyFileSync(x, path.join(publicPolyfill, path.basename(x))))
+        polyfills.length = 0
+    }
+
     if (env !== 'development') {
         config.plugins.push(new SSRPlugin('popup.html', src('./src/extension/popup-page/index.tsx')))
         config.plugins.push(new SSRPlugin('index.html', src('./src/index.tsx')))
+        polyfills.map(x => fs.copyFileSync(x, path.join(publicPolyfill, path.basename(x))))
     }
 
     // Let webpack build to es2017 instead of es5

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,5 @@
     </head>
     <body>
         <div id="root"></div>
-        <script src="polyfill/adoptedStyleSheets.js"></script>
     </body>
 </html>


### PR DESCRIPTION
This is based on t4, `feat: use manifest generator to generate manifests `