### PR TITLE
Upgrade to nodejs to 15.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 executors:
   maskbook_node:
     docker:
-      - image: circleci/node:14.4.0
+      - image: circleci/node:15.3.0
     working_directory: ~/repo
 commands:
   restore_workspace:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: self-hosted
 
     container:
-      image: differui/node-14.4.0-browsers:v1
+      image: differui/node-15.3.0-browsers:v1
 
       # more: https://github.community/t5/GitHub-Actions/How-to-run-action-as-a-non-root-user/m-p/45733/highlight/true#M6330
       options: '--user 1000


### PR DESCRIPTION
We must use NPM v7 in the future (#2007) and [it will be shipping with NodeJS 15.3.0](https://blog.npmjs.org/post/631877012766785536/release-v700). So upgrade to NodeJS 15.3.0 is a good choice.