### PR TITLE
feat: backport webpack 5 asset modules and worker support to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "eslint-plugin-unused-imports": "^1.0.0",
     "esm": "^3.2.25",
     "fake-indexeddb": "^3.1.2",
+    "file-loader": "^6.2.0",
     "fork-ts-checker-notifier-webpack-plugin": "^3.0.0",
     "fork-ts-checker-webpack-plugin": "^5.2.1",
     "html-webpack-plugin": "^4.5.0",
@@ -230,7 +231,8 @@
     "webpack-dev-server": "^3.11.0",
     "webpack-extension-manifest-plugin": "^0.5.0",
     "webpack-notifier": "^1.8.0",
-    "webpack-target-webextension": "^0.2.1"
+    "webpack-target-webextension": "^0.2.1",
+    "worker-plugin": "^5.0.0"
   },
   "optionalDependencies": {
     "expect-puppeteer": "^4.4.0",

--- a/scripts/webpack-5-asset-module-backport.ts
+++ b/scripts/webpack-5-asset-module-backport.ts
@@ -1,0 +1,93 @@
+// This is a backward port of Webpack 5 AssetModules and native worker to Webpack 4
+// https://webpack.js.org/guides/asset-modules/#root
+// https://webpack.js.org/blog/2020-10-10-webpack-5-release/#asset-modules
+// https://webpack.js.org/blog/2020-10-10-webpack-5-release/#native-worker-support
+
+// This is not a full-implement.
+// If you need any AssetModules feature that not supported yet, please contact @Jack-Works
+
+// Support for AssetModules
+// ✔️ `new URL("./file.png", import.meta.url)` as asset module
+// ✔️ Type: asset/resource (always)
+// ❌ Type: asset/inline (not supported)
+// ❌ Type: asset/source (not support)
+// ❌ Loaders for asset modules
+// ❌ assetModuleFilename
+
+// Support for native Workers
+// ✔️ `new *Worker(new URL("./file", import.meta.url))` as worker
+// ✔️ `new *Worklet(new URL("./file", import.meta.url))` as worker
+// ❌ Service Worker (it will be treaded as asset module, not a worker)
+
+// After upgraded to webpack 5, remove this file, worker-plugin and file-loader.
+import {
+    SourceFile,
+    TransformerFactory,
+    VisitResult,
+    Node,
+    isNewExpression,
+    isIdentifier,
+    isPropertyAccessExpression,
+    isMetaProperty,
+    SyntaxKind,
+    PropertyAccessExpression,
+    visitEachChild,
+    Expression,
+    NodeFactory,
+    isStringLiteralLike,
+} from 'typescript'
+
+export default (options: { isWorker?: (name: string) => boolean } = {}): TransformerFactory<SourceFile> => {
+    const isWorkerConstructor = options?.isWorker || ((name) => name.endsWith('Worker') || name.endsWith('Worklet'))
+    return (context) => (file) => {
+        return visit(file) as SourceFile
+        function visit(node: Node): VisitResult<Node> {
+            const assetPath = getAssetModule(node)
+            if (assetPath) {
+                if (isWorkerAsset(node)) {
+                    return createRequire(context.factory, assetPath, '!worker-plugin/loader!')
+                } else {
+                    return createRequire(context.factory, assetPath, '!file-loader!')
+                }
+            }
+            return visitEachChild(node, visit, context)
+        }
+    }
+    function isWorkerAsset(node: Node) {
+        const { parent } = node
+        if (!isNewExpression(parent)) return false
+        const { expression } = parent
+        if (!isIdentifier(expression)) return false
+        return isWorkerConstructor(expression.text)
+    }
+}
+// create require("loaderExpr") or require(`loader${Expr}`) based on what expr is.
+function createRequire(ts: NodeFactory, expr: Expression, loader: string) {
+    const args: Expression[] = []
+    if (isStringLiteralLike(expr)) args.push(ts.createStringLiteral(loader + expr.text))
+    else
+        args.push(
+            ts.createTemplateExpression(ts.createTemplateHead(loader, loader), [
+                ts.createTemplateSpan(expr, ts.createTemplateTail('', '')),
+            ]),
+        )
+    return ts.createCallExpression(ts.createIdentifier('require'), void 0, args)
+}
+// node is new URL(?, import.meta.url)
+function getAssetModule(node: Node): false | Expression {
+    if (!isNewExpression(node)) return false
+    const { expression, arguments: [arg0, arg1] = [] } = node
+    if (!isIdentifier(expression) || expression.text !== 'URL') return false
+    if (!isImportMetaURL(arg1)) return false
+    return arg0
+}
+function isImportMetaURL(node: Node): node is PropertyAccessExpression {
+    if (!isPropertyAccessExpression(node)) return false
+    if (node.name.text !== 'url') return false
+    node = node.expression
+    if (!isMetaProperty(node)) return false
+    const { keywordToken, name } = node
+    if (keywordToken !== SyntaxKind.ImportKeyword) return false
+    if (name.text !== 'meta') return false
+    return true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9996,6 +9996,14 @@ file-loader@^4.2.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
+file-loader@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
+  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 file-system-cache@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/file-system-cache/-/file-system-cache-1.0.5.tgz#84259b36a2bbb8d3d6eb1021d3132ffe64cfff4f"
@@ -21676,6 +21684,13 @@ worker-loader@^2.0.0:
   dependencies:
     loader-utils "^1.0.0"
     schema-utils "^0.4.0"
+
+worker-plugin@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/worker-plugin/-/worker-plugin-5.0.0.tgz#113b5fe1f4a5d6a957cecd29915bedafd70bb537"
+  integrity sha512-AXMUstURCxDD6yGam2r4E34aJg6kW85IiaeX72hi+I1cxyaMUtrvVY6sbfpGKAj5e7f68Acl62BjQF5aOOx2IQ==
+  dependencies:
+    loader-utils "^1.1.0"
 
 worker-rpc@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
# Backward port of Webpack 5 AssetModules and native worker to Webpack 4

After upgraded to webpack 5, remove this file, worker-plugin and file-loader.

- <https://webpack.js.org/guides/asset-modules/#root>
- <https://webpack.js.org/blog/2020-10-10-webpack-5-release/#asset-modules>
- <https://webpack.js.org/blog/2020-10-10-webpack-5-release/#native-worker-support>

This is not a full-implement. If you need any AssetModules feature that not supported yet, please contact @Jack-Works

## Support for AssetModules

- ✔️ `new URL("./file.png", import.meta.url)` as asset module
- ✔️ Type: asset/resource (always)
- ❌ Type: asset/inline (not supported)
- ❌ Type: asset/source (not support)
- ❌ Loaders for asset modules
- ❌ assetModuleFilename

## Support for native Workers

- ✔️ `new *Worker(new URL("./file", import.meta.url))` as worker
- ✔️ `new *Worklet(new URL("./file", import.meta.url))` as worker
- ❌ Service Worker (it will be treaded as asset module, not a worker)
