### PR TITLE
feat: popup identity selector

### DIFF
--- a/src/extension/popup-page/index.tsx
+++ b/src/extension/popup-page/index.tsx
@@ -1,5 +1,6 @@
+import '../../social-network-provider/popup-page/index'
 import '../../setup.ui'
-import React from 'react'
+import React, { useState } from 'react'
 
 import { ThemeProvider } from '@material-ui/styles'
 import { MaskbookLightTheme } from '../../utils/theme'
@@ -9,6 +10,9 @@ import { SSRRenderer } from '../../utils/SSRRenderer'
 import { useValueRef } from '../../utils/hooks/useValueRef'
 import { debugModeSetting } from '../../components/shared-settings/settings'
 import { useSettingsUI } from '../../components/shared-settings/createSettings'
+import { ChooseIdentity } from '../../components/shared/ChooseIdentity'
+import { getActivatedUI } from '../../social-network/ui'
+import { useAsync } from '../../utils/components/AsyncComponent'
 
 const useStyles = makeStyles(theme => ({
     button: {
@@ -33,6 +37,11 @@ SSRRenderer(<Popup />)
 export function Popup() {
     const classes = useStyles()
 
+    const [showIdentitySelector, setShowIdentitySelector] = useState(false)
+    setTimeout(() => {
+        if (getActivatedUI().networkIdentifier !== 'localhost') setShowIdentitySelector(true)
+    })
+
     return (
         <ThemeProvider theme={MaskbookLightTheme}>
             <style>{`
@@ -44,6 +53,7 @@ export function Popup() {
     }`}</style>
             <main className={classes.container}>
                 <img className={classes.logo} src="https://dimensiondev.github.io/Maskbook-VI/MB--Text--Blue.svg" />
+                {showIdentitySelector ? <ChooseIdentity /> : null}
                 <Button
                     variant="contained"
                     color="primary"

--- a/src/social-network-provider/facebook.com/ui-provider.ts
+++ b/src/social-network-provider/facebook.com/ui-provider.ts
@@ -27,7 +27,8 @@ export const facebookUISelf = defineSocialNetworkUI({
         InitFriendsValueRef(facebookUISelf, 'facebook.com')
         InitMyIdentitiesValueRef(facebookUISelf, 'facebook.com')
     },
-    shouldActivate() {
+    // ssr complains 'ReferenceError: window is not defined'
+    shouldActivate(location: Location | URL = globalThis.location) {
         return location.hostname.endsWith('facebook.com')
     },
     friendlyName: 'Facebook',

--- a/src/social-network-provider/popup-page/index.ts
+++ b/src/social-network-provider/popup-page/index.ts
@@ -1,0 +1,25 @@
+import { defineSocialNetworkUI, definedSocialNetworkUIs, SocialNetworkUI } from '../../social-network/ui'
+import '../../provider.ui'
+import { emptyDefinition } from '../../social-network/defaults/emptyDefinition'
+import { GetContext } from '@holoflows/kit/es'
+import { InitMyIdentitiesValueRef } from '../../social-network/defaults/MyIdentitiesRef'
+
+const popupPageUISelf = defineSocialNetworkUI({
+    ...emptyDefinition,
+    internalName: 'Popup page data source',
+    async init(e, p) {
+        emptyDefinition.init(e, p)
+        const activeTab = ((await browser.tabs.query({ active: true, currentWindow: true })) || [])[0]
+        const location = new URL(activeTab.url || window.location.href)
+        for (const ui of definedSocialNetworkUIs) {
+            if (ui.shouldActivate(location) && ui.networkIdentifier !== 'localhost') {
+                popupPageUISelf.networkIdentifier = ui.networkIdentifier
+                InitMyIdentitiesValueRef(popupPageUISelf, ui.networkIdentifier)
+                return
+            }
+        }
+    },
+    shouldActivate() {
+        return GetContext() === 'options'
+    },
+})

--- a/src/social-network-provider/twitter.com/ui/index.ts
+++ b/src/social-network-provider/twitter.com/ui/index.ts
@@ -18,7 +18,7 @@ export const instanceOfTwitterUI = defineSocialNetworkUI({
         InitFriendsValueRef(instanceOfTwitterUI, host)
         InitMyIdentitiesValueRef(instanceOfTwitterUI, host)
     },
-    shouldActivate() {
+    shouldActivate(location: Location | URL = window.location) {
         return location.hostname.endsWith(host)
     },
     friendlyName: 'Twitter (Insider Preview)',

--- a/src/social-network/ui.ts
+++ b/src/social-network/ui.ts
@@ -17,7 +17,7 @@ export interface SocialNetworkUIDefinition
         SocialNetworkUIInjections,
         SocialNetworkUIInformationCollector {
     /** Should this UI content script activate? */
-    shouldActivate(): boolean
+    shouldActivate(location?: Location | URL): boolean
     /**
      * Should Maskbook show Welcome Banner?
      */


### PR DESCRIPTION
This PR (together with its parent #291 #290) introduces real-time identity updating and selecting from the popup, and updates failing reason to be more accurate.

![maskbook](https://user-images.githubusercontent.com/14029711/67159720-378c9d80-f37b-11e9-8a5f-6cc8b28df104.gif)

If it's not a site that we care about, then the selector won't show up at all.

![maskbook3](https://user-images.githubusercontent.com/14029711/67159645-db754980-f379-11e9-9158-3581e51fe3f1.png)
