### PR TITLE
Fix some firefox bugs

### DIFF
--- a/public/firefoxFix.js
+++ b/public/firefoxFix.js
@@ -9,7 +9,7 @@
      *
      * If any API is complaining "this does not implements Window", add it here.
      */
-    const brokenAPI = ['requestAnimationFrame', 'setTimeout', 'clearTimeout', 'matchMedia']
+    const brokenAPI = ['requestAnimationFrame', 'setTimeout', 'clearTimeout', 'matchMedia', 'getComputedStyle']
 
     const webAPIs = Object.getOwnPropertyDescriptors(window)
     Reflect.deleteProperty(webAPIs, 'window')

--- a/src/social-network-provider/twitter.com/ui/fetch.ts
+++ b/src/social-network-provider/twitter.com/ui/fetch.ts
@@ -178,7 +178,7 @@ const registerPostCollector = (self: SocialNetworkUI) => {
             const tweetNode = getTweetNode(node)
             const isQuotedTweet = tweetNode?.getAttribute('role') === 'blockquote'
             return tweetNode
-                ? `${isQuotedTweet ? 'QUOTED' : ''}${postIdParser(tweetNode)}${node.innerText.replace(/\s/gms, '')}`
+                ? `${isQuotedTweet ? 'QUOTED' : ''}${postIdParser(tweetNode)}${node.innerText.replace(/\s/gm, '')}`
                 : node.innerText
         })
         .startWatch({


### PR DESCRIPTION
This PR fixs:

+ `getComputedStyle` not working when get background color of specific element
+ `dotAll` flag not supported in FF