### PR TITLE
fix: facebook support

### DIFF
--- a/packages/maskbook/src/components/InjectedComponents/AutoPasteFailedDialog.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/AutoPasteFailedDialog.tsx
@@ -113,25 +113,26 @@ export function AutoPasteFailedDialog(props: AutoPasteFailedDialogProps) {
                                 {t('copy_image')}
                             </Button>
                         ) : null}
-                        {url && permission !== 'granted' ? (
-                            <>
-                                <Button
-                                    variant="text"
-                                    component={Link}
-                                    download={`maskbook-encrypted-${formatDateTime(new Date()).replace(/:/g, '-')}.png`}
-                                    href={url}
-                                    startIcon={<Download />}>
-                                    {t('download')}
-                                </Button>
-                                <Button
-                                    variant="text"
-                                    component={Link}
-                                    href={url}
-                                    target="_blank"
-                                    startIcon={<OpenInBrowser />}>
-                                    {t('auto_paste_failed_dialog_image_caption')}
-                                </Button>
-                            </>
+                        {url ? (
+                            <Button
+                                variant="text"
+                                component={Link}
+                                download={`maskbook-encrypted-${formatDateTime(new Date()).replace(/:/g, '-')}.png`}
+                                href={url}
+                                startIcon={<Download />}>
+                                {t('download')}
+                            </Button>
+                        ) : null}
+                        {/* Open it in a new tab does not make sense for app. */}
+                        {url && process.env.architecture === 'web' ? (
+                            <Button
+                                variant="text"
+                                component={Link}
+                                href={url}
+                                target="_blank"
+                                startIcon={<OpenInBrowser />}>
+                                {t('auto_paste_failed_dialog_image_caption')}
+                            </Button>
                         ) : null}
                     </div>
                 </DialogContent>

--- a/packages/maskbook/src/components/InjectedComponents/CommentBox.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/CommentBox.tsx
@@ -42,7 +42,6 @@ export function CommentBox(props: CommentBoxProps) {
             placeholder={t('comment_box__placeholder')}
             onKeyDownCapture={(e) => {
                 const node = e.target as HTMLInputElement
-                console.log(e.currentTarget)
                 if (!node.value) return
                 if (e.key === 'Enter') {
                     props.onSubmit(node.value)

--- a/packages/maskbook/src/social-network-provider/facebook.com/UI/collectPosts.tsx
+++ b/packages/maskbook/src/social-network-provider/facebook.com/UI/collectPosts.tsx
@@ -14,7 +14,7 @@ import { Flags } from '../../../utils/flags'
 import { clickSeeMore } from './injectPostInspector'
 
 const posts = new LiveSelector().querySelectorAll<HTMLDivElement>(
-    isMobileFacebook ? '.story_body_container ' : '[role=article] [data-ad-preview="message"]',
+    isMobileFacebook ? '.story_body_container > div' : '[role=article] [data-ad-preview="message"]',
 )
 
 export function collectPostsFacebook(this: SocialNetworkUI) {

--- a/packages/maskbook/src/utils/hooks/useQueryNavigatorPermission.ts
+++ b/packages/maskbook/src/utils/hooks/useQueryNavigatorPermission.ts
@@ -20,6 +20,7 @@ export function useQueryNavigatorPermission(needRequest: boolean, name: Permissi
     const [permission, updatePermission] = useState<PermissionState>('prompt')
 
     useEffect(() => {
+        // TODO: Only camera related APi need to check Flags.has_no_WebRTC
         if (!needRequest || permission !== 'prompt' || Flags.has_no_WebRTC) return
         let permissionStatus: PermissionStatus
 
@@ -53,6 +54,6 @@ export function useQueryNavigatorPermission(needRequest: boolean, name: Permissi
         return () => {
             if (permissionStatus) permissionStatus.onchange = null
         }
-    }, [needRequest, permission])
+    }, [name, needRequest, permission])
     return permission
 }


### PR DESCRIPTION
I have no idea if it really fixed. But at least on my machine, it works as the following table describes.

Picture decryption failure is not caused by DOM change so cc @guanbinrui (#1813 and #976)

cc @Tedko.

maybe close #1813

fix for #1909 already pushed to the master branch (display a download button and requiring the user to upload by themself.)

## PC

-   [x] Encrypt text
-   [x] Decrypt text
-   [x] Encrypt pic
-   [x] Decrypt pic
-   [x] Encrypt comment
-   [x] Decrypt comment

## Mobile

-   [x] Encrypt text
-   [x] Decrypt text
-   [x] Encrypt pic
-   [ ] Decrypt pic
-   [x] Encrypt comment
-   [x] Decrypt comment
