### PR TITLE
fix: restore wallet if not exist

### DIFF
--- a/packages/maskbook/src/plugins/Wallet/services/wallet.ts
+++ b/packages/maskbook/src/plugins/Wallet/services/wallet.ts
@@ -156,7 +156,7 @@ export async function importNewWallet(
     if (rec._private_key_) record._private_key_ = rec._private_key_
     {
         const t = createTransaction(await createWalletDBAccess(), 'readwrite')('Wallet', 'ERC20Token')
-        await t.objectStore('Wallet').add(WalletRecordIntoDB(record))
+        if (!await t.objectStore('Wallet').get(record.address)) await t.objectStore('Wallet').add(WalletRecordIntoDB(record))
     }
     WalletMessages.events.walletsUpdated.sendToAll(undefined)
     selectMaskbookWallet(record)

--- a/packages/maskbook/src/plugins/Wallet/services/wallet.ts
+++ b/packages/maskbook/src/plugins/Wallet/services/wallet.ts
@@ -156,7 +156,8 @@ export async function importNewWallet(
     if (rec._private_key_) record._private_key_ = rec._private_key_
     {
         const t = createTransaction(await createWalletDBAccess(), 'readwrite')('Wallet', 'ERC20Token')
-        if (!await t.objectStore('Wallet').get(record.address)) await t.objectStore('Wallet').add(WalletRecordIntoDB(record))
+        if (!(await t.objectStore('Wallet').get(record.address)))
+            await t.objectStore('Wallet').add(WalletRecordIntoDB(record))
     }
     WalletMessages.events.walletsUpdated.sendToAll(undefined)
     selectMaskbookWallet(record)


### PR DESCRIPTION
close #2258

Delete 'Persona Card' would delete the data of persona, wallet remains. So check the existence of wallet when restore.