### PR TITLE
Some updates about provider and wallet

### DIFF
--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -29,7 +29,11 @@ import { MessageCenter } from '../../utils/messages'
 import { useValueRef } from '../../utils/hooks/useValueRef'
 import { PersonaIdentifier, ProfileIdentifier, Identifier, ECKeyIdentifier } from '../../database/type'
 import Services from '../../extension/service'
-import { currentSelectedWalletAddressSettings } from '../../plugins/Wallet/settings'
+import {
+    currentSelectedWalletProviderSettings,
+    currentSelectedWalletAddressSettings,
+} from '../../plugins/Wallet/settings'
+import { ProviderType } from '../../web3/types'
 
 export enum SetupGuideStep {
     FindUsername = 'find-username',
@@ -519,7 +523,10 @@ function SetupGuideUI(props: SetupGuideUIProps) {
                 passphrase: '',
             }),
         ])
-        if (address) currentSelectedWalletAddressSettings.value = address
+        if (address) {
+            currentSelectedWalletAddressSettings.value = address
+            currentSelectedWalletProviderSettings.value = ProviderType.Maskbook
+        }
         MessageCenter.emit('identityUpdated', undefined)
     }
     const onCreate = async () => {

--- a/packages/maskbook/src/components/custom-ui-helper.tsx
+++ b/packages/maskbook/src/components/custom-ui-helper.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { safeGetActiveUI } from '../utils/safeRequire'
 
 // Priority: classes from props > configHooks > defaultStyles

--- a/packages/maskbook/src/components/shared/InjectedDialog.tsx
+++ b/packages/maskbook/src/components/shared/InjectedDialog.tsx
@@ -1,17 +1,33 @@
 import {
+    createStyles,
     DialogActions,
     DialogClassKey,
     DialogContent,
     DialogContentProps,
     DialogTitle,
     IconButton,
+    makeStyles,
     Typography,
 } from '@material-ui/core'
 import React from 'react'
+import classNames from 'classnames'
 import { useI18N } from '../../utils/i18n-next-ui'
 import ShadowRootDialog from '../../utils/shadow-root/ShadowRootDialog'
 import { getCustomUIOverwrite, mergeClasses, useStylesExtends } from '../custom-ui-helper'
 import { DialogDismissIconUI } from '../InjectedComponents/DialogDismissIcon'
+
+const useStyles = makeStyles((theme) =>
+    createStyles({
+        dialogTitle: {
+            display: 'flex',
+            alignItems: 'center',
+        },
+        dialogTitleTypography: {
+            verticalAlign: 'middle',
+            marginLeft: 6,
+        },
+    }),
+)
 
 export type InjectedDialogClassKey =
     | DialogClassKey
@@ -20,6 +36,7 @@ export type InjectedDialogClassKey =
     | 'dialogActions'
     | 'dialogTitleTypography'
     | 'dialogCloseButton'
+
 export interface InjectedDialogProps extends withClasses<InjectedDialogClassKey>, React.PropsWithChildren<{}> {
     open: boolean
     onExit?(): void
@@ -37,6 +54,7 @@ export function InjectedDialog(props: InjectedDialogProps) {
         ...classes
     } = useStylesExtends({}, props, overwrite.InjectedDialog?.classes)
     const { t } = useI18N()
+    const classes_ = useStyles()
     const actions = CopyElementWithNewProps(props.children, DialogActions, { root: dialogActions })
     const content = CopyElementWithNewProps(props.children, DialogContent, { root: dialogContent })
 
@@ -51,14 +69,17 @@ export function InjectedDialog(props: InjectedDialogProps) {
             disableEnforceFocus
             onBackdropClick={props.onExit}
             onEscapeKeyDown={props.onExit}>
-            <DialogTitle classes={{ root: dialogTitle }}>
+            <DialogTitle classes={{ root: classNames(dialogTitle, classes_.dialogTitle) }}>
                 <IconButton
                     classes={{ root: dialogCloseButton }}
                     aria-label={t('post_dialog__dismiss_aria')}
                     onClick={props.onExit}>
                     <DialogDismissIconUI />
                 </IconButton>
-                <Typography className={dialogTitleTypography} display="inline" variant="inherit">
+                <Typography
+                    className={classNames(dialogTitleTypography, classes_.dialogTitleTypography)}
+                    display="inline"
+                    variant="inherit">
                     {props.title}
                 </Typography>
             </DialogTitle>

--- a/packages/maskbook/src/components/shared/SelectWallet/WalletInList.tsx
+++ b/packages/maskbook/src/components/shared/SelectWallet/WalletInList.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { ListItem, ListItemText, makeStyles, Theme, ListTypeMap, ListItemAvatar } from '@material-ui/core'
+import { ListItem, ListItemText, makeStyles, ListTypeMap, ListItemAvatar, Avatar } from '@material-ui/core'
 import { useI18N } from '../../../utils/i18n-next-ui'
 import { useStylesExtends } from '../../custom-ui-helper'
 import type { DefaultComponentProps } from '@material-ui/core/OverridableComponent'
 import type { WalletRecordDetailed } from '../../../plugins/Wallet/database/types'
-import { ProviderIcon } from '../ProviderIcon'
 import { formatEthereumAddress } from '../../../plugins/Wallet/formatter'
+import { useBlockie } from '../../../web3/hooks/useBlockie'
 
-const useStyle = makeStyles((theme: Theme) => ({
+const useStyle = makeStyles((theme) => ({
     root: {
         display: 'inline-grid',
     },
@@ -31,11 +31,13 @@ export function WalletInList(props: WalletInListProps) {
     const classes = useStylesExtends(useStyle(), props)
     const { wallet, disabled, onClick, ListItemProps } = props
 
-    const avatar = <ProviderIcon classes={{ icon: classes.icon }} size={40} providerType={wallet.provider} />
+    const walletBlockie = useBlockie(wallet.address)
 
     return (
         <ListItem button disabled={disabled} onClick={onClick} {...ListItemProps}>
-            {avatar ? <ListItemAvatar>{avatar}</ListItemAvatar> : null}
+            <ListItemAvatar>
+                <Avatar src={walletBlockie} />
+            </ListItemAvatar>
             <ListItemText
                 classes={{
                     root: classes.root,
@@ -43,7 +45,7 @@ export function WalletInList(props: WalletInListProps) {
                     secondary: classes.overflow,
                 }}
                 primary={wallet.name}
-                secondary={formatEthereumAddress(wallet.address, 16)}
+                secondary={formatEthereumAddress(wallet.address)}
                 secondaryTypographyProps={{
                     component: 'div',
                 }}

--- a/packages/maskbook/src/components/shared/SelectWallet/WalletInList.tsx
+++ b/packages/maskbook/src/components/shared/SelectWallet/WalletInList.tsx
@@ -3,7 +3,7 @@ import { ListItem, ListItemText, makeStyles, Theme, ListTypeMap, ListItemAvatar 
 import { useI18N } from '../../../utils/i18n-next-ui'
 import { useStylesExtends } from '../../custom-ui-helper'
 import type { DefaultComponentProps } from '@material-ui/core/OverridableComponent'
-import type { WalletRecord } from '../../../plugins/Wallet/database/types'
+import type { WalletRecordDetailed } from '../../../plugins/Wallet/database/types'
 import { ProviderIcon } from '../ProviderIcon'
 import { formatEthereumAddress } from '../../../plugins/Wallet/formatter'
 
@@ -20,7 +20,7 @@ const useStyle = makeStyles((theme: Theme) => ({
 }))
 
 export interface WalletInListProps extends withClasses<KeysInferFromUseStyles<typeof useStyle>> {
-    wallet: WalletRecord
+    wallet: WalletRecordDetailed
     disabled?: boolean
     onClick?: () => void
     ListItemProps?: Partial<DefaultComponentProps<ListTypeMap<{ button: true }, 'div'>>>

--- a/packages/maskbook/src/env.d.ts
+++ b/packages/maskbook/src/env.d.ts
@@ -138,7 +138,7 @@ declare module '@transak/transak-sdk' {
         public closeRequest(): void
         public modal(): void
 
-        public ALL_EVENTS_EVENTS = EVENTS.ALL
+        public ALL_EVENTS_EVENTS = EVENTS.ALL_EVENTS
         public ERROR = EVENTS.TRANSAK_ERROR
         public EVENTS = EVENTS
     }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/chainState.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/chainState.ts
@@ -1,7 +1,7 @@
 import stringify from 'json-stable-stringify'
 import { debounce, first, uniq } from 'lodash-es'
 import { PluginMessageCenter } from '../../../plugins/PluginMessages'
-import type { WalletRecord } from '../../../plugins/Wallet/database/types'
+import type { WalletRecordDetailed } from '../../../plugins/Wallet/database/types'
 import { getWallets } from '../../../plugins/Wallet/services'
 import { currentSelectedWalletAddressSettings } from '../../../plugins/Wallet/settings'
 import {
@@ -51,7 +51,7 @@ PluginMessageCenter.on('maskbook.wallets.update', revalidateChainState)
 //#endregion
 
 //#region tracking wallets
-let wallets: WalletRecord[] = []
+let wallets: WalletRecordDetailed[] = []
 const revalidateWallets = async () => {
     wallets = await getWallets()
 }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/provider.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/provider.ts
@@ -15,19 +15,16 @@ export async function createConnectionURI() {
 // If user confirmed the request we will receive the 'connect' event
 export async function connectWalletConnect() {
     const connector = await WalletConnect.createConnectorIfNeeded()
-    if (connector.connected) return connector.accounts[0]
-    const accounts = await WalletConnect.requestAccounts()
-    return accounts[0]
+    return first(connector.connected ? connector.accounts : await WalletConnect.requestAccounts())
 }
 //#endregion
 
 export async function connectMetaMask() {
     const accounts = await MetaMask.requestAccounts()
-    return accounts[0]
+    return first(accounts)
 }
 
 export async function connectMaskbook() {
     const wallets = await getWallets(ProviderType.Maskbook)
-    // return the first managed wallet
     return first(wallets)
 }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
@@ -10,9 +10,10 @@ import {
     currentSelectedWalletProviderSettings,
     currentSelectedWalletAddressSettings,
 } from '../../../../plugins/Wallet/settings'
-import { updateExoticWallet } from '../../../../plugins/Wallet/services'
+import { updateWallets } from '../../../../plugins/Wallet/services'
 import { ProviderType } from '../../../../web3/types'
 import { MessageCenter } from '../../../../utils/messages'
+import { resolveProviderName } from '../../../../web3/pipes'
 
 //#region tracking chain id of metamask
 let currentChainId: ChainId = ChainId.Mainnet
@@ -36,7 +37,6 @@ function onNetworkChanged(id: string) {
 function onNetworkError(error: any) {
     if (error === 'MetamaskInpageProvider - lost connection to MetaMask') {
         MessageCenter.emit('metamaskMessage', 'metamask_not_install')
-        updateExoticWallet(ProviderType.MetaMask, new Map())
     }
 }
 
@@ -74,7 +74,7 @@ async function updateWalletInDB(address: string, setAsDefault: boolean = false) 
     if (!EthereumAddress.isValid(address)) throw new Error('Cannot found account or invalid account')
 
     // update wallet in the DB
-    await updateExoticWallet(ProviderType.MetaMask, new Map([[address, { address }]]))
+    await updateWallets(new Map([[address, { address, name: resolveProviderName(ProviderType.MetaMask) }]]))
 
     // update trackers
     if (setAsDefault) {

--- a/packages/maskbook/src/extension/background-script/EthereumServices/providers/WalletConnect.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/providers/WalletConnect.ts
@@ -4,13 +4,18 @@ import type { provider as Provider, PromiEvent as PromiEventW3 } from 'web3-core
 import WalletConnect from '@walletconnect/client'
 import type { ITxData } from '@walletconnect/types'
 import * as Maskbook from '../providers/Maskbook'
-import { updateExoticWalletFromSource } from '../../../../plugins/Wallet/services'
-import { currentWalletConnectChainIdSettings } from '../../../../settings/settings'
+import { updateExoticWallet } from '../../../../plugins/Wallet/services'
+import {
+    currentSelectedWalletProviderSettings,
+    currentSelectedWalletAddressSettings,
+} from '../../../../plugins/Wallet/settings'
+import {
+    currentWalletConnectChainIdSettings,
+    currentWalletConnectListOfWalletAddressSettings,
+} from '../../../../settings/settings'
 import { ChainId, TransactionEventType } from '../../../../web3/types'
 import { ProviderType } from '../../../../web3/types'
-import { currentSelectedWalletAddressSettings } from '../../../../plugins/Wallet/settings'
-
-//#region tracking chain id
+//#region tracking chain id of wallet connect
 let currentChainId: ChainId = ChainId.Mainnet
 currentWalletConnectChainIdSettings.addListener((v) => (currentChainId = v))
 //#endregion
@@ -145,8 +150,12 @@ async function updateWalletInDB(address: string, name: string = 'WalletConnect',
     if (!EthereumAddress.isValid(address)) throw new Error('Cannot found account or invalid account')
 
     // update wallet in the DB
-    await updateExoticWalletFromSource(ProviderType.WalletConnect, new Map([[address, { name, address }]]))
+    await updateExoticWallet(ProviderType.WalletConnect, new Map([[address, { name, address }]]))
 
-    // update the selected wallet address
-    if (setAsDefault) currentSelectedWalletAddressSettings.value = address
+    // update trackers
+    if (setAsDefault) {
+        currentSelectedWalletAddressSettings.value = address
+        currentSelectedWalletProviderSettings.value = ProviderType.WalletConnect
+        currentWalletConnectListOfWalletAddressSettings.value = address
+    }
 }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/providers/WalletConnect.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/providers/WalletConnect.ts
@@ -4,7 +4,7 @@ import type { provider as Provider, PromiEvent as PromiEventW3 } from 'web3-core
 import WalletConnect from '@walletconnect/client'
 import type { ITxData } from '@walletconnect/types'
 import * as Maskbook from '../providers/Maskbook'
-import { updateExoticWallet } from '../../../../plugins/Wallet/services'
+import { updateWallets } from '../../../../plugins/Wallet/services'
 import {
     currentSelectedWalletProviderSettings,
     currentSelectedWalletAddressSettings,
@@ -15,6 +15,7 @@ import {
 } from '../../../../settings/settings'
 import { ChainId, TransactionEventType } from '../../../../web3/types'
 import { ProviderType } from '../../../../web3/types'
+import { resolveProviderName } from '../../../../web3/pipes'
 //#region tracking chain id of wallet connect
 let currentChainId: ChainId = ChainId.Mainnet
 currentWalletConnectChainIdSettings.addListener((v) => (currentChainId = v))
@@ -145,12 +146,16 @@ const onDisconnect = async (error: Error | null) => {
     connector = null
 }
 
-async function updateWalletInDB(address: string, name: string = 'WalletConnect', setAsDefault: boolean = false) {
+async function updateWalletInDB(
+    address: string,
+    name: string = resolveProviderName(ProviderType.WalletConnect),
+    setAsDefault: boolean = false,
+) {
     // validate address
     if (!EthereumAddress.isValid(address)) throw new Error('Cannot found account or invalid account')
 
     // update wallet in the DB
-    await updateExoticWallet(ProviderType.WalletConnect, new Map([[address, { name, address }]]))
+    await updateWallets(new Map([[address, { name, address }]]))
 
     // update trackers
     if (setAsDefault) {

--- a/packages/maskbook/src/extension/background-script/EthereumServices/transaction.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/transaction.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js'
 
 import { enhancePromiEvent, promiEventToIterator, StageType } from '../../../utils/promiEvent'
 import { getWallets } from '../../../plugins/Wallet/services'
-import type { WalletRecord } from '../../../plugins/Wallet/database/types'
+import type { WalletRecordDetailed } from '../../../plugins/Wallet/database/types'
 import { PluginMessageCenter } from '../../../plugins/PluginMessages'
 import * as Maskbook from './providers/Maskbook'
 import * as MetaMask from './providers/MetaMask'
@@ -17,7 +17,7 @@ import { getTransactionReceipt } from './network'
 import { getChainId } from './chainState'
 
 //#region tracking wallets
-let wallets: WalletRecord[] = []
+let wallets: WalletRecordDetailed[] = []
 const revalidate = async () => (wallets = await getWallets())
 PluginMessageCenter.on('maskbook.wallets.update', revalidate)
 revalidate()

--- a/packages/maskbook/src/extension/background-script/WelcomeServices/restoreBackup.ts
+++ b/packages/maskbook/src/extension/background-script/WelcomeServices/restoreBackup.ts
@@ -16,7 +16,7 @@ import { i18n } from '../../../utils/i18n-next'
 import { MessageCenter } from '../../../utils/messages'
 import { currentImportingBackup } from '../../../settings/settings'
 import { WalletRecordFromJSONFormat } from '../../../utils/type-transform/BackupFormat/JSON/DBRecord-JSON/WalletRecord'
-import { importNewWallet } from '../../../plugins/Wallet/services'
+import { importWallet } from '../../../plugins/Wallet/services'
 
 /**
  * Restore the backup
@@ -53,7 +53,7 @@ export async function restoreBackup(json: object, whoAmI?: ProfileIdentifier) {
 
                 for (const x of data.wallets) {
                     const record = WalletRecordFromJSONFormat(x)
-                    if (record.mnemonic || record._private_key_) await importNewWallet(record)
+                    if (record.mnemonic || record._private_key_) await importWallet(record)
                 }
             })
         }

--- a/packages/maskbook/src/extension/options-page/DashboardComponents/WalletContent.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardComponents/WalletContent.tsx
@@ -21,7 +21,7 @@ import { useMenu } from '../../../utils/hooks/useMenu'
 import { useI18N } from '../../../utils/i18n-next-ui'
 import { useColorStyles } from '../../../utils/theme'
 import { useMatchXS } from '../../../utils/hooks/useMatchXS'
-import type { WalletRecord } from '../../../plugins/Wallet/database/types'
+import type { WalletRecordDetailed } from '../../../plugins/Wallet/database/types'
 import { ProviderType, TokenDetailed } from '../../../web3/types'
 import { WalletAssetsTable } from './WalletAssetsTable'
 import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControlledDialog'
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme) =>
 )
 
 interface WalletContentProps {
-    wallet: WalletRecord
+    wallet: WalletRecordDetailed
     detailedTokens: TokenDetailed[]
 }
 

--- a/packages/maskbook/src/extension/options-page/DashboardRouters/Setup.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardRouters/Setup.tsx
@@ -42,7 +42,11 @@ import { RestoreFromQRCodeCameraBox } from '../DashboardComponents/RestoreFromQR
 import { sleep } from '../../../utils/utils'
 import { SetupStep } from '../SetupStep'
 import { Flags } from '../../../utils/flags'
-import { currentSelectedWalletAddressSettings } from '../../../plugins/Wallet/settings'
+import {
+    currentSelectedWalletProviderSettings,
+    currentSelectedWalletAddressSettings,
+} from '../../../plugins/Wallet/settings'
+import { ProviderType } from '../../../web3/types'
 
 //#region setup form
 const useSetupFormStyles = makeStyles((theme) =>
@@ -368,7 +372,10 @@ export function ConnectNetwork() {
                                     passphrase: '',
                                 }),
                             ])
-                            if (address) currentSelectedWalletAddressSettings.value = address
+                            if (address) {
+                                currentSelectedWalletAddressSettings.value = address
+                                currentSelectedWalletProviderSettings.value = ProviderType.Maskbook
+                            }
                             await sleep(300)
                             history.replace(Flags.has_no_browser_tab_ui ? DashboardRoute.Nav : DashboardRoute.Personas)
                         }}>

--- a/packages/maskbook/src/plugins/Wallet/UI/SelectProviderDialog.tsx
+++ b/packages/maskbook/src/plugins/Wallet/UI/SelectProviderDialog.tsx
@@ -21,19 +21,8 @@ import { MessageCenter } from '../../../utils/messages'
 import { Flags } from '../../../utils/flags'
 import { InjectedDialog } from '../../../components/shared/InjectedDialog'
 
-const useStyles = makeStyles((theme: Theme) =>
+const useStyles = makeStyles((theme) =>
     createStyles({
-        paper: {
-            width: '750px !important',
-            maxWidth: 'unset',
-        },
-        content: {
-            display: 'flex',
-            flexWrap: 'wrap',
-            justifyContent: 'space-around',
-            overflow: 'hidden',
-            padding: theme.spacing(2, 1),
-        },
         grid: {
             width: '100%',
         },
@@ -113,57 +102,55 @@ function SelectProviderDialogUI(props: SelectProviderDialogUIProps) {
         [enqueueSnackbar, t],
     )
     return (
-        <>
-            <InjectedDialog title="Connect wallet" open={open} onExit={onClose}>
-                <DialogContent>
-                    <GridList className={classes.grid} spacing={16} cellHeight={183}>
+        <InjectedDialog title="Connect Wallet" open={open} onExit={onClose}>
+            <DialogContent>
+                <GridList className={classes.grid} cellHeight={183}>
+                    <GridListTile>
+                        <Provider
+                            logo={<MaskbookIcon className={classes.icon} viewBox="0 0 45 45" />}
+                            name="Maskbook"
+                            description="Create wallet with Maskbook"
+                            onClick={() => onConnect(ProviderType.Maskbook)}
+                        />
+                    </GridListTile>
+                    {Flags.metamask_support_enabled ? (
                         <GridListTile>
                             <Provider
-                                logo={<MaskbookIcon className={classes.icon} viewBox="0 0 45 45" />}
-                                name="Maskbook"
-                                description="Create wallet with Maskbook"
-                                onClick={() => onConnect(ProviderType.Maskbook)}
+                                logo={<MetaMaskIcon className={classes.icon} viewBox="0 0 45 45" />}
+                                name="MetaMask"
+                                description="Connect to your MetaMask Wallet"
+                                onClick={() => onConnect(ProviderType.MetaMask)}
                             />
                         </GridListTile>
-                        {Flags.metamask_support_enabled ? (
-                            <GridListTile>
-                                <Provider
-                                    logo={<MetaMaskIcon className={classes.icon} viewBox="0 0 45 45" />}
-                                    name="MetaMask"
-                                    description="Connect to your MetaMask Wallet"
-                                    onClick={() => onConnect(ProviderType.MetaMask)}
-                                />
-                            </GridListTile>
-                        ) : null}
-                        {Flags.wallet_connect_support_enabled ? (
-                            <GridListTile>
-                                <Provider
-                                    logo={<WalletConnectIcon className={classes.icon} viewBox="0 0 45 45" />}
-                                    name="WalletConnect"
-                                    description="Scan with WalletConnect to connect"
-                                    onClick={() => onConnect(ProviderType.WalletConnect)}
-                                />
-                            </GridListTile>
-                        ) : null}
+                    ) : null}
+                    {Flags.wallet_connect_support_enabled ? (
                         <GridListTile>
                             <Provider
-                                logo={
-                                    <MoreHorizontal
-                                        className={classes.icon}
-                                        viewBox="0 0 22.5 22.5"
-                                        width={45}
-                                        height={45}
-                                    />
-                                }
-                                name="More"
-                                description="Comming soon…"
-                                ButtonBaseProps={{ disabled: true }}
+                                logo={<WalletConnectIcon className={classes.icon} viewBox="0 0 45 45" />}
+                                name="WalletConnect"
+                                description="Scan with WalletConnect to connect"
+                                onClick={() => onConnect(ProviderType.WalletConnect)}
                             />
                         </GridListTile>
-                    </GridList>
-                </DialogContent>
-            </InjectedDialog>
-        </>
+                    ) : null}
+                    <GridListTile>
+                        <Provider
+                            logo={
+                                <MoreHorizontal
+                                    className={classes.icon}
+                                    viewBox="0 0 22.5 22.5"
+                                    width={45}
+                                    height={45}
+                                />
+                            }
+                            name="More"
+                            description="Comming soon…"
+                            ButtonBaseProps={{ disabled: true }}
+                        />
+                    </GridListTile>
+                </GridList>
+            </DialogContent>
+        </InjectedDialog>
     )
 }
 

--- a/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
+++ b/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
@@ -15,7 +15,13 @@ import { GetContext } from '@dimensiondev/holoflows-kit/es'
 import { currentSelectedWalletProviderSettings, currentSelectedWalletAddressSettings } from '../settings'
 import { InjectedDialog } from '../../../components/shared/InjectedDialog'
 
-const useStyles = makeStyles((theme) => createStyles({}))
+const useStyles = makeStyles((theme) =>
+    createStyles({
+        paper: {
+            minHeight: 500,
+        },
+    }),
+)
 
 interface SelectWalletDialogUIProps extends withClasses<never> {}
 
@@ -72,7 +78,7 @@ function SelectWalletDialogUI(props: SelectWalletDialogUIProps) {
 
     return (
         <>
-            <InjectedDialog open={open} onExit={onClose} title="Select Wallet">
+            <InjectedDialog classes={classes} open={open} onExit={onClose} title="Select Wallet">
                 <DialogContent>
                     {wallets.map((wallet) => (
                         <WalletInList key={wallet.address} wallet={wallet} onClick={() => onSelect(wallet)} />

--- a/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
+++ b/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
@@ -7,7 +7,7 @@ import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControl
 import { MaskbookWalletMessages, WalletMessageCenter } from '../messages'
 import { useWallets } from '../hooks/useWallet'
 import { WalletInList } from '../../../components/shared/SelectWallet/WalletInList'
-import type { WalletRecord } from '../database/types'
+import type { WalletRecordDetailed } from '../database/types'
 import Services from '../../../extension/service'
 import { DashboardRoute } from '../../../extension/options-page/Route'
 import { sleep } from '../../../utils/utils'
@@ -38,7 +38,7 @@ function SelectWalletDialogUI(props: SelectWalletDialogUIProps) {
     //#endregion
 
     const onSelect = useCallback(
-        (wallet: WalletRecord) => {
+        (wallet: WalletRecordDetailed) => {
             currentSelectedWalletAddressSettings.value = wallet.address
             currentSelectedWalletProviderSettings.value = wallet.provider
             onClose()

--- a/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
+++ b/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback } from 'react'
-import { Button, createStyles, DialogActions, DialogContent, makeStyles } from '@material-ui/core'
+import {
+    Button,
+    createStyles,
+    DialogActions,
+    DialogContent,
+    List,
+    ListSubheader,
+    makeStyles,
+    Typography,
+} from '@material-ui/core'
 import { useHistory } from 'react-router-dom'
 import { useI18N } from '../../../utils/i18n-next-ui'
 import { useStylesExtends } from '../../../components/custom-ui-helper'
@@ -14,11 +23,41 @@ import { sleep } from '../../../utils/utils'
 import { GetContext } from '@dimensiondev/holoflows-kit/es'
 import { currentSelectedWalletProviderSettings, currentSelectedWalletAddressSettings } from '../settings'
 import { InjectedDialog } from '../../../components/shared/InjectedDialog'
+import { resolveProviderName } from '../../../web3/pipes'
+import { ProviderType } from '../../../web3/types'
+import { ProviderIcon } from '../../../components/shared/ProviderIcon'
 
 const useStyles = makeStyles((theme) =>
     createStyles({
         paper: {
-            minHeight: 500,
+            height: 500,
+        },
+        content: {
+            padding: theme.spacing(0, 2, 1, 2),
+            '&::-webkit-scrollbar': {
+                display: 'none',
+            },
+        },
+        list: {
+            padding: 0,
+        },
+        subHeader: {
+            display: 'flex',
+            alignItems: 'center',
+            padding: theme.spacing(2, 2, 1),
+            backgroundColor: theme.palette.background.paper,
+            '&:first-child': {
+                paddingTop: 0,
+            },
+        },
+        subHeaderIcon: {
+            fontSize: 24,
+            width: 24,
+            height: 24,
+        },
+        subHeaderText: {
+            fontSize: 14,
+            marginLeft: theme.spacing(1),
         },
     }),
 )
@@ -79,10 +118,34 @@ function SelectWalletDialogUI(props: SelectWalletDialogUIProps) {
     return (
         <>
             <InjectedDialog classes={classes} open={open} onExit={onClose} title="Select Wallet">
-                <DialogContent>
-                    {wallets.map((wallet) => (
-                        <WalletInList key={wallet.address} wallet={wallet} onClick={() => onSelect(wallet)} />
-                    ))}
+                <DialogContent className={classes.content}>
+                    <List className={classes.list} dense>
+                        {[ProviderType.MetaMask, ProviderType.WalletConnect, ProviderType.Maskbook].map((provider) =>
+                            wallets.some((x) => x.provider === provider) ? (
+                                <>
+                                    <ListSubheader className={classes.subHeader}>
+                                        <ProviderIcon
+                                            classes={{ icon: classes.subHeaderIcon }}
+                                            size={24}
+                                            providerType={provider}
+                                        />
+                                        <Typography className={classes.subHeaderText}>
+                                            {resolveProviderName(provider)}
+                                        </Typography>
+                                    </ListSubheader>
+                                    {wallets
+                                        .filter((x) => x.provider === provider)
+                                        .map((wallet) => (
+                                            <WalletInList
+                                                key={wallet.address}
+                                                wallet={wallet}
+                                                onClick={() => onSelect(wallet)}
+                                            />
+                                        ))}
+                                </>
+                            ) : null,
+                        )}
+                    </List>
                 </DialogContent>
                 <DialogActions>
                     <Button variant="text" onClick={onCreate}>

--- a/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
+++ b/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
@@ -117,12 +117,12 @@ function SelectWalletDialogUI(props: SelectWalletDialogUIProps) {
 
     return (
         <>
-            <InjectedDialog classes={classes} open={open} onExit={onClose} title="Select Wallet">
+            <InjectedDialog open={open} onExit={onClose} title="Select Wallet">
                 <DialogContent className={classes.content}>
                     <List className={classes.list} dense>
                         {[ProviderType.MetaMask, ProviderType.WalletConnect, ProviderType.Maskbook].map((provider) =>
                             wallets.some((x) => x.provider === provider) ? (
-                                <>
+                                <React.Fragment key={provider}>
                                     <ListSubheader className={classes.subHeader}>
                                         <ProviderIcon
                                             classes={{ icon: classes.subHeaderIcon }}
@@ -142,7 +142,7 @@ function SelectWalletDialogUI(props: SelectWalletDialogUIProps) {
                                                 onClick={() => onSelect(wallet)}
                                             />
                                         ))}
-                                </>
+                                </React.Fragment>
                             ) : null,
                         )}
                     </List>

--- a/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
+++ b/packages/maskbook/src/plugins/Wallet/UI/SelectWalletDialog.tsx
@@ -12,7 +12,7 @@ import Services from '../../../extension/service'
 import { DashboardRoute } from '../../../extension/options-page/Route'
 import { sleep } from '../../../utils/utils'
 import { GetContext } from '@dimensiondev/holoflows-kit/es'
-import { currentSelectedWalletAddressSettings } from '../settings'
+import { currentSelectedWalletProviderSettings, currentSelectedWalletAddressSettings } from '../settings'
 import { InjectedDialog } from '../../../components/shared/InjectedDialog'
 
 const useStyles = makeStyles((theme) => createStyles({}))
@@ -40,6 +40,7 @@ function SelectWalletDialogUI(props: SelectWalletDialogUIProps) {
     const onSelect = useCallback(
         (wallet: WalletRecord) => {
             currentSelectedWalletAddressSettings.value = wallet.address
+            currentSelectedWalletProviderSettings.value = wallet.provider
             onClose()
         },
         [onClose],

--- a/packages/maskbook/src/plugins/Wallet/database/types.ts
+++ b/packages/maskbook/src/plugins/Wallet/database/types.ts
@@ -24,7 +24,6 @@ export interface WalletRecord {
     erc20_token_whitelist: Set<string>
     /** A list of untrusted ERC20 token address */
     erc20_token_blacklist: Set<string>
-    provider: ProviderType
     mnemonic: string[]
     passphrase: string
     _public_key_?: string
@@ -32,6 +31,10 @@ export interface WalletRecord {
     _private_key_?: string
     createdAt: Date
     updatedAt: Date
+}
+
+export interface WalletRecordDetailed extends WalletRecord {
+    provider: ProviderType
 }
 
 export interface ERC20TokenRecordInDatabase extends ERC20TokenRecord {}

--- a/packages/maskbook/src/plugins/Wallet/hooks/useWallet.ts
+++ b/packages/maskbook/src/plugins/Wallet/hooks/useWallet.ts
@@ -4,13 +4,13 @@ import { PluginMessageCenter } from '../../PluginMessages'
 import Services from '../../../extension/service'
 import type { ProviderType } from '../../../web3/types'
 import { useValueRef } from '../../../utils/hooks/useValueRef'
-import type { WalletRecord } from '../database/types'
-import { WalletArrayComparer, WalletComparer } from '../helpers'
+import { WalletArrayComparer } from '../helpers'
 import { isSameAddress } from '../../../web3/helpers'
 import { currentSelectedWalletAddressSettings } from '../settings'
+import type { WalletRecordDetailed } from '../database/types'
 
 //#region tracking wallets
-const walletsRef = new ValueRef<WalletRecord[]>([], WalletArrayComparer)
+const walletsRef = new ValueRef<WalletRecordDetailed[]>([], WalletArrayComparer)
 async function revalidate() {
     walletsRef.value = await Services.Plugin.invokePlugin('maskbook.wallet', 'getWallets')
 }

--- a/packages/maskbook/src/plugins/Wallet/hooks/useWallet.ts
+++ b/packages/maskbook/src/plugins/Wallet/hooks/useWallet.ts
@@ -6,7 +6,7 @@ import type { ProviderType } from '../../../web3/types'
 import { useValueRef } from '../../../utils/hooks/useValueRef'
 import { WalletArrayComparer } from '../helpers'
 import { isSameAddress } from '../../../web3/helpers'
-import { currentSelectedWalletAddressSettings } from '../settings'
+import { currentSelectedWalletAddressSettings, currentSelectedWalletProviderSettings } from '../settings'
 import type { WalletRecordDetailed } from '../database/types'
 
 //#region tracking wallets
@@ -20,8 +20,13 @@ revalidate()
 
 export function useSelectedWallet() {
     const address = useValueRef(currentSelectedWalletAddressSettings)
+    const provider = useValueRef(currentSelectedWalletProviderSettings)
     const wallets = useWallets()
-    return wallets.find((x) => isSameAddress(x.address, address)) ?? first(wallets)
+    const wallet = wallets.find((x) => isSameAddress(x.address, address)) ?? first(wallets)
+    return {
+        ...wallet,
+        provider,
+    } as typeof wallet
 }
 
 export function useWallet(address: string) {

--- a/packages/maskbook/src/plugins/Wallet/services/helpers.ts
+++ b/packages/maskbook/src/plugins/Wallet/services/helpers.ts
@@ -8,17 +8,7 @@ import type {
 } from '../database/types'
 import { resolveChainId } from '../../../web3/pipes'
 import { formatChecksumAddress } from '../formatter'
-import { ChainId, ProviderType } from '../../../web3/types'
-
-function fixWalletRecordProviderType(record: WalletRecord | WalletRecordInDatabase) {
-    if (record.provider) return
-    const record_ = record as { type?: 'managed' | 'exotic' } & WalletRecord
-    record.provider =
-        record_.type === 'managed' || record_._private_key_ || record_.mnemonic.length
-            ? ProviderType.Maskbook
-            : ProviderType.MetaMask
-    delete record_.type
-}
+import { ChainId } from '../../../web3/types'
 
 export async function getWalletByAddress(t: IDBPSafeTransaction<WalletDB, ['Wallet'], 'readonly'>, address: string) {
     const record = await t.objectStore('Wallet').get(formatChecksumAddress(address))
@@ -27,14 +17,12 @@ export async function getWalletByAddress(t: IDBPSafeTransaction<WalletDB, ['Wall
 
 export function WalletRecordIntoDB(x: WalletRecord) {
     const record = x as WalletRecordInDatabase
-    fixWalletRecordProviderType(record)
     record.address = formatChecksumAddress(x.address)
     return record
 }
 
 export function WalletRecordOutDB(x: WalletRecordInDatabase) {
     const record = x as WalletRecord
-    fixWalletRecordProviderType(record)
     record.address = formatChecksumAddress(record.address)
     record.erc20_token_whitelist = x.erc20_token_whitelist ?? new Set()
     record.erc20_token_blacklist = x.erc20_token_blacklist ?? new Set()

--- a/packages/maskbook/src/plugins/Wallet/services/wallet.ts
+++ b/packages/maskbook/src/plugins/Wallet/services/wallet.ts
@@ -1,11 +1,11 @@
 import * as bip39 from 'bip39'
-import { first } from 'lodash-es'
+import { first, some } from 'lodash-es'
 import { HDKey, EthereumAddress } from 'wallet.ts'
 import { BigNumber } from 'bignumber.js'
 import { ec as EC } from 'elliptic'
 import { createTransaction } from '../../../database/helpers/openDB'
 import { createWalletDBAccess } from '../database/Wallet.db'
-import type { WalletRecord } from '../database/types'
+import type { WalletRecord, WalletRecordDetailed } from '../database/types'
 import { PluginMessageCenter } from '../../PluginMessages'
 import { buf2hex, hex2buf, assert } from '../../../utils/utils'
 import { ProviderType } from '../../../web3/types'
@@ -14,6 +14,10 @@ import { formatChecksumAddress } from '../formatter'
 import { getWalletByAddress, WalletRecordIntoDB, WalletRecordOutDB } from './helpers'
 import { isSameAddress } from '../../../web3/helpers'
 import { currentSelectedWalletAddressSettings } from '../settings'
+import {
+    currentMetaMaskListOfWalletAddressSettings,
+    currentWalletConnectListOfWalletAddressSettings,
+} from '../../../settings/settings'
 
 // Private key at m/44'/coinType'/account'/change/addressIndex
 // coinType = ether
@@ -41,7 +45,7 @@ export async function getWallet(address: string) {
     return wallets.find((x) => isSameAddress(x.address, address))
 }
 
-export async function getWallets(provider?: ProviderType) {
+export async function getWallets(provider?: ProviderType): Promise<WalletRecordDetailed[]> {
     const t = createTransaction(await createWalletDBAccess(), 'readonly')('Wallet')
     const records = await t.objectStore('Wallet').getAll()
     const wallets = (
@@ -55,9 +59,29 @@ export async function getWallets(provider?: ProviderType) {
             }),
         )
     ).sort(sortWallet)
-    return wallets.length && typeof provider !== 'undefined' ? wallets.filter((x) => x.provider === provider) : wallets
+
+    switch (provider) {
+        case ProviderType.MetaMask:
+            return wallets
+                .filter((x) =>
+                    some(currentMetaMaskListOfWalletAddressSettings.value.split(','), (y) =>
+                        isSameAddress(x.address, y),
+                    ),
+                )
+                .map((x) => ({ ...x, provider: ProviderType.MetaMask }))
+        case ProviderType.WalletConnect:
+            return wallets
+                .filter((x) =>
+                    some(currentWalletConnectListOfWalletAddressSettings.value.split(','), (y) =>
+                        isSameAddress(x.address, y),
+                    ),
+                )
+                .map((x) => ({ ...x, provider: ProviderType.WalletConnect }))
+        default:
+            return wallets.filter((x) => x._private_key_).map((x) => ({ ...x, provider: ProviderType.Maskbook }))
+    }
     async function makePrivateKey(record: WalletRecord) {
-        if (record.provider !== ProviderType.Maskbook) return '0x'
+        if (!record.mnemonic && !record._private_key_) return '0x'
         const { privateKey } = record._private_key_
             ? await recoverWalletFromPrivateKey(record._private_key_)
             : await recoverWalletFromMnemonic(record.mnemonic, record.passphrase)
@@ -65,18 +89,13 @@ export async function getWallets(provider?: ProviderType) {
     }
 }
 
-export async function updateExoticWallet(
-    provider: ProviderType,
-    updates: Map<string, Partial<WalletRecord>>,
-): Promise<void> {
+export async function updateWallets(updates: Map<string, Partial<WalletRecord>>): Promise<void> {
     const walletStore = createTransaction(await createWalletDBAccess(), 'readwrite')('Wallet').objectStore('Wallet')
     let modified = false
     for await (const cursor of walletStore) {
         const wallet = cursor.value
-        if (wallet.provider === ProviderType.Maskbook) continue
-        if (wallet.provider !== provider) continue
         {
-            if (updates.has(formatChecksumAddress(wallet.address))) {
+            if (updates.has(formatChecksumAddress(wallet.address)))
                 await cursor.update(
                     WalletRecordIntoDB({
                         ...WalletRecordOutDB(cursor.value),
@@ -84,25 +103,23 @@ export async function updateExoticWallet(
                         updatedAt: new Date(),
                     }),
                 )
-            } else await cursor.delete()
+            else await cursor.delete()
             modified = true
         }
     }
     for (const address of updates.keys()) {
         const wallet = await walletStore.get(formatChecksumAddress(address))
-        // cannot update managed wallet as an exotic wallet
-        if (wallet && wallet.provider === ProviderType.Maskbook && provider !== ProviderType.Maskbook) continue
         await walletStore.put(
             WalletRecordIntoDB({
                 address,
+                name: '',
                 createdAt: new Date(),
                 updatedAt: new Date(),
                 erc20_token_blacklist: new Set(),
                 erc20_token_whitelist: new Set(),
-                name: resolveProviderName(provider),
-                passphrase: '',
-                provider,
                 mnemonic: [] as string[],
+                passphrase: '',
+                ...wallet,
                 ...updates.get(address)!,
             }),
         )
@@ -137,7 +154,7 @@ export async function importWallet(
         'name'
     >,
 ) {
-    const { name, provider = ProviderType.Maskbook, mnemonic = [], passphrase = '' } = rec
+    const { name, mnemonic = [], passphrase = '' } = rec
     const address = await getWalletAddress()
     if (!address) throw new Error('cannot get the wallet address')
     if (rec.name === null) rec.name = address.slice(0, 6)
@@ -145,7 +162,6 @@ export async function importWallet(
         name,
         mnemonic,
         passphrase,
-        provider,
         address,
         erc20_token_whitelist: new Set(),
         erc20_token_blacklist: new Set(),

--- a/packages/maskbook/src/plugins/Wallet/settings.ts
+++ b/packages/maskbook/src/plugins/Wallet/settings.ts
@@ -1,12 +1,24 @@
 import { createGlobalSettings } from '../../settings/createSettings'
+import { ProviderType } from '../../web3/types'
 import { PLUGIN_IDENTIFIER } from './constants'
 
 /**
- * The address of selected wallet
+ * The address of the selected wallet
  */
 export const currentSelectedWalletAddressSettings = createGlobalSettings<string>(
     `${PLUGIN_IDENTIFIER}+selectedWalletAddress`,
     '',
+    {
+        primary: () => 'DO NOT DISPLAY IT IN UI',
+    },
+)
+
+/**
+ * The provider type of the selected wallet
+ */
+export const currentSelectedWalletProviderSettings = createGlobalSettings<ProviderType>(
+    `${PLUGIN_IDENTIFIER}+seelctedWalletProviderType`,
+    ProviderType.Maskbook,
     {
         primary: () => 'DO NOT DISPLAY IT IN UI',
     },

--- a/packages/maskbook/src/settings/settings.ts
+++ b/packages/maskbook/src/settings/settings.ts
@@ -51,6 +51,65 @@ export const appearanceSettings = createGlobalSettings<Appearance>('appearance',
     secondary: () => i18n.t('settings_appearance_secondary'),
 })
 
+/**
+ * A list of wallet address which using Maskbook as the provider
+ */
+export const currentMaskbookListOfWalletAddressSettings = createGlobalSettings<string>(
+    'maskbook list of wallet address',
+    '',
+    {
+        primary: () => 'DO NOT DISPLAY IT IN UI',
+    },
+)
+
+/**
+ * A list of wallet address which using Metamask as the provider
+ */
+export const currentMetaMaskListOfWalletAddressSettings = createGlobalSettings<string>(
+    'metamask list of wallet address',
+    '',
+    {
+        primary: () => 'DO NOT DISPLAY IT IN UI',
+    },
+)
+
+/**
+ * A list of wallet address which using WalletConnect as the provider
+ */
+export const currentWalletConnectListOfWalletAddressSettings = createGlobalSettings<string>(
+    'walletconnect list of wallet address',
+    '',
+    {
+        primary: () => 'DO NOT DISPLAY IT IN UI',
+    },
+)
+
+/**
+ * The chain id using by Maskbook
+ */
+export const currentMaskbookChainIdSettings = createGlobalSettings<ChainId>('maskbook chain id', ChainId.Mainnet, {
+    primary: () => i18n.t('settings_choose_eth_network'),
+    secondary: () => 'This only affects the built-in wallet.',
+})
+
+/**
+ * The chain id using by Metamask
+ */
+export const currentMetaMaskChainIdSettings = createGlobalSettings<ChainId>('metamask chain id', ChainId.Mainnet, {
+    primary: () => 'DO NOT DISPLAY IT IN UI',
+})
+
+/**
+ * The chain id using by WalletConnect
+ */
+export const currentWalletConnectChainIdSettings = createGlobalSettings<ChainId>(
+    'walletconnect chain id',
+    ChainId.Mainnet,
+    {
+        primary: () => 'DO NOT DISPLAY IT IN UI',
+    },
+)
+
 //#region chain state settings
 export interface ChainState {
     chainId: ChainId
@@ -59,25 +118,6 @@ export interface ChainState {
 export const currentChainStateSettings = createGlobalSettings<string>('chain state', stringify([]), {
     primary: () => 'DO NOT DISPLAY IT IN UI',
 })
-//#endregion
-
-//#region provider chain id
-export const currentMaskbookChainIdSettings = createGlobalSettings<ChainId>('maskbook chain id', ChainId.Mainnet, {
-    primary: () => i18n.t('settings_choose_eth_network'),
-    secondary: () => 'This only affects the built-in wallet.',
-})
-
-export const currentMetaMaskChainIdSettings = createGlobalSettings<ChainId>('metamask chain id', ChainId.Mainnet, {
-    primary: () => 'DO NOT DISPLAY IT IN UI',
-})
-
-export const currentWalletConnectChainIdSettings = createGlobalSettings<ChainId>(
-    'walletconnect chain id',
-    ChainId.Mainnet,
-    {
-        primary: () => 'DO NOT DISPLAY IT IN UI',
-    },
-)
 //#endregion
 
 export const lastActivatedWalletProvider = createInternalSettings<ProviderType>(

--- a/packages/maskbook/src/settings/settings.ts
+++ b/packages/maskbook/src/settings/settings.ts
@@ -63,7 +63,7 @@ export const currentMaskbookListOfWalletAddressSettings = createGlobalSettings<s
 )
 
 /**
- * A list of wallet address which using Metamask as the provider
+ * A list of wallet address which using MetaMask as the provider
  */
 export const currentMetaMaskListOfWalletAddressSettings = createGlobalSettings<string>(
     'metamask list of wallet address',
@@ -93,7 +93,7 @@ export const currentMaskbookChainIdSettings = createGlobalSettings<ChainId>('mas
 })
 
 /**
- * The chain id using by Metamask
+ * The chain id using by MetaMask
  */
 export const currentMetaMaskChainIdSettings = createGlobalSettings<ChainId>('metamask chain id', ChainId.Mainnet, {
     primary: () => 'DO NOT DISPLAY IT IN UI',

--- a/packages/maskbook/src/social-network-provider/twitter.com/ui/custom.ts
+++ b/packages/maskbook/src/social-network-provider/twitter.com/ui/custom.ts
@@ -106,8 +106,6 @@ const useInjectedDialogClassesOverwrite = makeStyles((theme) =>
             },
         },
         dialogTitle: {
-            display: 'flex',
-            alignItems: 'center',
             padding: '10px 15px',
             borderBottom: `1px solid ${theme.palette.type === 'dark' ? '#2f3336' : '#ccd6dd'}`,
             '& > h2': {
@@ -145,10 +143,6 @@ const useInjectedDialogClassesOverwrite = makeStyles((theme) =>
                 margin: '0 auto',
                 padding: '7px 14px 6px !important',
             },
-        },
-        dialogTitleTypography: {
-            verticalAlign: 'middle',
-            marginLeft: 6,
         },
     }),
 )

--- a/packages/maskbook/src/web3/UI/EthereumAccountChip.tsx
+++ b/packages/maskbook/src/web3/UI/EthereumAccountChip.tsx
@@ -9,18 +9,19 @@ import {
     Typography,
     Box,
     Divider,
+    Avatar,
 } from '@material-ui/core'
 import { ChevronDown, Copy } from 'react-feather'
 import { useCopyToClipboard } from 'react-use'
 import { useStylesExtends } from '../../components/custom-ui-helper'
 import { useWallets } from '../../plugins/Wallet/hooks/useWallet'
 import { isSameAddress } from '../helpers'
-import { ProviderIcon } from '../../components/shared/ProviderIcon'
 import { formatEthereumAddress } from '../../plugins/Wallet/formatter'
 import { useSnackbarCallback } from '../../extension/options-page/DashboardDialogs/Base'
 import { MaskbookWalletMessages, WalletMessageCenter } from '../../plugins/Wallet/messages'
 import { useI18N } from '../../utils/i18n-next-ui'
 import { useRemoteControlledDialog } from '../../utils/hooks/useRemoteControlledDialog'
+import { useBlockie } from '../hooks/useBlockie'
 
 const useStyles = makeStyles((theme: Theme) => {
     return createStyles({
@@ -69,9 +70,7 @@ export function EthereumAccountChip(props: EthereumAccountChipProps) {
 
     const wallets = useWallets()
     const currentWallet = wallets.find((x) => isSameAddress(x.address, address))
-    const avatar = (
-        <ProviderIcon classes={{ icon: classes.providerIcon }} size={18} providerType={currentWallet?.provider} />
-    )
+    const currentWalletBlockie = useBlockie(currentWallet?.address ?? '')
     const address_ = address.replace(/^0x/i, '')
 
     //#region copy addr to clipboard
@@ -120,9 +119,9 @@ export function EthereumAccountChip(props: EthereumAccountChipProps) {
 
     return (
         <>
-            {avatar ? (
+            {currentWalletBlockie ? (
                 <Chip
-                    avatar={avatar}
+                    avatar={<Avatar src={currentWalletBlockie} />}
                     className={classes.root}
                     classes={{ label: classes.label }}
                     size="small"

--- a/packages/maskbook/src/web3/UI/EthereumAccountChip.tsx
+++ b/packages/maskbook/src/web3/UI/EthereumAccountChip.tsx
@@ -9,19 +9,18 @@ import {
     Typography,
     Box,
     Divider,
-    Avatar,
 } from '@material-ui/core'
 import { ChevronDown, Copy } from 'react-feather'
 import { useCopyToClipboard } from 'react-use'
 import { useStylesExtends } from '../../components/custom-ui-helper'
 import { useWallets } from '../../plugins/Wallet/hooks/useWallet'
 import { isSameAddress } from '../helpers'
+import { ProviderIcon } from '../../components/shared/ProviderIcon'
 import { formatEthereumAddress } from '../../plugins/Wallet/formatter'
 import { useSnackbarCallback } from '../../extension/options-page/DashboardDialogs/Base'
 import { MaskbookWalletMessages, WalletMessageCenter } from '../../plugins/Wallet/messages'
 import { useI18N } from '../../utils/i18n-next-ui'
 import { useRemoteControlledDialog } from '../../utils/hooks/useRemoteControlledDialog'
-import { useBlockie } from '../hooks/useBlockie'
 
 const useStyles = makeStyles((theme: Theme) => {
     return createStyles({
@@ -70,7 +69,9 @@ export function EthereumAccountChip(props: EthereumAccountChipProps) {
 
     const wallets = useWallets()
     const currentWallet = wallets.find((x) => isSameAddress(x.address, address))
-    const currentWalletBlockie = useBlockie(currentWallet?.address ?? '')
+    const avatar = (
+        <ProviderIcon classes={{ icon: classes.providerIcon }} size={18} providerType={currentWallet?.provider} />
+    )
     const address_ = address.replace(/^0x/i, '')
 
     //#region copy addr to clipboard
@@ -119,9 +120,9 @@ export function EthereumAccountChip(props: EthereumAccountChipProps) {
 
     return (
         <>
-            {currentWalletBlockie ? (
+            {avatar ? (
                 <Chip
-                    avatar={<Avatar src={currentWalletBlockie} />}
+                    avatar={avatar}
                     className={classes.root}
                     classes={{ label: classes.label }}
                     size="small"

--- a/packages/maskbook/src/web3/hooks/useBlockie.ts
+++ b/packages/maskbook/src/web3/hooks/useBlockie.ts
@@ -1,8 +1,10 @@
 import { create } from 'ethereum-blockies'
 import { useMemo } from 'react'
+import { EthereumAddress } from 'wallet.ts'
 
 export function useBlockie(address: string) {
     return useMemo(() => {
+        if (!EthereumAddress.isValid(address)) return ''
         try {
             return create({
                 seed: address,


### PR DESCRIPTION
+ [ ] <del>Alert user if the exotic wallet already existed as a managed wallet.</del>
+ [x] Remove `provider` from `WalletRecord` and track it by settings.
+ [x] Update the `<SelectWalletDialog />` component to support duplicate wallet address.
+ [ ] CRUD wallet

![select_wallet](https://user-images.githubusercontent.com/52657989/97688541-371dfb00-1ad5-11eb-8cd2-7e31e89a9fe7.png)