### PR TITLE
chore: prevent style override

### DIFF
--- a/src/components/InjectedComponents/PostDialog.tsx
+++ b/src/components/InjectedComponents/PostDialog.tsx
@@ -301,6 +301,7 @@ export function PostDialogUI(props: PostDialogUIProps) {
             {!process.env.STORYBOOK && (
                 <RedPacketDialog
                     classes={classes}
+                    theme={props.theme}
                     open={props.open && redPacketDialogOpen}
                     onConfirm={() => setRedPacketDialogOpen(false)}
                     onDecline={() => setRedPacketDialogOpen(false)}

--- a/src/plugins/RedPacket/UI/RedPacketDialog.tsx
+++ b/src/plugins/RedPacket/UI/RedPacketDialog.tsx
@@ -1,5 +1,14 @@
 import React, { useState, useCallback } from 'react'
-import { makeStyles, DialogTitle, IconButton, DialogContent, Typography, DialogProps } from '@material-ui/core'
+import {
+    makeStyles,
+    DialogTitle,
+    IconButton,
+    DialogContent,
+    Typography,
+    DialogProps,
+    Theme,
+    ThemeProvider,
+} from '@material-ui/core'
 import { useStylesExtends } from '../../../components/custom-ui-helper'
 import { DialogDismissIconUI } from '../../../components/InjectedComponents/DialogDismissIcon'
 import AbstractTab, { AbstractTabProps } from '../../../extension/options-page/DashboardComponents/AbstractTab'
@@ -9,7 +18,7 @@ import ShadowRootDialog from '../../../utils/shadow-root/ShadowRootDialog'
 import { RedPacketMetaKey } from '../constants'
 import { useI18N } from '../../../utils/i18n-next-ui'
 import { RedPacketForm } from './RedPacketForm'
-import { RedPacketBacklogList, RedPacketOutboundList } from './RedPacketList'
+import { RedPacketBacklogList } from './RedPacketList'
 import { PortalShadowRoot } from '../../../utils/shadow-root/ShadowRootPortal'
 import { useAccount } from '../../../web3/hooks/useAccount'
 import Services from '../../../extension/service'
@@ -31,10 +40,13 @@ interface RedPacketDialogProps
         | 'switch'
     > {
     open: boolean
+    theme?: Theme
     onConfirm: (opt?: RedPacketJSONPayload | null) => void
     onDecline: () => void
     DialogProps?: Partial<DialogProps>
 }
+
+const defaultTheme = {}
 
 const useStyles = makeStyles({
     MUIInputRoot: {
@@ -99,28 +111,30 @@ export default function RedPacketDialog(props: RedPacketDialogProps) {
     }
 
     return (
-        <ShadowRootDialog
-            className={classes.dialog}
-            classes={{ container: classes.container, paper: classes.paper }}
-            open={props.open}
-            scroll="paper"
-            fullWidth
-            maxWidth="sm"
-            disableAutoFocus
-            disableEnforceFocus
-            BackdropProps={{ className: classes.backdrop }}
-            {...props.DialogProps}>
-            <DialogTitle className={classes.header}>
-                <IconButton classes={{ root: classes.close }} onClick={props.onDecline}>
-                    <DialogDismissIconUI />
-                </IconButton>
-                <Typography className={classes.title} display="inline" variant="inherit">
-                    {t('plugin_red_packet_display_name')}
-                </Typography>
-            </DialogTitle>
-            <DialogContent className={classes.content}>
-                <AbstractTab height={362} {...tabProps}></AbstractTab>
-            </DialogContent>
-        </ShadowRootDialog>
+        <ThemeProvider theme={props.theme ?? defaultTheme}>
+            <ShadowRootDialog
+                className={classes.dialog}
+                classes={{ container: classes.container, paper: classes.paper }}
+                open={props.open}
+                scroll="paper"
+                fullWidth
+                maxWidth="sm"
+                disableAutoFocus
+                disableEnforceFocus
+                BackdropProps={{ className: classes.backdrop }}
+                {...props.DialogProps}>
+                <DialogTitle className={classes.header}>
+                    <IconButton classes={{ root: classes.close }} onClick={props.onDecline}>
+                        <DialogDismissIconUI />
+                    </IconButton>
+                    <Typography className={classes.title} display="inline" variant="inherit">
+                        {t('plugin_red_packet_display_name')}
+                    </Typography>
+                </DialogTitle>
+                <DialogContent className={classes.content}>
+                    <AbstractTab height={362} {...tabProps}></AbstractTab>
+                </DialogContent>
+            </ShadowRootDialog>
+        </ThemeProvider>
     )
 }


### PR DESCRIPTION
fix red packet dialog style broken when open the wallet dialog, `<ThemeProvider>` generates a special class name for each dialog to prevent `<style>` override by the following ones:

<img src="https://user-images.githubusercontent.com/63733714/96978533-0bd56200-1551-11eb-9bff-d756b86393f9.png" width=600 />

![image](https://user-images.githubusercontent.com/63733714/96984384-06791700-1553-11eb-9e5e-a3d7c539342f.png)


to:  (Now the style of Red packet dialog can't be overrided by the third dialog wallet dialog since it has a different class name)

<img src="https://user-images.githubusercontent.com/63733714/96978437-f2341a80-1550-11eb-8b90-ba09b366f264.png" width=600 />

![image](https://user-images.githubusercontent.com/63733714/96982566-7f2ba380-1552-11eb-8357-7976457f4d7a.png)







