### PR TITLE
fix: The "Find your username" dialog in mobile apps need re-designed

### DIFF
--- a/packages/maskbook/src/background-service.ts
+++ b/packages/maskbook/src/background-service.ts
@@ -21,7 +21,6 @@ import * as type from './database/type'
 import * as post from './database/post'
 import { definedSocialNetworkWorkers } from './social-network/worker'
 import { getWelcomePageURL } from './extension/options-page/Welcome/getWelcomePageURL'
-import { exclusiveTasks } from './extension/content-script/tasks'
 import { Flags } from './utils/flags'
 
 import('./plugins/PluginSerivce')
@@ -92,13 +91,6 @@ if (isEnvironment(Environment.ManifestBackground)) {
         if (Flags.has_native_welcome_ui) return
         if (detail.reason === 'install') {
             browser.tabs.create({ url: getWelcomePageURL() })
-        }
-    })
-
-    contentScriptReady.then(() => {
-        // TODO: support twitter
-        if (Flags.has_no_browser_tab_ui) {
-            exclusiveTasks(getWelcomePageURL(), { important: true })
         }
     })
 }

--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -40,21 +40,10 @@ export enum SetupGuideStep {
 }
 
 //#region wizard dialog
-const useTextFieldMobileStyle = makeStyles((theme) => ({
-    root: {
-        '& .MuiOutlinedInput-root': {
-            'border-radius': 0,
-        },
-    },
-}))
-
 const wizardTheme = (theme: Theme): Theme =>
     merge(cloneDeep(theme), {
         overrides: {
             MuiOutlinedInput: {
-                //root: {
-                //    borderRadius:  0,
-                //},
                 input: {
                     paddingTop: 14.5,
                     paddingBottom: 14.5,
@@ -156,6 +145,11 @@ const useWizardDialogStyles = makeStyles((theme) =>
         },
         sandbox: {
             marginTop: 16,
+        },
+        tip: {
+            fontSize: 16,
+            lineHeight: 1.75,
+            marginBottom: 24,
         },
         button: {
             fontSize: 16,
@@ -361,7 +355,6 @@ function FindUsername({ username, onConnect, onDone, onClose, onUsernameChange =
     const isMobile = useMatchXS()
     const classes = useWizardDialogStyles()
     const findUsernameClasses = useFindUsernameStyles()
-    const textFieldClasses = useTextFieldMobileStyle()
     const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
         e.stopPropagation()
         if (e.key !== 'Enter') return
@@ -386,7 +379,6 @@ function FindUsername({ username, onConnect, onDone, onClose, onUsernameChange =
                 <form>
                     <Box className={findUsernameClasses.input} display="flex" alignItems="center">
                         <TextField
-                            className={textFieldClasses.root}
                             variant="outlined"
                             label={t('username')}
                             value={username}
@@ -394,6 +386,9 @@ function FindUsername({ username, onConnect, onDone, onClose, onUsernameChange =
                             InputProps={{
                                 classes: {
                                     focused: findUsernameClasses.inputFocus,
+                                    root: {
+                                        borderRadius: '24px !important',
+                                    },
                                 },
                                 startAdornment: (
                                     <InputAdornment position="start">
@@ -474,7 +469,6 @@ function SayHelloWorld({ createStatus, onCreate, onSkip, onBack, onClose }: SayH
             status={createStatus}
             optional
             title={t('setup_guide_say_hello_title')}
-            content={}
             tip={
                 <form>
                     <Typography className={classNames(classes.tip, sayHelloWorldClasses.primary)} variant="body2">

--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -157,6 +157,11 @@ const useWizardDialogStyles = makeStyles((theme) =>
         sandbox: {
             marginTop: 16,
         },
+        tip: {
+            fontSize: 16,
+            lineHeight: 1.75,
+            marginBottom: 24,
+        },
         button: {
             fontSize: 16,
             width: 200,

--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -386,9 +386,6 @@ function FindUsername({ username, onConnect, onDone, onClose, onUsernameChange =
                             InputProps={{
                                 classes: {
                                     focused: findUsernameClasses.inputFocus,
-                                    root: {
-                                        borderRadius: '24px !important',
-                                    },
                                 },
                                 startAdornment: (
                                     <InputAdornment position="start">

--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -40,14 +40,6 @@ export enum SetupGuideStep {
 }
 
 //#region wizard dialog
-const useTextFieldMobileStyle = makeStyles((theme) => ({
-    root: {
-        '& .MuiOutlinedInput-root': {
-            'border-radius': 0,
-        },
-    },
-}))
-
 const wizardTheme = (theme: Theme): Theme =>
     merge(cloneDeep(theme), {
         overrides: {
@@ -366,7 +358,6 @@ function FindUsername({ username, onConnect, onDone, onClose, onUsernameChange =
     const isMobile = useMatchXS()
     const classes = useWizardDialogStyles()
     const findUsernameClasses = useFindUsernameStyles()
-    const textFieldClasses = useTextFieldMobileStyle()
     const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
         e.stopPropagation()
         if (e.key !== 'Enter') return
@@ -391,7 +382,6 @@ function FindUsername({ username, onConnect, onDone, onClose, onUsernameChange =
                 <form>
                     <Box className={findUsernameClasses.input} display="flex" alignItems="center">
                         <TextField
-                            className={textFieldClasses.root}
                             variant="outlined"
                             label={t('username')}
                             value={username}

--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -299,6 +299,7 @@ function FindUsername({ username, onConnect, onDone, onClose, onUsernameChange =
                             variant="outlined"
                             label={t('username')}
                             value={username}
+                            disabled={!username}
                             InputProps={{
                                 classes: {
                                     focused: findUsernameClasses.inputFocus,

--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -44,9 +44,6 @@ const wizardTheme = (theme: Theme): Theme =>
     merge(cloneDeep(theme), {
         overrides: {
             MuiOutlinedInput: {
-                //root: {
-                //    borderRadius:  0,
-                //},
                 input: {
                     paddingTop: 14.5,
                     paddingBottom: 14.5,

--- a/packages/maskbook/src/social-network-provider/twitter.com/ui/custom.ts
+++ b/packages/maskbook/src/social-network-provider/twitter.com/ui/custom.ts
@@ -12,6 +12,8 @@ import produce, { setAutoFreeze } from 'immer'
 import type { InjectedDialogClassKey } from '../../../components/shared/InjectedDialog'
 import type { StyleRules } from '@material-ui/core'
 
+import { isMobileTwitter } from '../utils/isMobile'
+
 const primaryColorRef = new ValueRef(toRGB([29, 161, 242]))
 const primaryColorContrastColorRef = new ValueRef(toRGB([255, 255, 255]))
 const backgroundColorRef = new ValueRef(toRGB([255, 255, 255]))
@@ -54,7 +56,7 @@ function useTheme() {
                 dark: toRGB(shade(primaryColorRGB, -10)),
                 contrastText: toRGB(primaryContrastColorRGB),
             }
-            theme.shape.borderRadius = 15
+            theme.shape.borderRadius = isMobileTwitter ? 0 : 15
             theme.breakpoints.values = { xs: 0, sm: 687, md: 1024, lg: 1280, xl: 1920 }
             theme.overrides = theme.overrides || {}
             theme.overrides!.MuiButton = {


### PR DESCRIPTION
On mobile apps, re-locate the "Find your username" dialog to the bottom of the webView to avoid blocking the sign in related elements of Twitter/FB UI