### PR TITLE
Early open option page if no wallet was imported

### DIFF
--- a/src/components/InjectedComponents/PostDialog.tsx
+++ b/src/components/InjectedComponents/PostDialog.tsx
@@ -181,7 +181,18 @@ export function PostDialogUI(props: PostDialogUIProps) {
                             <ClickableChip
                                 ChipProps={{
                                     label: '💰 Red Packet',
-                                    onClick: () => setRedPacketDialogOpen(true),
+                                    onClick: async () => {
+                                        const [wallets] = await Services.Plugin.invokePlugin(
+                                            'maskbook.wallet',
+                                            'getWallets',
+                                        )
+
+                                        if (wallets.length) {
+                                            setRedPacketDialogOpen(true)
+                                        } else {
+                                            Services.Welcome.openOptionsPage('/wallets/error?reason=nowallet')
+                                        }
+                                    },
                                 }}
                             />
                         </Box>


### PR DESCRIPTION
This PR includes:

+ Fix #750 
+ Fix a UI bug

![image](https://user-images.githubusercontent.com/52657989/74298389-9049d100-4d84-11ea-81a5-92ed860f925c.png)

close #750 