### PR TITLE
feat: add plugin stage and scope

### DIFF
--- a/packages/maskbook/src/plugins/FileService/define.tsx
+++ b/packages/maskbook/src/plugins/FileService/define.tsx
@@ -2,7 +2,7 @@ import { formatFileSize } from '@dimensiondev/kit'
 import { truncate } from 'lodash-es'
 import React from 'react'
 import { createTypedMessageMetadataReader } from '../../protocols/typed-message/metadata'
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import { identifier, META_KEY_1, pluginName } from './constants'
 import { Preview } from './Preview'
 import type { FileInfo } from './types'
@@ -30,6 +30,7 @@ const [FileServiceCompositionEntry, FileServiceCompositionUI] = createCompositio
 export const FileServicePluginDefine: PluginConfig = {
     pluginName,
     identifier,
+    stage: PluginStage.Production,
     successDecryptionInspector(props) {
         const metadata = FileInfoMetadataReader(props.message.meta)
         if (!metadata.ok) return null

--- a/packages/maskbook/src/plugins/FileService/define.tsx
+++ b/packages/maskbook/src/plugins/FileService/define.tsx
@@ -2,7 +2,7 @@ import { formatFileSize } from '@dimensiondev/kit'
 import { truncate } from 'lodash-es'
 import React from 'react'
 import { createTypedMessageMetadataReader } from '../../protocols/typed-message/metadata'
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import { identifier, META_KEY_1, pluginName } from './constants'
 import { Preview } from './Preview'
 import type { FileInfo } from './types'
@@ -31,6 +31,7 @@ export const FileServicePluginDefine: PluginConfig = {
     pluginName,
     identifier,
     stage: PluginStage.Production,
+    scope: PluginScope.Public,
     successDecryptionInspector(props) {
         const metadata = FileInfoMetadataReader(props.message.meta)
         if (!metadata.ok) return null

--- a/packages/maskbook/src/plugins/Gitcoin/define.tsx
+++ b/packages/maskbook/src/plugins/Gitcoin/define.tsx
@@ -1,4 +1,4 @@
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import React, { Suspense, useMemo } from 'react'
 import { SnackbarContent } from '@material-ui/core'
 import { parseURL } from '../../utils/utils'
@@ -13,6 +13,7 @@ export const GitcoinPluginDefine: PluginConfig = {
     pluginName: 'Gitcoin',
     identifier: 'co.gitcoin',
     stage: PluginStage.Production,
+    scope: PluginScope.Public,
     successDecryptionInspector: function Component(props): JSX.Element | null {
         const text = useMemo(() => extractTextFromTypedMessage(props.message), [props.message])
         const link = useMemo(() => parseURL(text.val || ''), [text.val]).find(isGitcoin)

--- a/packages/maskbook/src/plugins/Gitcoin/define.tsx
+++ b/packages/maskbook/src/plugins/Gitcoin/define.tsx
@@ -1,4 +1,4 @@
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import React, { Suspense, useMemo } from 'react'
 import { SnackbarContent } from '@material-ui/core'
 import { parseURL } from '../../utils/utils'
@@ -12,6 +12,7 @@ const isGitcoin = (x: string): boolean => x.startsWith('https://gitcoin.co/grant
 export const GitcoinPluginDefine: PluginConfig = {
     pluginName: 'Gitcoin',
     identifier: 'co.gitcoin',
+    stage: PluginStage.Production,
     successDecryptionInspector: function Component(props): JSX.Element | null {
         const text = useMemo(() => extractTextFromTypedMessage(props.message), [props.message])
         const link = useMemo(() => parseURL(text.val || ''), [text.val]).find(isGitcoin)

--- a/packages/maskbook/src/plugins/Polls/define.tsx
+++ b/packages/maskbook/src/plugins/Polls/define.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import type { PollMetaData } from './types'
 import { PollMetadataReader } from './utils'
 import PollsInPost from './UI/PollsInPost'
@@ -19,6 +19,7 @@ const [PollCompositionEntry, PollCompositionUI] = createCompositionDialog('ðŸ—³ï
 export const PollsPluginDefine: PluginConfig = {
     pluginName,
     identifier,
+    stage: PluginStage.Beta,
     successDecryptionInspector: function Comp(props) {
         const metadata = PollMetadataReader(props.message.meta)
         if (!metadata.ok) return null

--- a/packages/maskbook/src/plugins/Polls/define.tsx
+++ b/packages/maskbook/src/plugins/Polls/define.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import type { PollMetaData } from './types'
 import { PollMetadataReader } from './utils'
 import PollsInPost from './UI/PollsInPost'
@@ -20,6 +20,7 @@ export const PollsPluginDefine: PluginConfig = {
     pluginName,
     identifier,
     stage: PluginStage.Beta,
+    scope: PluginScope.Internal,
     successDecryptionInspector: function Comp(props) {
         const metadata = PollMetadataReader(props.message.meta)
         if (!metadata.ok) return null

--- a/packages/maskbook/src/plugins/RedPacket/define.tsx
+++ b/packages/maskbook/src/plugins/RedPacket/define.tsx
@@ -1,4 +1,4 @@
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import { RedPacketInspector } from './UI/RedPacketInspector'
 import React from 'react'
 import { formatBalance } from '../Wallet/formatter'
@@ -33,6 +33,7 @@ const [RedPacketCompositionEntry, RedPacketCompositionUI] = createCompositionDia
 export const RedPacketPluginDefine: PluginConfig = {
     pluginName: 'Red Packet',
     identifier: RedPacketPluginID,
+    stage: PluginStage.Production,
     successDecryptionInspector: function Comp(props) {
         if (!RedPacketMetadataReader(props.message.meta).ok) return null
         return <RedPacketInspector {...props} />

--- a/packages/maskbook/src/plugins/RedPacket/define.tsx
+++ b/packages/maskbook/src/plugins/RedPacket/define.tsx
@@ -1,4 +1,4 @@
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import { RedPacketInspector } from './UI/RedPacketInspector'
 import React from 'react'
 import { formatBalance } from '../Wallet/formatter'
@@ -34,6 +34,7 @@ export const RedPacketPluginDefine: PluginConfig = {
     pluginName: 'Red Packet',
     identifier: RedPacketPluginID,
     stage: PluginStage.Production,
+    scope: PluginScope.Public,
     successDecryptionInspector: function Comp(props) {
         if (!RedPacketMetadataReader(props.message.meta).ok) return null
         return <RedPacketInspector {...props} />

--- a/packages/maskbook/src/plugins/Storybook/define.tsx
+++ b/packages/maskbook/src/plugins/Storybook/define.tsx
@@ -1,4 +1,4 @@
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import { registerTypedMessageRenderer, TypedMessage } from '../../protocols/typed-message'
 import type { TypedMessageRendererProps } from '../../components/InjectedComponents/TypedMessageRenderer'
 import React from 'react'
@@ -6,7 +6,8 @@ import React from 'react'
 export const StorybookPluginDefine: PluginConfig = {
     pluginName: 'Storybook test',
     identifier: 'storybook.debug',
-    stage: PluginStage.Internal,
+    stage: PluginStage.Development,
+    scope: PluginScope.Internal,
     postDialogMetadataBadge: new Map([['test', (payload) => 'a lovely test badge']]),
 }
 if (process.env.STORYBOOK) {

--- a/packages/maskbook/src/plugins/Storybook/define.tsx
+++ b/packages/maskbook/src/plugins/Storybook/define.tsx
@@ -1,4 +1,4 @@
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import { registerTypedMessageRenderer, TypedMessage } from '../../protocols/typed-message'
 import type { TypedMessageRendererProps } from '../../components/InjectedComponents/TypedMessageRenderer'
 import React from 'react'
@@ -6,6 +6,7 @@ import React from 'react'
 export const StorybookPluginDefine: PluginConfig = {
     pluginName: 'Storybook test',
     identifier: 'storybook.debug',
+    stage: PluginStage.Internal,
     postDialogMetadataBadge: new Map([['test', (payload) => 'a lovely test badge']]),
 }
 if (process.env.STORYBOOK) {

--- a/packages/maskbook/src/plugins/Trader/define.tsx
+++ b/packages/maskbook/src/plugins/Trader/define.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import {
     TypedMessage,
     isTypedMessageAnchor,
@@ -15,6 +15,7 @@ const isCashTagMessage = (m: TypedMessage): m is TypedMessageAnchor => isTypedMe
 export const TraderPluginDefine: PluginConfig = {
     pluginName: 'Trader',
     identifier: PLUGIN_IDENTIFIER,
+    stage: PluginStage.Production,
     messageProcessor(message: TypedMessageCompound) {
         return {
             ...message,

--- a/packages/maskbook/src/plugins/Trader/define.tsx
+++ b/packages/maskbook/src/plugins/Trader/define.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import {
     TypedMessage,
     isTypedMessageAnchor,
@@ -16,6 +16,7 @@ export const TraderPluginDefine: PluginConfig = {
     pluginName: 'Trader',
     identifier: PLUGIN_IDENTIFIER,
     stage: PluginStage.Production,
+    scope: PluginScope.Public,
     messageProcessor(message: TypedMessageCompound) {
         return {
             ...message,

--- a/packages/maskbook/src/plugins/Transak/define.tsx
+++ b/packages/maskbook/src/plugins/Transak/define.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import { PLUGIN_IDENTIFIER } from './constants'
 import { BuyTokenDialog } from './UI/BuyTokenDialog'
 
@@ -7,6 +7,7 @@ export const TransakPluginDefine: PluginConfig = {
     pluginName: 'Transak',
     identifier: PLUGIN_IDENTIFIER,
     stage: PluginStage.Production,
+    scope: PluginScope.Public,
     PageComponent() {
         return (
             <>

--- a/packages/maskbook/src/plugins/Transak/define.tsx
+++ b/packages/maskbook/src/plugins/Transak/define.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
-import { ThemeProvider } from '@material-ui/core'
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import { PLUGIN_IDENTIFIER } from './constants'
 import { BuyTokenDialog } from './UI/BuyTokenDialog'
-import { useMaskbookTheme } from '../../utils/theme'
 
 export const TransakPluginDefine: PluginConfig = {
     pluginName: 'Transak',
     identifier: PLUGIN_IDENTIFIER,
+    stage: PluginStage.Production,
     PageComponent() {
         return (
             <>

--- a/packages/maskbook/src/plugins/Wallet/define.tsx
+++ b/packages/maskbook/src/plugins/Wallet/define.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { PluginStage, PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig, PluginScope } from '../plugin'
 import { PLUGIN_IDENTIFIER } from './constants'
 import { SelectProviderDialog } from './UI/SelectProviderDialog'
 import { SelectWalletDialog } from './UI/SelectWalletDialog'
@@ -9,6 +9,7 @@ export const WalletPluginDefine: PluginConfig = {
     pluginName: 'Wallet',
     identifier: PLUGIN_IDENTIFIER,
     stage: PluginStage.Production,
+    scope: PluginScope.Public,
     PageComponent() {
         return (
             <>

--- a/packages/maskbook/src/plugins/Wallet/define.tsx
+++ b/packages/maskbook/src/plugins/Wallet/define.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import type { PluginConfig } from '../plugin'
+import { PluginStage, PluginConfig } from '../plugin'
 import { PLUGIN_IDENTIFIER } from './constants'
 import { SelectProviderDialog } from './UI/SelectProviderDialog'
 import { SelectWalletDialog } from './UI/SelectWalletDialog'
@@ -8,6 +8,7 @@ import { WalletConnectQRCodeDialog } from './UI/WalletConnectQRCodeDialog'
 export const WalletPluginDefine: PluginConfig = {
     pluginName: 'Wallet',
     identifier: PLUGIN_IDENTIFIER,
+    stage: PluginStage.Production,
     PageComponent() {
         return (
             <>

--- a/packages/maskbook/src/plugins/plugin.ts
+++ b/packages/maskbook/src/plugins/plugin.ts
@@ -8,9 +8,17 @@ type PluginInjectFunction<T> =
       }
     | React.ComponentType<T>
 
+export const enum PluginStage {
+    Development,
+    Internal,
+    Beta,
+    Production,
+}
+
 export interface PluginConfig {
     pluginName: string
     identifier: string
+    stage: PluginStage
     successDecryptionInspector?: PluginInjectFunction<{ message: TypedMessage }>
     postInspector?: PluginInjectFunction<{}>
     PageComponent?: React.ComponentType<{}>

--- a/packages/maskbook/src/plugins/plugin.ts
+++ b/packages/maskbook/src/plugins/plugin.ts
@@ -8,9 +8,13 @@ type PluginInjectFunction<T> =
       }
     | React.ComponentType<T>
 
+export const enum PluginScope {
+    Internal,
+    Public,
+}
+
 export const enum PluginStage {
     Development,
-    Internal,
     Beta,
     Production,
 }
@@ -19,6 +23,7 @@ export interface PluginConfig {
     pluginName: string
     identifier: string
     stage: PluginStage
+    scope: PluginScope
     successDecryptionInspector?: PluginInjectFunction<{ message: TypedMessage }>
     postInspector?: PluginInjectFunction<{}>
     PageComponent?: React.ComponentType<{}>


### PR DESCRIPTION
> Maybe use a "beta: true" when registering plugin

one idea, add a `PluginStage` enum.

```ts
stage: PluginStage.Development // e.q: us election 2020 
stage: PluginStage.Internal // e.q: metadata inspector
stage: PluginStage.Beta // e.q: poll
stage: PluginStage.Production // e.q: red packet and file service
```

_Originally posted by @septs in https://github.com/DimensionDev/Maskbook/issues/1810#issuecomment-720209879_