### PR TITLE
fix: firefox regression (bring by "chore: reduce the use of `any`")

### DIFF
--- a/src/components/shared-settings/createSettings.tsx
+++ b/src/components/shared-settings/createSettings.tsx
@@ -30,7 +30,7 @@ export function createNewSettings<T extends browser.storage.StorageValue>(
         if (typeof browser === 'object') {
             const value = await browser.storage.local.get()
             const stored = value.settings
-            if (typeof stored === 'object' && stored !== null && Reflect.has(stored, key)) {
+            if (typeof stored === 'object' && stored !== null && key in (stored as any)) {
                 settings.value = Reflect.get(stored, key)
             }
         }

--- a/src/extension/injected-script/addEventListener.ts
+++ b/src/extension/injected-script/addEventListener.ts
@@ -24,7 +24,7 @@ export interface CustomEvents {
         }
         return new Proxy(x, {
             get(target: T, key: keyof T) {
-                return Reflect.get(mockTable, key) || target[key]
+                return (mockTable as any)[key] || target[key]
             },
         })
     }

--- a/src/extension/service.ts
+++ b/src/extension/service.ts
@@ -79,10 +79,9 @@ function register<T extends Service>(service: T, name: keyof Services, mock?: Pa
         if (GetContext() === 'debugging') {
             // ? -> UI developing
             const mockService = new Proxy(mock || {}, {
-                get(target: Record<string, (...args: unknown[]) => unknown>, key: keyof typeof target) {
-                    return async function(...args: unknown[]) {
-                        const f = target[key]
-                        if (typeof f === 'function') return f(...args)
+                get(target: any, key: string) {
+                    return async function(...args: any[]) {
+                        if (target[key]) return target[key](...args)
                         return void 0
                     }
                 },

--- a/src/utils/components/AsyncComponent.tsx
+++ b/src/utils/components/AsyncComponent.tsx
@@ -66,16 +66,12 @@ export function useAsync<T>(fn: () => PromiseLike<T>, dep: ReadonlyArray<unknown
             unmounted = true
         }
         // eslint-disable-next-line
-    }, dep.concat(fn))
+    }, dep)
     return {
         then(f, r) {
-            return new Promise(async (resolve, reject) => {
-                res = (val: unknown) => {
-                    f ? resolve(f(val as T)) : resolve(val as any)
-                }
-                rej = (err: unknown) => {
-                    r ? resolve(r(err)) : reject(err)
-                }
+            return new Promise<any>((resolve, reject) => {
+                res = (val: any) => (f ? resolve(f(val)) : resolve(val))
+                rej = (err: any) => (r ? resolve(r(err)) : reject(err))
             })
         },
     }


### PR DESCRIPTION
This commit brings a regression on Firefox.

This reverts commit a5402a8456e1de0a882cbaf0560f6ce432cbb3f3.