### PR TITLE
chore: remove duplicated injected script

### DIFF
--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -1,4 +1,3 @@
-import './extension/injected-script/addEventListener'
 import './setup.ui'
 import { GetContext } from '@holoflows/kit/es'
 if (GetContext() === 'content') {


### PR DESCRIPTION
close https://github.com/DimensionDev/Maskbook/issues/1483
content-script would be loaded in all case, content-script contains injected-script already: https://github.com/DimensionDev/Maskbook/commit/975febc10c035ef0015089b501b428f7d842d8ea#diff-075daa7a311f82142f0742717ab50b51R1

so I think we can just remove other injected-script load.