### PR TITLE
fix: workaround for Chunk Load failed

### DIFF
--- a/packages/maskbook/src/components/QRScanner/ShapeDetectionPolyfill.ts
+++ b/packages/maskbook/src/components/QRScanner/ShapeDetectionPolyfill.ts
@@ -5,7 +5,6 @@ import { OnDemandWorker } from '../../web-workers/OnDemandWorker'
 
 let worker: OnDemandWorker
 sideEffect.then(() => {
-    __webpack_public_path__ = browser.runtime.getURL('/')
     worker = new OnDemandWorker(new URL('../../web-workers/QRCode.ts', import.meta.url), { name: 'ShapeDetection' })
 })
 

--- a/packages/maskbook/src/network/gun/index.ts
+++ b/packages/maskbook/src/network/gun/index.ts
@@ -5,7 +5,6 @@ import { OnDemandWorker } from '../../web-workers/OnDemandWorker'
 
 export let GunWorker: OnDemandWorker | undefined
 if (process.env.architecture) {
-    __webpack_public_path__ = browser.runtime.getURL('/')
     GunWorker = new OnDemandWorker(new URL('./worker.ts', import.meta.url), { name: 'Gun' })
     // we're in webpack bundle
 }

--- a/packages/maskbook/src/plugins/Polls/utils.ts
+++ b/packages/maskbook/src/plugins/Polls/utils.ts
@@ -14,7 +14,6 @@ const PollMessage = createPluginMessage<{ _: unknown }>(identifier)
 export const PluginPollRPC = createPluginRPC(
     identifier,
     () => {
-        __webpack_public_path__ = browser.runtime.getURL('/')
         const PollWorker = new OnDemandWorker(new URL('./Services.ts', import.meta.url), { name: 'Plugin/Poll' })
         return AsyncCall<typeof import('./Services')>({}, { channel: new WorkerChannel(PollWorker) })
     },

--- a/public/patches.js
+++ b/public/patches.js
@@ -1,6 +1,21 @@
 // Fix regenerator runtime
 globalThis.regeneratorRuntime = undefined
 
+{
+    // Workaround for https://github.com/crimx/webpack-target-webextension/issues/9
+    const orig = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src')
+    Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+        ...orig,
+        set(src) {
+            try {
+                const root = (typeof browser === 'object' ? browser : chrome).runtime.getURL('/')
+                if (src.startsWith(root)) src = src.slice(root.length)
+            } catch {}
+            return orig.set.call(this, src)
+        },
+    })
+}
+
 // Fix for globalThis !== window in content script in Firefox
 {
     const fix = () => {


### PR DESCRIPTION
cc @septs with this PR you don't need

```js
    __webpack_public_path__ = browser.runtime.getURL('/')
```

anymore