### PR TITLE
Remove default background color

### DIFF
--- a/src/social-network-provider/twitter.com/ui/custom.ts
+++ b/src/social-network-provider/twitter.com/ui/custom.ts
@@ -104,10 +104,9 @@ function getBackgroundColor<T extends HTMLElement>(selector: string) {
         // @ts-ignore CSSOM
         element.computedStyleMap?.()?.get?.('background-color') ||
             element?.style?.backgroundColor ||
-            getComputedStyle?.(element, null).getPropertyValue('background-color') ||
-            'rgb(255, 255, 255)',
+            getComputedStyle?.(element, null).getPropertyValue('background-color'),
     )
-    return toRGB(fromRGB(color)!)
+    return color ? toRGB(fromRGB(color)!) : ''
 }
 
 export const twitterUICustomUI: SocialNetworkUICustomUI = {


### PR DESCRIPTION
Get background color API may return `''` during app running. So use a default background color may cause flash it with theme color. Remove the background color and let it fail silently.

close #623