### PR TITLE
feat: add new typed message

### DIFF
--- a/src/components/InjectedComponents/AdditionalPostBox.tsx
+++ b/src/components/InjectedComponents/AdditionalPostBox.tsx
@@ -18,6 +18,7 @@ import { steganographyModeSetting } from '../shared-settings/settings'
 import { useValueRef } from '../../utils/hooks/useValueRef'
 import { BannerProps } from '../Welcomes/Banner'
 import useConnectingStatus from '../../utils/hooks/useConnectingStatus'
+import { makeTypedMessage } from '../../extension/background-script/CryptoServices/utils'
 
 const useStyles = makeStyles({
     header: { padding: '8px 12px 0' },
@@ -126,7 +127,7 @@ export function AdditionalPostBox(props: AdditionalPostBoxProps) {
         useCallback(
             async (target: (Profile | Group)[], text: string) => {
                 const [encrypted, token] = await Services.Crypto.encryptTo(
-                    text,
+                    makeTypedMessage(text),
                     target.map(x => x.identifier),
                     currentIdentity!.identifier,
                 )

--- a/src/components/InjectedComponents/DecryptedPost.tsx
+++ b/src/components/InjectedComponents/DecryptedPost.tsx
@@ -23,9 +23,10 @@ import { deconstructPayload } from '../../utils/type-transform/Payload'
 import { DebugList } from '../DebugModeUI/DebugList'
 import { useStylesExtends } from '../custom-ui-helper'
 import { BannerProps } from '../Welcomes/Banner'
+import { TypedMessage } from '../../extension/background-script/CryptoServices/utils'
 
 export interface DecryptPostSuccessProps extends withClasses<KeysInferFromUseStyles<typeof useSuccessStyles>> {
-    data: { signatureVerifyResult: boolean; content: string }
+    data: { signatureVerifyResult: boolean; content: TypedMessage }
     requestAppendRecipients?(to: Profile[]): Promise<void>
     alreadySelectedPreviously: Profile[]
     people: Profile[]
@@ -57,6 +58,16 @@ export const DecryptPostSuccess = React.memo(function DecryptPostSuccess({
         passString = '✔'
         failString = '❌'
     }
+    const msg = data.content
+    if (msg.type === 'unknown')
+        return <AdditionalContent title="Unknown type of Maskbook message" {...props.AdditionalContentProps} />
+    else if (msg.type === 'complex')
+        return (
+            <AdditionalContent
+                title="Complex Maskbook message is not renderable currently"
+                {...props.AdditionalContentProps}
+            />
+        )
     return (
         <AdditionalContent
             title={
@@ -76,7 +87,7 @@ export const DecryptPostSuccess = React.memo(function DecryptPostSuccess({
                     )}
                 </>
             }
-            renderText={data.content}
+            renderText={data.content.type}
             {...props.AdditionalContentProps}
         />
     )
@@ -119,8 +130,7 @@ export const DecryptPostFailed = React.memo(function DecryptPostFailed({ error, 
 })
 
 export interface DecryptPostProps {
-    onDecrypted(post: string): void
-
+    onDecrypted(post: TypedMessage): void
     postBy: ProfileIdentifier
     whoAmI: ProfileIdentifier
     encryptedText: string

--- a/src/components/InjectedComponents/PostDialog.tsx
+++ b/src/components/InjectedComponents/PostDialog.tsx
@@ -26,6 +26,7 @@ import { getActivatedUI } from '../../social-network/ui'
 import Services from '../../extension/service'
 import { SelectRecipientsUI, SelectRecipientsUIProps } from '../shared/SelectRecipients/SelectRecipients'
 import { DialogDismissIconUI } from './DialogDismissIcon'
+import { makeTypedMessage } from '../../extension/background-script/CryptoServices/utils'
 
 const useStyles = makeStyles({
     MUIInputRoot: {
@@ -180,7 +181,7 @@ export function PostDialog(props: PostDialogProps) {
         useCallback(
             async (target: (Profile | Group)[], text: string) => {
                 const [encrypted, token] = await Services.Crypto.encryptTo(
-                    text,
+                    makeTypedMessage(text),
                     target.map(x => x.identifier),
                     currentIdentity!.identifier,
                 )

--- a/src/components/InjectedComponents/PostInspector.tsx
+++ b/src/components/InjectedComponents/PostInspector.tsx
@@ -11,9 +11,10 @@ import { getActivatedUI } from '../../social-network/ui'
 import { useValueRef } from '../../utils/hooks/useValueRef'
 import { debugModeSetting } from '../shared-settings/settings'
 import { DebugList } from '../DebugModeUI/DebugList'
+import { TypedMessage } from '../../extension/background-script/CryptoServices/utils'
 
 export interface PostInspectorProps {
-    onDecrypted(post: string): void
+    onDecrypted(post: TypedMessage): void
     post: string
     postBy: ProfileIdentifier
     postId: string

--- a/src/crypto/crypto-alpha-38.ts
+++ b/src/crypto/crypto-alpha-38.ts
@@ -1,1 +1,22 @@
+import { TypedMessage, makeTypedMessage } from '../extension/background-script/CryptoServices/utils'
 export * from './crypto-alpha-39'
+/**
+ * With plugin: {"payload": "data"}🧩My message
+ * Without plugin: My message
+ */
+export function typedMessageStringify(x: TypedMessage) {
+    if (x.type !== 'text') throw new Error('Not supported typed message.')
+    let msg = x.content
+    if (x.meta) msg = JSON.stringify(x.meta) + '🧩' + msg
+    return msg
+}
+export function typedMessageParse(x: string) {
+    const [maybeMetadata, ...end] = x.split('🧩')
+    try {
+        const json: unknown = JSON.parse(maybeMetadata)
+        if (typeof json !== 'object' || json === null || Object.keys(json).length === 0)
+            throw new Error('Not a metadata')
+        return makeTypedMessage(end.join('🧩'), json)
+    } catch {}
+    return makeTypedMessage(x)
+}

--- a/src/crypto/crypto-alpha-39.ts
+++ b/src/crypto/crypto-alpha-39.ts
@@ -83,3 +83,4 @@ export { decryptMessage1ToNByOther, decryptMessage1ToNByMyself, extractAESKeyInM
 export { encryptWithAES, decryptWithAES } from './crypto-alpha-40'
 export { sign, verify } from './crypto-alpha-40'
 export { encryptComment, decryptComment } from './crypto-alpha-40'
+export { typedMessageStringify, typedMessageParse } from './crypto-alpha-40'

--- a/src/crypto/crypto-alpha-40.ts
+++ b/src/crypto/crypto-alpha-40.ts
@@ -343,3 +343,12 @@ export async function decryptComment(
     }
 }
 //#endregion
+
+import { makeTypedMessage } from '../extension/background-script/CryptoServices/utils'
+
+export function typedMessageStringify(x: any) {
+    throw new Error('Not supported typed message in version older than v39.')
+}
+export function typedMessageParse(x: string) {
+    return makeTypedMessage(x)
+}

--- a/src/extension/background-script/CryptoServices/utils.ts
+++ b/src/extension/background-script/CryptoServices/utils.ts
@@ -25,3 +25,29 @@ export const cryptoProviderTable = {
     [-39]: Alpha39,
     [-38]: Alpha38,
 } as const
+
+export interface TypedMessageMetadata {
+    meta?: object
+    version: 1
+}
+export interface TypedMessageText extends TypedMessageMetadata {
+    type: 'text'
+    content: string
+}
+export interface TypedMessageComplex extends TypedMessageMetadata {
+    type: 'complex'
+    items: TypedMessage[]
+}
+export interface TypedMessageUnknown extends TypedMessageMetadata {
+    type: 'unknown'
+}
+export type TypedMessage = TypedMessageText | TypedMessageComplex | TypedMessageUnknown
+export function makeTypedMessage(text: string, meta?: object): TypedMessageText
+export function makeTypedMessage(content: string, meta?: object): TypedMessage {
+    if (typeof content === 'string') {
+        const text: TypedMessageText = { type: 'text', content, version: 1, meta }
+        return text
+    }
+    const msg: TypedMessageUnknown = { type: 'unknown', version: 1, meta }
+    return msg
+}

--- a/src/social-network/defaults/injectPostInspector.tsx
+++ b/src/social-network/defaults/injectPostInspector.tsx
@@ -6,6 +6,7 @@ import { ProfileIdentifier } from '../../database/type'
 import { useValueRef } from '../../utils/hooks/useValueRef'
 import { PostInspector, PostInspectorProps } from '../../components/InjectedComponents/PostInspector'
 import { makeStyles } from '@material-ui/core'
+import { TypedMessage } from '../../extension/background-script/CryptoServices/utils'
 
 export function injectPostInspectorDefault<T extends string>(
     config: InjectPostInspectorDefaultConfig = {},
@@ -40,7 +41,9 @@ export function injectPostInspectorDefault<T extends string>(
     const zipPostF = zipPost || (() => {})
     return function injectPostInspector(current: PostInfo) {
         const injectionPointDefault = () => current.rootNodeProxy.afterShadow
-        const onDecrypted = (val: string) => (current.decryptedPostContent.value = val)
+        const onDecrypted = (val: TypedMessage) => {
+            if (val.type === 'text') current.decryptedPostContent.value = val.content
+        }
         return renderInShadowRoot(
             <PostInspectorDefault
                 onDecrypted={onDecrypted}

--- a/src/stories/Injections.tsx
+++ b/src/stories/Injections.tsx
@@ -21,6 +21,7 @@ import { PersonOrGroupInChip, PersonOrGroupInList } from '../components/shared/S
 import { MaskbookLightTheme } from '../utils/theme'
 import { PostDialog } from '../components/InjectedComponents/PostDialog'
 import { PostDialogHint } from '../components/InjectedComponents/PostDialogHint'
+import { makeTypedMessage } from '../extension/background-script/CryptoServices/utils'
 
 storiesOf('Injections', module)
     .add('PersonOrGroupInChip', () => (
@@ -102,7 +103,7 @@ storiesOf('Injections', module)
                         alreadySelectedPreviously={[]}
                         requestAppendRecipients={async () => {}}
                         people={demoPeople}
-                        data={{ content: msg, signatureVerifyResult: vr }}
+                        data={{ content: makeTypedMessage(msg), signatureVerifyResult: vr }}
                     />
                 </FakePost>
                 <FakePost title="Decrypting:">


### PR DESCRIPTION
This PR introduce a new mechanism: Typed Message.

In many IM protocol, there're more message types than the plain text. This PR enables Maskbook to construct typed message with metadata. With this mechanism, we can support message type like picture, files, audios, etc... Plugin can inject their data into the `meta` section.

Typed Message is a media-independent representation of a Maskbook message. The `parse` and `stringify` part can be different according to the payload version.

For example: In version -38, it will be constructed as `{"some_meta": "meta_1"}🧩Normal message`.
In future version, it can be constructed as some custom binary format.

```ts
export interface TypedMessageMetadata {
    meta?: object
    version: 1
}
export interface TypedMessageText extends TypedMessageMetadata {
    type: 'text'
    content: string
}
export interface TypedMessageComplex extends TypedMessageMetadata {
    type: 'complex'
    items: TypedMessage[]
}
export interface TypedMessageUnknown extends TypedMessageMetadata {
    type: 'unknown'
}
export type TypedMessage = TypedMessageText | TypedMessageComplex | TypedMessageUnknown
```