### PR TITLE
chore: provide consistent extension id when install from source

### DIFF
--- a/config-overrides/index.js
+++ b/config-overrides/index.js
@@ -180,8 +180,8 @@ function override(config, env) {
         if (target.FirefoxForAndroid) modifiers.firefox(manifest)
         if (target.StandaloneGeckoView) modifiers.geckoview(manifest)
         if (target.WKWebview) modifiers.WKWebview(manifest)
-        if (env === 'development') modifiers.development(manifest)
-        else modifiers.production(manifest)
+        if (env === 'development') modifiers.development(manifest, target)
+        else modifiers.production(manifest, target)
 
         config.plugins.push(new ManifestGeneratorPlugin({ config: { base: manifest } }))
     }

--- a/config-overrides/index.js
+++ b/config-overrides/index.js
@@ -180,6 +180,8 @@ function override(config, env) {
         if (target.FirefoxForAndroid) modifiers.firefox(manifest)
         if (target.StandaloneGeckoView) modifiers.geckoview(manifest)
         if (target.WKWebview) modifiers.WKWebview(manifest)
+        if (env === 'development') modifiers.development(manifest)
+        else modifiers.production(manifest)
 
         config.plugins.push(new ManifestGeneratorPlugin({ config: { base: manifest } }))
     }

--- a/config-overrides/manifest.overrides.js
+++ b/config-overrides/manifest.overrides.js
@@ -24,9 +24,9 @@ function chromium(manifest) {}
  * @param {typeof base} manifest
  */
 function WKWebview(manifest) {}
-function development(manifest) {
+function development(manifest, target) {
     manifest.key = // ID：jkoeaghipilijlahjplgbfiocjhldnap
         'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoz51rhO1w+wD0EKZJEFJaSMkIcIj0qRadfi0tqcl5nbpuJAsafvLe3MaTbW9LhbixTg9PHybO3tlYUFJrZgUuZlEvt2T6SKIu6Rs9e9B3/brNQG3+hCHudbZkq2WG2IzO44dglrs24bRp/pV5oIif0bLuwrzvYsPQ6hgSp+5gc4pg0LEJPLFp01fbORDknWt8suJmEMz7S0O5+u13+34NvxYzUNeLJF9gYrd4zzrAFYITDEYcqr0OMZvVrKz7IkJasER1uJyoGj4gFJeXNGE8y4Sqb150wBju70lKNKlNevWDRJKasG9CjagAD2+BAfqNyltn7KwK7jAyL1w6d6mOwIDAQAB'
 }
-function production(manifest) {}
+function production(manifest, target) {}
 module.exports = { firefox, geckoview, chromium, WKWebview, development, production }

--- a/config-overrides/manifest.overrides.js
+++ b/config-overrides/manifest.overrides.js
@@ -24,4 +24,9 @@ function chromium(manifest) {}
  * @param {typeof base} manifest
  */
 function WKWebview(manifest) {}
-module.exports = { firefox, geckoview, chromium, WKWebview }
+function development(manifest) {
+    manifest.key = // ID：jkoeaghipilijlahjplgbfiocjhldnap
+        'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoz51rhO1w+wD0EKZJEFJaSMkIcIj0qRadfi0tqcl5nbpuJAsafvLe3MaTbW9LhbixTg9PHybO3tlYUFJrZgUuZlEvt2T6SKIu6Rs9e9B3/brNQG3+hCHudbZkq2WG2IzO44dglrs24bRp/pV5oIif0bLuwrzvYsPQ6hgSp+5gc4pg0LEJPLFp01fbORDknWt8suJmEMz7S0O5+u13+34NvxYzUNeLJF9gYrd4zzrAFYITDEYcqr0OMZvVrKz7IkJasER1uJyoGj4gFJeXNGE8y4Sqb150wBju70lKNKlNevWDRJKasG9CjagAD2+BAfqNyltn7KwK7jAyL1w6d6mOwIDAQAB'
+}
+function production(manifest) {}
+module.exports = { firefox, geckoview, chromium, WKWebview, development, production }


### PR DESCRIPTION
The ID will be `jkoeaghipilijlahjplgbfiocjhldnap`. Same as the one of chrome store.

? what about firefox?

close #28 