### PR TITLE
Canonify image URL for Twitter

### DIFF
--- a/src/social-network-provider/facebook.com/UI/collectPosts.tsx
+++ b/src/social-network-provider/facebook.com/UI/collectPosts.tsx
@@ -132,21 +132,18 @@ async function getSteganographyContent(node: DOMProxy) {
     const pass = getPostBy(node, false).identifier.toText()
     return (
         await Promise.all(
-            imgUrls
-                .map(async url => {
-                    try {
-                        const content = await Services.Steganography.decodeImage(
-                            new Uint8Array(await downloadUrl(url)),
-                            {
-                                pass,
-                            },
-                        )
-                        return content.indexOf('🎼') === 0 ? content : ''
-                    } catch {
-                        return ''
-                    }
-                })
-                .filter(Boolean),
+            imgUrls.map(async url => {
+                try {
+                    const content = await Services.Steganography.decodeImage(new Uint8Array(await downloadUrl(url)), {
+                        pass,
+                    })
+                    return content.indexOf('🎼') === 0 ? content : ''
+                } catch {
+                    return ''
+                }
+            }),
         )
-    ).join('\n')
+    )
+        .filter(Boolean)
+        .join('\n')
 }

--- a/src/social-network-provider/twitter.com/utils/url.ts
+++ b/src/social-network-provider/twitter.com/utils/url.ts
@@ -24,6 +24,25 @@ export const getProfileUrl = (self: ProfileIdentifier, isMobile: boolean = false
         : `${hostLeadingUrlAutoTwitter(isMobile)}/${self.userId}`
 }
 
+// more about twitter photo url formating: https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object#photo_format
+export const canonifyImgUrl = (url: string) => {
+    const parsed = new URL(url)
+    if (parsed.hostname !== 'pbs.twimg.com') {
+        return url
+    }
+    const { searchParams } = parsed
+    searchParams.set('name', 'orig')
+    // we can't understand original image format when given url labeled as webp
+    if (searchParams.get('format') === 'webp') {
+        searchParams.set('format', 'png')
+        const pngURL = parsed.href
+        searchParams.set('format', 'jpg')
+        const jpgURL = parsed.href
+        return [pngURL, jpgURL]
+    }
+    return parsed.href
+}
+
 export const topSites = [
     'www.google.com',
     'www.youtube.com',


### PR DESCRIPTION
## Why Twitter image payload breaks?

Twitter may delivery different image URLs according to network condition or user preferred configrations. Some of them are highly compressed which can not be decoded.
 
## How to fix?

The URL of Twitter photo adhere [fixed formatting](https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object#photo_format). We can get original photo with URL like `https://pbs.twimg.com/media/[id]?format=[jpg|png]&name=orig`.

## Refs

- https://stackoverflow.com/questions/39108742/how-to-get-different-sized-media-twitter-api/39118748

close #773