### PR TITLE
feat!: upgrade version of file service metadata

### DIFF
--- a/packages/maskbook/src/plugins/FileService/Preview.tsx
+++ b/packages/maskbook/src/plugins/FileService/Preview.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }))
 
-export const Preview: React.FC<Props> = ({ info }) => {
+export function Preview({ info }: { info: FileInfo }) {
     const { t } = useI18N()
     const classes = useStyles()
     const fileKey = info.key ? (

--- a/packages/maskbook/src/plugins/FileService/components/Uploading.tsx
+++ b/packages/maskbook/src/plugins/FileService/components/Uploading.tsx
@@ -80,7 +80,8 @@ export const Uploading: React.FC = () => {
             300000, // ≈ 5 minutes
         )
         const item: FileInfo = {
-            type: 'arweave',
+            type: 'file',
+            provider: 'arweave',
             id: state.checksum,
 
             name: state.name,

--- a/packages/maskbook/src/plugins/FileService/constants.ts
+++ b/packages/maskbook/src/plugins/FileService/constants.ts
@@ -2,6 +2,7 @@ export const pluginName = 'File Service'
 export const identifier = 'com.maskbook.fileservice'
 export const pluginId = 'maskbook.fileservice'
 export const META_KEY_1 = 'com.maskbook.fileservice:1'
+export const META_KEY_2 = 'com.maskbook.fileservice:2'
 
 export const MAX_FILE_SIZE = 0xa00000 // = 10 MiB
 

--- a/packages/maskbook/src/plugins/FileService/database.ts
+++ b/packages/maskbook/src/plugins/FileService/database.ts
@@ -1,22 +1,36 @@
 import { createPluginDatabase } from '../../database/Plugin/wrap-plugin-database'
 import { asyncIteratorToArray } from '../../utils/type-transform/asyncIteratorHelpers'
 import { identifier } from './constants'
-import type { FileInfo } from './types'
+import { FileInfoV1ToV2 } from './define'
+import type { FileInfo, FileInfoV1 } from './types'
 
-type TaggedTypes = FileInfo
+type TaggedTypes = FileInfo | FileInfoV1
 
 const Database = createPluginDatabase<TaggedTypes>(identifier)
 
+let migrationDone = false
+async function migrationV1_V2() {
+    if (migrationDone) return
+    for await (const x of Database.iterate_mutate('arweave')) {
+        await Database.add(FileInfoV1ToV2(x.data))
+        await x.delete()
+    }
+    migrationDone = true
+}
+
 export async function getRecentFiles() {
-    const files: FileInfo[] = await asyncIteratorToArray(Database.iterate('arweave'))
+    await migrationV1_V2()
+    const files: FileInfo[] = await asyncIteratorToArray(Database.iterate('file'))
     files.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
     return files.slice(0, 4)
 }
 
 export async function getFileInfo(checksum: string) {
-    return Database.get('arweave', checksum)
+    await migrationV1_V2()
+    return Database.get('file', checksum)
 }
 
 export async function setFileInfo(info: FileInfo) {
+    await migrationV1_V2()
     return Database.add(info)
 }

--- a/packages/maskbook/src/plugins/FileService/define.tsx
+++ b/packages/maskbook/src/plugins/FileService/define.tsx
@@ -2,14 +2,26 @@ import { formatFileSize } from '@dimensiondev/kit'
 import { truncate } from 'lodash-es'
 import { createTypedMessageMetadataReader } from '../../protocols/typed-message/metadata'
 import { PluginConfig, PluginStage, PluginScope } from '../types'
-import { identifier, META_KEY_1, pluginName } from './constants'
+import { identifier, META_KEY_1, META_KEY_2, pluginName } from './constants'
 import { Preview } from './Preview'
-import type { FileInfo } from './types'
-import schema from './schema.json'
+import type { FileInfo, FileInfoV1 } from './types'
+import schema from './schema-v1.json'
 import { createCompositionDialog } from '../utils/createCompositionDialog'
 import FileServiceDialog from './MainDialog'
+import type { Result } from 'ts-results'
+import type { TypedMessage } from '../../protocols/typed-message'
 
-export const FileInfoMetadataReader = createTypedMessageMetadataReader<FileInfo>(META_KEY_1, schema)
+const reader_v1 = createTypedMessageMetadataReader<FileInfoV1>(META_KEY_1, schema)
+const reader_v2 = createTypedMessageMetadataReader<FileInfo>(META_KEY_2, schema)
+export function FileInfoMetadataReader(meta: TypedMessage['meta']): Result<FileInfo, void> {
+    const v2 = reader_v2(meta)
+    if (v2.ok) return v2
+    return reader_v1(meta).map(FileInfoV1ToV2)
+}
+export function FileInfoV1ToV2(info: FileInfoV1): FileInfo {
+    return { ...info, type: 'file', provider: 'arweave' }
+}
+
 const [FileServiceCompositionEntry, FileServiceCompositionUI] = createCompositionDialog('📃 File Service', (props) => (
     <FileServiceDialog
         // classes={classes}

--- a/packages/maskbook/src/plugins/FileService/schema-v1.json
+++ b/packages/maskbook/src/plugins/FileService/schema-v1.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": true,
     "properties": {

--- a/packages/maskbook/src/plugins/FileService/schema-v2.json
+++ b/packages/maskbook/src/plugins/FileService/schema-v2.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "type": {
+            "type": "string",
+            "enum": ["file"],
+            "title": "type"
+        },
+        "provider": {
+            "type": "string",
+            "enum": ["arweave"],
+            "title": "provider"
+        },
+        "id": {
+            "type": "string",
+            "title": "id"
+        },
+        "name": {
+            "type": "string",
+            "title": "name"
+        },
+        "size": {
+            "type": "number",
+            "title": "size"
+        },
+        "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "createdAt"
+        },
+        "key": {
+            "type": "string",
+            "title": "key"
+        },
+        "payloadTxID": {
+            "type": "string",
+            "title": "payloadTxID"
+        },
+        "landingTxID": {
+            "type": "string",
+            "title": "landingTxID"
+        }
+    },
+    "required": ["createdAt", "id", "landingTxID", "name", "payloadTxID", "provider", "size", "type"]
+}

--- a/packages/maskbook/src/plugins/FileService/types.ts
+++ b/packages/maskbook/src/plugins/FileService/types.ts
@@ -1,5 +1,6 @@
 export interface FileInfo {
-    type: 'arweave'
+    type: 'file'
+    provider: 'arweave'
     id: string
 
     name: string
@@ -9,4 +10,7 @@ export interface FileInfo {
     key: string | undefined
     payloadTxID: string
     landingTxID: string
+}
+export type FileInfoV1 = Omit<FileInfo, 'type' | 'provider'> & {
+    type: 'arweave'
 }

--- a/packages/maskbook/src/stories/Plugin-FileService.tsx
+++ b/packages/maskbook/src/stories/Plugin-FileService.tsx
@@ -27,7 +27,8 @@ storiesOf('Plugin: File Service', module)
                         name: text('File name', 'file.png'),
                         payloadTxID: text('Payload TxID', 'Payload TxID'),
                         size: number('File Size', 2333),
-                        type: 'arweave',
+                        type: 'file',
+                        provider: 'arweave',
                     }}
                 />
             </div>


### PR DESCRIPTION
Now FileService will emit v2 FileInfo so the older version of Mask Network needs to upgrade to see the content of v2.

I didn't test it. @septs 

It's a necessary part of #2176 . @developerfred may want to take a look about this PR