### PR TITLE
chore: bump version to 1.10.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maskbook",
   "license": "AGPL-3.0-or-later",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "private": true,
   "engines": {
     "node": ">=13.2.0"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json.schemastore.org/chrome-manifest",
     "name": "Maskbook",
-    "version": "1.10.6",
+    "version": "1.10.7",
     "manifest_version": 2,
     "web_accessible_resources": ["*.css", "*.js", "*.jpg", "*.png"],
     "permissions": ["storage", "downloads", "webNavigation", "activeTab"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,17 +1630,24 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@7.7.7":
+"@babel/runtime@7.7.7", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.7.tgz#194769ca8d6d7790ec23605af9ee3e42a0aa79cf"
   integrity sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@7.8.4", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6":
+"@babel/runtime@7.8.4", "@babel/runtime@^7.3.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.7.6":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -12030,20 +12037,10 @@ jss-plugin-vendor-prefixer@^10.0.0:
     css-vendor "^2.0.6"
     jss "10.0.0"
 
-jss@10.0.0:
+jss@10.0.0, jss@^10, jss@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.0.tgz#998d5026c02accae15708de83bd6ba57bac977d2"
   integrity sha512-TPpDFsiBjuERiL+dFDq8QCdiF9oDasPcNqCKLGCo/qED3fNYOQ8PX2lZhknyTiAt3tZrfOFbb0lbQ9lTjPZxsQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    csstype "^2.6.5"
-    is-in-browser "^1.1.3"
-    tiny-warning "^1.0.2"
-
-jss@^10, jss@^10.0.0:
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.4.tgz#46ebdde1c40c9a079d64f3334cb88ae28fd90bfd"
-  integrity sha512-GqHmeDK83qbqMAVjxyPfN1qJVTKZne533a9bdCrllZukUM8npG/k+JumEPI86IIB5ifaZAHG2HAsUziyxOiooQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
     csstype "^2.6.5"


### PR DESCRIPTION
# Chrome Web Store
- [ ] Install as a new user, setup Facebook
- [ ] Install as a new user, setup Twitter
- [ ] Install as a new user, setup Facebook and Twitter
- [ ] Setup in the last released version, then upgrade to this version (Can be omitted if there is nothing need to be "upgrade")
- [ ] Install as a return user
- [ ] Release on the Chrome Web Store

# Firefox Addon
- [ ] Install as a new user, setup Facebook
- [ ] Install as a new user, setup Twitter
- [ ] Install as a new user, setup Facebook and Twitter
- [ ] Install as a return user
- [ ] Setup in the last released version, then upgrade to this version (Can be omitted if there is nothing need to be "upgrade")
- [ ] (Firefox for Android) Install as a new user, setup Facebook
- [ ] (Firefox for Android) Install as a new user, setup Twitter
- [ ] (Firefox for Android) Install as a new user, setup Facebook and Twitter
- [ ] (Firefox for Android) Install as a return user
- [ ] (Firefox for Android) Setup in the last released version, then upgrade to this version (Can be omitted if there is nothing need to be "upgrade")
- [ ] Release on the Firefox Addon

# Release on GitHub
- [ ] changelog
    - [ ] Release on Github