### PR TITLE
fix: immersive setup not respect user input

### DIFF
--- a/src/components/InjectedComponents/ImmersiveSetup/SetupStepper.tsx
+++ b/src/components/InjectedComponents/ImmersiveSetup/SetupStepper.tsx
@@ -236,7 +236,7 @@ export function ImmersiveSetupStepper(
 
     const lastRecognized = useValueRef(getActivatedUI().lastRecognizedIdentity)
     const touched = React.useRef(false)
-    const [username, setUsername] = React.useState(getUserID(lastRecognized.identifier))
+    const [username, setUsername] = React.useState(lastState.username || '')
     if (username === '' && touched.current === false) {
         const uid = getUserID(lastRecognized.identifier)
         uid !== '' && setUsername(uid)


### PR DESCRIPTION
This fixes if a user changes their id at the first step, we still show the previously auto-detected one when setting up bio.

#545