### PR TITLE
Run ci test cases in single tread mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start:ios": "webpack-dev-server --wk-webview --mode development",
     "storybook": "start-storybook -p 9009 -s public --quiet",
     "test": "jest --watch",
-    "test:ci": "jest --ci --collectCoverage=true --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --ci --collectCoverage=true --reporters=default --reporters=jest-junit -w 1",
     "uninstall": "ts-node scripts/postinstall.ts"
   },
   "husky": {


### PR DESCRIPTION
Solve the intermittently failing with “not enough memory” error.

## Refs:

+ https://blog.lysender.com/2019/08/jest-tests-failing-on-circleci-enomem-not-enough-memory/
+ https://github.com/zcorky/moment/issues/26
