### PR TITLE
fix: emotion throw window not found in ssr

### DIFF
--- a/scripts/SSRWorker.js
+++ b/scripts/SSRWorker.js
@@ -24,12 +24,13 @@ async function SSR(path) {
 }
 module.exports.SSR = SSR
 async function worker(path) {
-    require('ts-node').register({ project: require.resolve('../tsconfig.json'), transpileOnly: true })
     Object.assign(globalThis, mockedGlobalThis())
 
     require = require('esm')(module)
+    require('ts-node').register({ project: require.resolve('../tsconfig.json'), transpileOnly: true })
 
     globalThis.window = globalThis
+    require('@emotion/react')
     require('../packages/maskbook/src/polyfill/index')
     delete globalThis.window
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -315,7 +315,8 @@ export default function (cli_env: Record<string, boolean> = {}, argv: any) {
     function getSSRPlugin() {
         if (env === 'development') return []
         return [
-            new SSRPlugin('popup.html', src('./packages/maskbook/src/extension/popup-page/index.tsx'), 'Mask Network'),
+            // TODO: Help wanted
+            // new SSRPlugin('popup.html', src('./packages/maskbook/src/extension/popup-page/index.tsx'), 'Mask Network'),
         ]
     }
 }


### PR DESCRIPTION
Actually, I didn't fix it.

```
/home/jack/workspace/maskbook/node_modules/ts-node/src/index.ts:1
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/jack/workspace/maskbook/node_modules/@babel/runtime/helpers/esm/extends.js
    at new NodeError (node:internal/errors:278:15)
    at Module._extensions..js (node:internal/modules/cjs/loader:1119:13)
    at Object.require.extensions.<computed> [as .js] (/home/jack/workspace/maskbook/node_modules/ts-node/src/index.ts:1032:44) {
  code: 'ERR_REQUIRE_ESM'
}
```

Help wanted cc @septs @zhouhanseng @guanbinrui .

You can run SSR without webpack by

```shell
node scripts/SSRWorker.js packages/maskbook/src/extension/popup-page/index.tsx
```