### PR TITLE
fix: material-ui tab indicator width

### DIFF
--- a/src/extension/options-page/DashboardComponents/AbstractTab.tsx
+++ b/src/extension/options-page/DashboardComponents/AbstractTab.tsx
@@ -28,12 +28,14 @@ export interface AbstractTabProps {
 export default function AbstractTab({ tabs, state, height = 200 }: AbstractTabProps) {
     const classes = useStyles()
     const [value, setValue] = state
+    const tabIndicatorStyle = tabs.length ? { width: 100 / tabs.length + '%' } : undefined
 
     return (
         <>
             <Paper square elevation={0}>
                 <Tabs
                     value={value}
+                    TabIndicatorProps={{ style: tabIndicatorStyle }}
                     variant="fullWidth"
                     indicatorColor="primary"
                     textColor="primary"


### PR DESCRIPTION
It always displays a width broken tab indicator when opening its container at first time: https://github.com/mui-org/material-ui/issues/10465. According to https://github.com/mui-org/material-ui/pull/14638, to fix it just override its style.

![image](https://user-images.githubusercontent.com/63733714/94988314-de734500-059e-11eb-88fd-802783c18b33.png)

![image](https://user-images.githubusercontent.com/63733714/94988317-e0d59f00-059e-11eb-917e-17e2a32c773c.png)
 