### PR TITLE
feat: add CDN for the arweave file service

### DIFF
--- a/packages/maskbook/src/_locales/en/messages.json
+++ b/packages/maskbook/src/_locales/en/messages.json
@@ -350,7 +350,7 @@
     "plugin_file_service_unencrypted": "This file is not encrypted",
     "plugin_file_service_signing_failed": "Service unavailable. Wait a few minutes and try again.",
     "plugin_file_service_on_encrypt_it": "Make It Encrypted",
-    "plugin_file_service_use_cdn": "Use CDN",
+    "plugin_file_service_use_cdn": "Use Meson CDN",
     "plugin_file_service_legal_text": "By using this plugin, you agree to the <terms>terms</terms> and the <policy>privacy policy</policy>.",
     "plugin_file_service_legal_terms_link": "https://legal.mask.io/arweave/file-service/plugin-terms.html",
     "plugin_file_service_legal_policy_link": "https://legal.mask.io/arweave/file-service/privacy-policy-uploader.html",

--- a/packages/maskbook/src/_locales/en/messages.json
+++ b/packages/maskbook/src/_locales/en/messages.json
@@ -350,6 +350,7 @@
     "plugin_file_service_unencrypted": "This file is not encrypted",
     "plugin_file_service_signing_failed": "Service unavailable. Wait a few minutes and try again.",
     "plugin_file_service_on_encrypt_it": "Make It Encrypted",
+    "plugin_file_service_use_cdn": "Use CDN",
     "plugin_file_service_legal_text": "By using this plugin, you agree to the <terms>terms</terms> and the <policy>privacy policy</policy>.",
     "plugin_file_service_legal_terms_link": "https://legal.mask.io/arweave/file-service/plugin-terms.html",
     "plugin_file_service_legal_policy_link": "https://legal.mask.io/arweave/file-service/privacy-policy-uploader.html",

--- a/packages/maskbook/src/_locales/ja/messages.json
+++ b/packages/maskbook/src/_locales/ja/messages.json
@@ -350,7 +350,7 @@
     "plugin_file_service_unencrypted": "このファイルは暗号化されていません。",
     "plugin_file_service_signing_failed": "サービスが使用できません。今しばらくお待ちください。",
     "plugin_file_service_on_encrypt_it": "暗号化しましょう",
-    "plugin_file_service_use_cdn": "加速リンクを使用する",
+    "plugin_file_service_use_cdn": "Mesonを使用して加速する",
     "plugin_file_service_legal_text": "このプラグインを使用することで<terms>利用規約</terms>並びに<policy>プライバシーポリシー</policy>に同意したこととなります。",
     "plugin_file_service_legal_terms_link": "https://legal.mask.io/arweave/file-service/plugin-terms.html",
     "plugin_file_service_legal_policy_link": "https://legal.mask.io/arweave/file-service/privacy-policy-uploader.html",

--- a/packages/maskbook/src/_locales/ja/messages.json
+++ b/packages/maskbook/src/_locales/ja/messages.json
@@ -350,6 +350,7 @@
     "plugin_file_service_unencrypted": "このファイルは暗号化されていません。",
     "plugin_file_service_signing_failed": "サービスが使用できません。今しばらくお待ちください。",
     "plugin_file_service_on_encrypt_it": "暗号化しましょう",
+    "plugin_file_service_use_cdn": "加速リンクを使用する",
     "plugin_file_service_legal_text": "このプラグインを使用することで<terms>利用規約</terms>並びに<policy>プライバシーポリシー</policy>に同意したこととなります。",
     "plugin_file_service_legal_terms_link": "https://legal.mask.io/arweave/file-service/plugin-terms.html",
     "plugin_file_service_legal_policy_link": "https://legal.mask.io/arweave/file-service/privacy-policy-uploader.html",

--- a/packages/maskbook/src/_locales/zh/messages.json
+++ b/packages/maskbook/src/_locales/zh/messages.json
@@ -350,7 +350,7 @@
     "plugin_file_service_unencrypted": "文檔未被加密",
     "plugin_file_service_signing_failed": "服務當前不可用，請稍後重試",
     "plugin_file_service_on_encrypt_it": "上傳前加密",
-    "plugin_file_service_use_cdn": "使用加速鏈接",
+    "plugin_file_service_use_cdn": "使用 Meson 加速",
     "plugin_file_service_legal_text": "使用本插件意味著同意<terms>使用條款</terms>與<policy>隱私政策</policy>",
     "plugin_file_service_legal_terms_link": "https://legal.mask.io/arweave/file-service/plugin-terms.html",
     "plugin_file_service_legal_policy_link": "https://legal.mask.io/arweave/file-service/privacy-policy-uploader.html",

--- a/packages/maskbook/src/_locales/zh/messages.json
+++ b/packages/maskbook/src/_locales/zh/messages.json
@@ -350,6 +350,7 @@
     "plugin_file_service_unencrypted": "文檔未被加密",
     "plugin_file_service_signing_failed": "服務當前不可用，請稍後重試",
     "plugin_file_service_on_encrypt_it": "上傳前加密",
+    "plugin_file_service_use_cdn": "使用加速鏈接",
     "plugin_file_service_legal_text": "使用本插件意味著同意<terms>使用條款</terms>與<policy>隱私政策</policy>",
     "plugin_file_service_legal_terms_link": "https://legal.mask.io/arweave/file-service/plugin-terms.html",
     "plugin_file_service_legal_policy_link": "https://legal.mask.io/arweave/file-service/privacy-policy-uploader.html",

--- a/packages/maskbook/src/plugins/FileService/arweave/index.ts
+++ b/packages/maskbook/src/plugins/FileService/arweave/index.ts
@@ -3,7 +3,7 @@ import { encodeArrayBuffer, encodeText } from '@dimensiondev/kit'
 import Arweave from 'arweave/web'
 import type Transaction from 'arweave/web/lib/transaction'
 import { isEmpty, isNil } from 'lodash-es'
-import { landing } from '../constants'
+import { landing, mesonPrefix } from '../constants'
 import { sign } from './remote-signing'
 import token from './token.json'
 
@@ -47,14 +47,18 @@ export interface LandingPageMetadata {
     size: number
     type: string
     txId: string
+    useCDN: boolean
 }
 
 export async function uploadLandingPage(metadata: LandingPageMetadata) {
+    let linkPrefix: string = 'https://arweave.net'
+    if (metadata.useCDN) {
+        linkPrefix = mesonPrefix
+    }
     const encodedMetadata = JSON.stringify({
         name: metadata.name,
         size: metadata.size,
-        // link: `https://arweave.net/${metadata.txId}`,
-        link: `https://coldcdn.com/api/cdn/bronil/${metadata.txId}`,
+        link: `${linkPrefix}/${metadata.txId}`,
         signed: await makeFileKeySigned(metadata.key),
         createdAt: new Date().toISOString(),
     })

--- a/packages/maskbook/src/plugins/FileService/arweave/index.ts
+++ b/packages/maskbook/src/plugins/FileService/arweave/index.ts
@@ -53,7 +53,8 @@ export async function uploadLandingPage(metadata: LandingPageMetadata) {
     const encodedMetadata = JSON.stringify({
         name: metadata.name,
         size: metadata.size,
-        link: `https://arweave.net/${metadata.txId}`,
+        // link: `https://arweave.net/${metadata.txId}`,
+        link: `https://coldcdn.com/api/cdn/bronil/${metadata.txId}`,
         signed: await makeFileKeySigned(metadata.key),
         createdAt: new Date().toISOString(),
     })

--- a/packages/maskbook/src/plugins/FileService/components/Upload.tsx
+++ b/packages/maskbook/src/plugins/FileService/components/Upload.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
     container: {
         display: 'flex',
         flexDirection: 'column',
-        height: 250,
+        height: 260,
     },
     upload: {
         flex: 1,
@@ -29,7 +29,20 @@ const useStyles = makeStyles((theme) => ({
         alignItems: 'center',
         height: 'fit-content',
     },
+    checkItems: {
+        display: 'flex',
+        justifyContent: 'start',
+        alignItems: 'center',
+        height: 'fit-content',
+    },
     encrypted: {
+        userSelect: 'none',
+        '& span': {
+            fontSize: 12,
+            lineHeight: 1.75,
+        },
+    },
+    usedCDN: {
         userSelect: 'none',
         '& span': {
             fontSize: 12,
@@ -52,6 +65,7 @@ export const Upload: React.FC = () => {
     const classes = useStyles()
     const history = useHistory()
     const [encrypted, setEncrypted] = useState(true)
+    const [useCDN, setUseCDN] = useState(false)
     const recent = useAsync(() => PluginFileServiceRPC.getRecentFiles(), [])
     const onFile = async (file: File) => {
         let key: string | undefined = undefined
@@ -69,6 +83,7 @@ export const Upload: React.FC = () => {
                 type: file.type,
                 block,
                 checksum,
+                useCDN,
             })
         } else {
             history.replace(FileRouter.uploaded, item)
@@ -80,12 +95,19 @@ export const Upload: React.FC = () => {
                 <UploadDropArea maxFileSize={MAX_FILE_SIZE} onFile={onFile} />
                 <RecentFiles files={recent.value ?? []} />
             </section>
-            <section className={classes.legal}>
+            <section className={classes.checkItems}>
                 <FormControlLabel
                     control={<Checkbox checked={encrypted} onChange={(event, checked) => setEncrypted(checked)} />}
                     className={classes.encrypted}
                     label={t('plugin_file_service_on_encrypt_it')}
                 />
+                <FormControlLabel
+                    control={<Checkbox checked={useCDN} onChange={(event, checked) => setUseCDN(checked)} />}
+                    className={classes.usedCDN}
+                    label={t('plugin_file_service_use_cdn')}
+                />
+            </section>
+            <section className={classes.legal}>
                 <Typography className={classes.legalText}>
                     <Trans
                         i18nKey="plugin_file_service_legal_text"

--- a/packages/maskbook/src/plugins/FileService/components/Uploading.tsx
+++ b/packages/maskbook/src/plugins/FileService/components/Uploading.tsx
@@ -79,6 +79,7 @@ export const Uploading: React.FC = () => {
             }),
             300000, // ≈ 5 minutes
         )
+        console.log("landingTxID", landingTxID, "payloadTxID", payloadTxID, "key", state.key)
         const item: FileInfo = {
             type: 'arweave',
             id: state.checksum,

--- a/packages/maskbook/src/plugins/FileService/components/Uploading.tsx
+++ b/packages/maskbook/src/plugins/FileService/components/Uploading.tsx
@@ -41,6 +41,7 @@ interface RouteState {
     type: string
     block: Uint8Array
     checksum: string
+    useCDN: boolean
 }
 
 export const Uploading: React.FC = () => {
@@ -76,10 +77,10 @@ export const Uploading: React.FC = () => {
                 txId: payloadTxID,
                 type: state.type,
                 key: state.key,
+                useCDN: state.useCDN,
             }),
             300000, // ≈ 5 minutes
         )
-        console.log("landingTxID", landingTxID, "payloadTxID", payloadTxID, "key", state.key)
         const item: FileInfo = {
             type: 'arweave',
             id: state.checksum,

--- a/packages/maskbook/src/plugins/FileService/constants.ts
+++ b/packages/maskbook/src/plugins/FileService/constants.ts
@@ -7,6 +7,7 @@ export const MAX_FILE_SIZE = 0xa00000 // = 10 MiB
 
 export const landing = 'https://files.maskbook.com/partner/arweave/landing-page.html'
 export const signing = 'https://service.maskbook.com/arweave-remote-signing'
+export const mesonPrefix = 'https://coldcdn.com/api/cdn/9m5pde'
 
 export const enum FileRouter {
     upload = '/upload',


### PR DESCRIPTION
### Issue related
#2160 

### Solution
We add a checkbox in upload page. If user check this option, the file link will be changed to acceleration link.

For users who can't reach the basic endpoint `https://arweave.net`, we can add the cache link for landing page in next iteration.

Test link (have fun): https://arweave.net/VzLiXPYJLyAmWoQbH05W5P5SOaqWesQCFg7a935iKYE#MrRBRMeAnB8EQBE4


<img src="https://user-images.githubusercontent.com/8394303/104575323-f6745d80-5691-11eb-9812-9b643c0794d3.png" width="60%">
