### PR TITLE
Fix USDx Decimal

### DIFF
--- a/src/plugins/Wallet/erc20/mainnet.json
+++ b/src/plugins/Wallet/erc20/mainnet.json
@@ -51,7 +51,7 @@
             "address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
         },
         {
-            "decimals": 6,
+            "decimals": 18,
             "symbol": "USDx",
             "name": "dForce USD",
             "address": "0xeb269732ab75A6fD61Ea60b06fE994cD32a83549"


### PR DESCRIPTION
see: https://etherscan.io/token/0xeb269732ab75a6fd61ea60b06fe994cd32a83549
The correct decimal of USDx is 18. right now the incorrect decimal is causing problems like -

(now w/ incorrect decimal) https://imgur.com/o3Fzpad
correct number https://imgur.com/VrV3ZrW