### PR TITLE
Add 'Seen by Maskbook database' into twitter profile page

### DIFF
--- a/src/components/InjectedComponents/AdditionalPostContent.tsx
+++ b/src/components/InjectedComponents/AdditionalPostContent.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
     root: { backgroundColor: 'transparent' },
     title: { display: 'flex', alignItems: 'center' },
     center: { justifyContent: 'center' },
-    icon: { transform: 'translate(-1px, 1px)' },
+    icon: { transform: 'translate(-1px, 0)' },
 })
 export const AdditionalContent = React.memo(function AdditionalContent(props: AdditionalContentProps) {
     const classes = useStylesExtends(useStyles(), props)
@@ -29,7 +29,7 @@ export const AdditionalContent = React.memo(function AdditionalContent(props: Ad
                 gutterBottom
                 className={classNames(classes.title, { [classes.center]: props.center })}>
                 <img alt="" width={16} height={16} src={icon} className={classes.icon} />
-                {props.title}
+                <span>{props.title}</span>
             </Typography>
             {props.renderText ? (
                 <Typography variant="body2" component="p">

--- a/src/components/InjectedComponents/PersonKnown.tsx
+++ b/src/components/InjectedComponents/PersonKnown.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { PersonIdentifier } from '../../database/type'
 import { AdditionalContent, AdditionalContentProps } from './AdditionalPostContent'
 import { geti18nString } from '../../utils/i18n'

--- a/src/components/InjectedComponents/PersonKnown.tsx
+++ b/src/components/InjectedComponents/PersonKnown.tsx
@@ -1,0 +1,34 @@
+import { PersonIdentifier } from '../../database/type'
+import { AdditionalContent, AdditionalContentProps } from './AdditionalPostContent'
+import { geti18nString } from '../../utils/i18n'
+import AsyncComponent from '../../utils/components/AsyncComponent'
+import Services from '../../extension/service'
+
+export interface PersonKnownProps {
+    whois?: PersonIdentifier | null
+    AdditionalContentProps?: Partial<AdditionalContentProps>
+}
+
+export function PersonKnown(props: PersonKnownProps) {
+    const { whois } = props
+    if (!whois) return null
+    return (
+        <AsyncComponent
+            promise={() =>
+                Services.People.queryPerson(whois).then(p => {
+                    if (!p.fingerprint) throw new TypeError('public key not found')
+                })
+            }
+            dependencies={[]}
+            awaitingComponent={null}
+            completeComponent={
+                <AdditionalContent
+                    center
+                    title={geti18nString('seen_in_maskbook_database')}
+                    {...props.AdditionalContentProps}
+                />
+            }
+            failedComponent={null}
+        />
+    )
+}

--- a/src/social-network-provider/facebook.com/UI/injectKnownIdentity.tsx
+++ b/src/social-network-provider/facebook.com/UI/injectKnownIdentity.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { LiveSelector, MutationObserverWatcher } from '@holoflows/kit'
 import { renderInShadowRoot } from '../../../utils/jss/renderInShadowRoot'
 import { SocialNetworkUI } from '../../../social-network/ui'

--- a/src/social-network-provider/twitter.com/ui/inject.tsx
+++ b/src/social-network-provider/twitter.com/ui/inject.tsx
@@ -5,6 +5,7 @@ import { hasDraftEditor, newPostEditorBelow, postPopupInjectPointSelector } from
 import { renderInShadowRoot } from '../../../utils/jss/renderInShadowRoot'
 import { PostInfo, SocialNetworkUIInjections } from '../../../social-network/ui'
 import { injectPostInspectorDefault } from '../../../social-network/defaults/injectPostInspector'
+import { injectKnownIdentityAtTwitter } from './injectKnownIdentity'
 
 // Closing these shadowRoot prevents external access to them.
 const newMOW = (i: LiveSelector<HTMLElement, true>) =>
@@ -34,4 +35,5 @@ const injectPostInspector = (current: PostInfo) => {
 export const twitterUIInjections: SocialNetworkUIInjections = {
     injectPostBox,
     injectPostInspector,
+    injectKnownIdentity: injectKnownIdentityAtTwitter,
 }

--- a/src/social-network-provider/twitter.com/ui/injectKnownIdentity.tsx
+++ b/src/social-network-provider/twitter.com/ui/injectKnownIdentity.tsx
@@ -1,0 +1,63 @@
+import { MutationObserverWatcher } from '@holoflows/kit'
+import { PersonKnown } from '../../../components/InjectedComponents/PersonKnown'
+import { bioSelector, bioCard } from '../utils/selector'
+import { renderInShadowRoot } from '../../../utils/jss/renderInShadowRoot'
+import { PersonIdentifier } from '../../../database/type'
+import { twitterUrl } from '../utils/url'
+import { makeStyles } from '@material-ui/styles'
+import { timeout } from '../../../utils/utils'
+import AsyncComponent from '../../../utils/components/AsyncComponent'
+import { useState } from 'react'
+import { bioCardParser } from '../utils/fetch'
+
+const useStyles = makeStyles({
+    root: {
+        marginTop: -10,
+        marginBottom: 10,
+    },
+    center: {
+        color: '#657786', // TODO: use color in theme
+        justifyContent: 'flex-start',
+        marginBottom: 0,
+    },
+})
+
+function PersonKnownAtTwitter() {
+    const [userId, setUserId] = useState(PersonIdentifier.unknown.userId)
+    return (
+        <AsyncComponent
+            promise={async () => {
+                const [bioCardNode] = await timeout(new MutationObserverWatcher(bioCard<false>(false)), 10000)
+                setUserId(bioCardParser(bioCardNode).handle)
+            }}
+            dependencies={[userId]}
+            awaitingComponent={null}
+            completeComponent={
+                <PersonKnown
+                    whois={new PersonIdentifier(twitterUrl.hostIdentifier, userId)}
+                    AdditionalContentProps={{
+                        classes: {
+                            ...useStyles(),
+                        },
+                    }}
+                />
+            }
+            failedComponent={null}
+        />
+    )
+}
+
+export function injectKnownIdentityAtTwitter() {
+    const target = new MutationObserverWatcher(bioSelector())
+        .setDOMProxyOption({
+            beforeShadowRootInit: { mode: 'closed' },
+            afterShadowRootInit: { mode: 'closed' },
+        })
+        .startWatch({
+            childList: true,
+            subtree: true,
+            characterData: true,
+        })
+
+    renderInShadowRoot(<PersonKnownAtTwitter />, target.firstDOMProxy.beforeShadow)
+}

--- a/src/social-network-provider/twitter.com/ui/injectKnownIdentity.tsx
+++ b/src/social-network-provider/twitter.com/ui/injectKnownIdentity.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { MutationObserverWatcher } from '@holoflows/kit'
 import { PersonKnown } from '../../../components/InjectedComponents/PersonKnown'
 import { bioSelector, bioCard } from '../utils/selector'

--- a/src/social-network-provider/twitter.com/utils/selector.ts
+++ b/src/social-network-provider/twitter.com/utils/selector.ts
@@ -4,20 +4,27 @@ import { postBoxInPopup } from './postBox'
 import { isNull } from 'lodash-es'
 
 type E = HTMLElement
-const querySelector = <T extends E>(selector: string) => {
-    return new LiveSelector().querySelector<T>(selector).enableSingleMode()
+const querySelector = <T extends E, SingleMode extends boolean = true>(
+    selector: string,
+    singleMode: boolean = true,
+) => {
+    const ls = new LiveSelector<T, SingleMode>().querySelector<T>(selector)
+    return (singleMode ? ls.enableSingleMode() : ls) as LiveSelector<T, SingleMode>
 }
 const querySelectorAll = <T extends E>(selector: string) => {
     return new LiveSelector().querySelectorAll<T>(selector)
 }
 
-export const bioCard = () =>
-    querySelector<HTMLDivElement>(
+export const bioSelector = () => querySelector<HTMLDivElement>(['[data-testid="UserProfileHeader_Items"]'].join())
+
+export const bioCard = <SingleMode extends boolean = true>(singleMode = true) =>
+    querySelector<HTMLDivElement, SingleMode>(
         [
             '.profile', // legacy twitter
             'a[href*="header_photo"] ~ div', // new twitter
             'div[data-testid="primaryColumn"] > div > div:last-child > div > div > div > div ~ div', // new twitter without header photo
         ].join(),
+        singleMode,
     )
 
 export const newPostButton = () => querySelector<E>('[data-testid="SideNav_NewTweet_Button"]')
@@ -25,8 +32,7 @@ export const newPostButton = () => querySelector<E>('[data-testid="SideNav_NewTw
 const postEditor = () =>
     postBoxInPopup() ? '[aria-labelledby="modal-header"]' : '[role="main"] :not(aside) > [role="progressbar"] ~ div'
 
-export const newPostEditorBelow: () => LiveSelector<E, true> = () =>
-    querySelector<E>('[role="main"] :not(aside) > [role="progressbar"] ~ div')
+export const newPostEditorBelow = () => querySelector<E>('[role="main"] :not(aside) > [role="progressbar"] ~ div')
 export const newPostEditorSelector = () => querySelector<HTMLDivElement>(`${postEditor()} .DraftEditor-root`)
 export const newPostEditorFocusAnchor = () => querySelector<E>(`${postEditor()} .public-DraftEditor-content`)
 


### PR DESCRIPTION
This PR includes:

+ Refactor `PersonKnown` and move it to `InjectedCompone/` folder;
+ Refactor `querySelector()` make it support specific `singleMode`;
+ Inject `PersonKnown` component into twitter profile page;
+ Refine vertical alignment of `AdditionalContent` component;

Related Issues:

+ #469 

Screenshots:

![image](https://user-images.githubusercontent.com/52657989/70606337-34a18100-1c37-11ea-8190-744d46e8db4c.png)
