### PR TITLE
fix: show red packet total amount

### DIFF
--- a/src/plugins/RedPacket/UI/CreateRedPacketForm.tsx
+++ b/src/plugins/RedPacket/UI/CreateRedPacketForm.tsx
@@ -316,7 +316,7 @@ export function CreateRedPacketForm(props: CreateRedPacketProps) {
             <TransactionDialog
                 state={createState}
                 summary={`Creating red packet with ${formatBalance(
-                    new BigNumber(amount),
+                    new BigNumber(totalAmount),
                     token.decimals,
                     token.decimals,
                 )} ${token.symbol}`}


### PR DESCRIPTION
It should show the total amount.

![image](https://user-images.githubusercontent.com/63733714/94986615-b382f400-0592-11eb-86ff-38888de95788.png)


![image](https://user-images.githubusercontent.com/63733714/94986619-ba116b80-0592-11eb-911a-89489dd7cb1a.png)
