### PR TITLE
fix: img payload in firefox

### DIFF
--- a/src/extension/injected-script/addEventListener.ts
+++ b/src/extension/injected-script/addEventListener.ts
@@ -53,7 +53,8 @@ import type { CustomEvents } from './CustomEvents'
                 document.activeElement!.dispatchEvent(e)
                 return undefined!
             } else if (textOrImage.type === 'image') {
-                const xray_binary = globalThis.window.Uint8Array.from(textOrImage.value)
+                const Uint8Array = globalThis.Uint8Array ? globalThis.Uint8Array : globalThis.window.Uint8Array
+                const xray_binary = Uint8Array.from(textOrImage.value)
                 const xray_blob = new Blob([clone_into(xray_binary)], { type: 'image/png' })
                 const file = un_xray(
                     new File([un_xray(xray_blob)], 'image.png', {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,7 +111,6 @@ module.exports = (argvEnv, argv) => {
         let resolution = 'desktop'
         if (target.Chromium) buildTarget = 'chromium'
         if (target.Firefox) buildTarget = 'firefox'
-        if (target.FirefoxDesktop) firefoxVariant = 'fennec'
         if (target.FirefoxForAndroid) firefoxVariant = 'fennec'
         if (target.StandaloneGeckoView) {
             firefoxVariant = 'geckoview'


### PR DESCRIPTION
Fix the bug that there's no 'img payload' in firefox browser.