### PR TITLE
iOS: Fix QR scanning; try close options-page after setup

### DIFF
--- a/src/background-service.ts
+++ b/src/background-service.ts
@@ -69,6 +69,7 @@ if (GetContext() === 'background') {
     })
 
     browser.runtime.onInstalled.addListener(detail => {
+        if (webpackEnv.target === 'WKWebview') return
         const {
             getWelcomePageURL,
         } = require('./extension/options-page/Welcome/getWelcomePageURL') as typeof import('./extension/options-page/Welcome/getWelcomePageURL')

--- a/src/components/Welcomes/1b1.tsx
+++ b/src/components/Welcomes/1b1.tsx
@@ -103,9 +103,14 @@ export default function Welcome({ back, restore: originalRestore }: Props) {
     const ref = React.useRef<HTMLInputElement>(null)
     const textAreaRef = React.useRef<HTMLTextAreaElement>(null)
     const restore = (str: string) => {
-        const json = JSON.parse(str)
-        const upgraded = UpgradeBackupJSONFile(json)
-        setJson(upgraded)
+        try {
+            const json = JSON.parse(str)
+            const upgraded = UpgradeBackupJSONFile(json)
+            setJson(upgraded)
+        } catch (e) {
+            alert(e)
+            setJson(null)
+        }
     }
     const { dragEvents, fileReceiver, fileRef, dragStatus } = useDragAndDrop(file => {
         const fr = new FileReader()

--- a/src/components/Welcomes/1b1.tsx
+++ b/src/components/Welcomes/1b1.tsx
@@ -196,7 +196,9 @@ export default function Welcome({ back, restore: originalRestore }: Props) {
                 {tab === 0 ? FileUI() : null}
                 {tab === 1 ? (
                     hasWKWebkitRPCHandlers ? (
-                        <WKWebkitQR onScan={restore} onQuit={() => setTab(0)} />
+                        json ? null : (
+                            <WKWebkitQR onScan={restore} onQuit={() => setTab(0)} />
+                        )
                     ) : (
                         QR()
                     )

--- a/src/components/Welcomes/Banner.tsx
+++ b/src/components/Welcomes/Banner.tsx
@@ -91,9 +91,8 @@ export function Banner({
     }
     const getStartedDefault = useCallback(() => {
         setStorage(props.networkIdentifier as string, { forceDisplayWelcome: false })
-        unmount()
         Services.Welcome.openWelcomePage(lastRecognizedIdentity)
-    }, [lastRecognizedIdentity, props.networkIdentifier, unmount])
+    }, [lastRecognizedIdentity, props.networkIdentifier])
     return (
         <BannerUI
             disabled={lastRecognizedIdentity.identifier.isUnknown}

--- a/src/extension/options-page/Welcome/index.tsx
+++ b/src/extension/options-page/Welcome/index.tsx
@@ -312,7 +312,13 @@ export default withRouter(function _WelcomePortal(props: RouteComponentProps) {
                     currentIdentities={ownIds}
                     personHintFromSearch={personFromURL}
                     onSelectIdentity={p => (selectedIdRef.value = p)}
-                    onFinish={() => props.history.replace('/')}
+                    onFinish={reason => {
+                        if (reason === 'done') {
+                            if (webpackEnv.firefoxVariant === 'GeckoView' || webpackEnv.target === 'WKWebview')
+                                window.close()
+                        }
+                        props.history.replace('/')
+                    }}
                 />
             </IdentifierRefContext.Provider>
         </ResponsiveDialog>

--- a/src/extension/options-page/Welcome/index.tsx
+++ b/src/extension/options-page/Welcome/index.tsx
@@ -275,7 +275,6 @@ export default withRouter(function _WelcomePortal(props: RouteComponentProps) {
                     nickname: person.nickname,
                     avatarURL: person.avatar,
                 })
-                setStep(WelcomeState.SelectIdentity)
             })
         }
     }, [props.location.search, selectedId.identifier])
@@ -312,11 +311,9 @@ export default withRouter(function _WelcomePortal(props: RouteComponentProps) {
                     currentIdentities={ownIds}
                     personHintFromSearch={personFromURL}
                     onSelectIdentity={p => (selectedIdRef.value = p)}
-                    onFinish={reason => {
-                        if (reason === 'done') {
-                            if (webpackEnv.firefoxVariant === 'GeckoView' || webpackEnv.target === 'WKWebview')
-                                window.close()
-                        }
+                    onFinish={() => {
+                        if (webpackEnv.firefoxVariant === 'GeckoView' || webpackEnv.target === 'WKWebview')
+                            window.close()
                         props.history.replace('/')
                     }}
                 />

--- a/src/utils/hooks/useValueRef.ts
+++ b/src/utils/hooks/useValueRef.ts
@@ -3,6 +3,9 @@ import { useState, useEffect } from 'react'
 
 export function useValueRef<T>(ref: ValueRef<T>) {
     const [value, setValue] = useState<T>(ref.value)
-    useEffect(() => ref.addListener(newValue => setValue(newValue)), [ref])
+    useEffect(() => {
+        if (value !== ref.value) setValue(ref.value)
+        return ref.addListener(v => setValue(v))
+    }, [ref, value])
     return value
 }


### PR DESCRIPTION
This commit fixes:
+ repeatedly brings up scan-qr UI on iOS
+ try close options-page after setup on mobile geckoview and WKWebView