### PR TITLE
fix: husky configuration

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-lint-staged
+npx lint-staged
 npm run locale-kit -- --sync-key
-prettier --check .
+npx prettier --check .

--- a/.prettierignore
+++ b/.prettierignore
@@ -169,3 +169,8 @@ common/deploy/
 common/temp/
 common/autoinstallers/*/.npmrc
 **/.rush/temp/
+
+## storybook-shared
+packages/storybook-shared/*.js
+packages/storybook-shared/*.map
+packages/storybook-shared/*.d.ts


### PR DESCRIPTION
```
septs@CBDesktop02 ~/Projects/DimensionDev/Maskbook (feature/integrate-stego-js-v2) $ git commit -m 'chore: update lock'
.husky/pre-commit: line 4: lint-staged: command not found
husky - pre-commit hook exited with code 127 (error)
```

```
septs@CBDesktop02 ~/Projects/DimensionDev/Maskbook (feature/integrate-stego-js-v2*) $ git commit -m 'chore: update lock'
ℹ No staged files match any configured task.

> maskbook@1.22.3 locale-kit
> ts-node scripts/locale-kit.ts "--sync-key"

Scanned 0 unused keys, run `npm run locale-kit -- --remove-unused-keys` to remove them.
Unsynced [] locales
Synced keys
$ git add packages/maskbook/src/_locales # cwd:
Checking formatting...
[warn] packages/storybook-shared/index.d.ts
[warn] packages/storybook-shared/index.js
[warn] packages/storybook-shared/story-of.d.ts
[warn] packages/storybook-shared/story-of.js
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
npm ERR! code 1
npm ERR! path /Users/septs/Projects/DimensionDev/Maskbook
npm ERR! command failed
npm ERR! command sh -c prettier "--check" "."

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/septs/.npm/_logs/2021-02-01T04_29_30_149Z-debug.log
husky - pre-commit hook exited with code 1 (error)
```