### PR TITLE
Bump target version from es2017 to es2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2017",
-    "lib": ["dom", "dom.iterable", "es2017", "esnext.asynciterable", "esnext.array"],
+    "target": "es2019",
+    "lib": ["dom", "dom.iterable", "es2019"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
ES2018 support status:

![image](https://user-images.githubusercontent.com/5390719/70294514-b56b1200-181e-11ea-8ce9-1795913927af.png)

Chrome all green. Firefox and iOS does not support some RegExp features.

RegExp related features can not be transformed by TypeScript compiler. So it's safe to upgrade to ES2018

ES2019 support status:

![image](https://user-images.githubusercontent.com/5390719/70294538-cf0c5980-181e-11ea-9775-1654291c2fb1.png)

All platforms green.