### PR TITLE
feat: third-part form libraries

### DIFF
--- a/packages/maskbook/package.json
+++ b/packages/maskbook/package.json
@@ -17,6 +17,7 @@
     "@ethersproject/networks": "^5.0.4",
     "@ethersproject/providers": "^5.0.9",
     "@ethersproject/solidity": "^5.0.4",
+    "@hookform/resolvers": "^1.3.4",
     "@msgpack/msgpack": "^2.3.0",
     "@openzeppelin/contracts": "^3.2.0",
     "@popperjs/core": "*",
@@ -79,6 +80,7 @@
     "react-draggable": "^4.4.3",
     "react-feather": "^2.0.9",
     "react-highlight-words": "^0.17.0",
+    "react-hook-form": "^6.15.1",
     "react-i18next": "^11.8.4",
     "react-middle-ellipsis": "^1.1.0",
     "react-router": "^5.2.0",
@@ -104,7 +106,8 @@
     "web3-utils": "^1.3.0",
     "webcrypto-liner": "1.2.3",
     "webextension-polyfill": "^0.7.0",
-    "z-schema": "^5.0.0"
+    "z-schema": "^5.0.0",
+    "zod": "^3.0.0-alpha.4"
   },
   "devDependencies": {
     "@dimensiondev/webextension-shim": "0.0.3-20201120022530-b318b89",

--- a/packages/maskbook/package.json
+++ b/packages/maskbook/package.json
@@ -58,6 +58,8 @@
     "eth-contract-metadata": "^1.15.0",
     "ethereum-blockies": "^0.1.1",
     "event-iterator": "^2.0.0",
+    "formik": "^2.2.6",
+    "formik-material-ui": "^3.0.1",
     "fuse.js": "^6.4.3",
     "gun": "0.2020.520",
     "https-browserify": "^1.0.0",
@@ -106,6 +108,7 @@
     "web3-utils": "^1.3.0",
     "webcrypto-liner": "1.2.3",
     "webextension-polyfill": "^0.7.0",
+    "yup": "^0.32.8",
     "z-schema": "^5.0.0",
     "zod": "^3.0.0-alpha.4"
   },

--- a/packages/maskbook/package.json
+++ b/packages/maskbook/package.json
@@ -114,6 +114,7 @@
   },
   "devDependencies": {
     "@dimensiondev/webextension-shim": "0.0.3-20201120022530-b318b89",
+    "@hookform/devtools": "^2.2.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@sinonjs/text-encoding": "^0.7.1",
     "@storybook/addon-actions": "^5.3.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,7 @@ importers:
       zod: 3.0.0-alpha.4
     devDependencies:
       '@dimensiondev/webextension-shim': 0.0.3-20201120022530-b318b89
+      '@hookform/devtools': 2.2.1_react-hook-form@6.15.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.3_a16822dab3ce6e2b05b029223ee2977b
       '@sinonjs/text-encoding': 0.7.1
       '@storybook/addon-actions': 5.3.21
@@ -311,6 +312,7 @@ importers:
       '@ethersproject/networks': ^5.0.4
       '@ethersproject/providers': ^5.0.9
       '@ethersproject/solidity': ^5.0.4
+      '@hookform/devtools': ^2.2.1
       '@hookform/resolvers': ^1.3.4
       '@msgpack/msgpack': ^2.3.0
       '@openzeppelin/contracts': ^3.2.0
@@ -3326,6 +3328,22 @@ packages:
     dev: true
     resolution:
       integrity: sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
+  /@hookform/devtools/2.2.1_react-hook-form@6.15.1:
+    dependencies:
+      '@emotion/core': 10.1.1
+      '@emotion/styled': 10.0.27_@emotion+core@10.1.1
+      '@types/lodash': 4.14.168
+      little-state-machine: 3.1.4
+      lodash: 4.17.20
+      react-hook-form: 6.15.1
+      react-simple-animate: 3.3.11
+    dev: true
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      react-hook-form: '>=6.5.0'
+    resolution:
+      integrity: sha512-VQh4kqwUOpz9LCDzIP0aJ4qnD/ob8Gp09L8gDy++9XtL66z6g8kbCynUvBrJm4qbCNdH0M7/Spm3AUjJqUuFlA==
   /@hookform/resolvers/1.3.4_react-hook-form@6.15.1:
     dependencies:
       react-hook-form: 6.15.1
@@ -6517,7 +6535,6 @@ packages:
     resolution:
       integrity: sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==
   /@types/lodash/4.14.168:
-    dev: false
     resolution:
       integrity: sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
   /@types/markdown-to-jsx/6.11.3:
@@ -16881,6 +16898,13 @@ packages:
       enquirer: '>= 2.3.0 < 3'
     resolution:
       integrity: sha512-G9IFI/m65icgVlifS0wMQnvn35/8VJGzEb3crpE4NnaegQYQOn/wP7yqi9TTJQ/eoxme4UaPbffBK1XqKP/DOg==
+  /little-state-machine/3.1.4:
+    dev: true
+    peerDependencies:
+      react: ^16.8.0
+      react-dom: ^16.8.0
+    resolution:
+      integrity: sha512-gYlLCj6oUME0NG34/2O0Ljy52qYYyYDJ5yiAuq2ijbaRlBKIqtQQkKkEYn0KfjYXCE693j+bdY22EyZin25Bhw==
   /load-json-file/1.1.0:
     dependencies:
       graceful-fs: 4.2.4
@@ -20527,6 +20551,13 @@ packages:
       react: ^16.0.0 || ^17.0.0
     resolution:
       integrity: sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==
+  /react-simple-animate/3.3.11:
+    dev: true
+    peerDependencies:
+      react: ^16.8.0
+      react-dom: ^16.8.0
+    resolution:
+      integrity: sha512-kt2SKJ4Gw3klTmRbik/9R741fPiVRVlxkXvV0c3uu8NqOtdc5ITis62WcdiKH6U5QhCjXNfLW9lrbQ4cAYujyA==
   /react-sizeme/2.6.12:
     dependencies:
       element-resize-detector: 1.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,8 @@ importers:
       eth-contract-metadata: 1.17.0
       ethereum-blockies: 0.1.1
       event-iterator: 2.0.0
+      formik: 2.2.6
+      formik-material-ui: 3.0.1_formik@2.2.6
       fuse.js: 6.4.6
       gun: 0.2020.520
       https-browserify: 1.0.0
@@ -227,6 +229,7 @@ importers:
       web3-utils: 1.3.3
       webcrypto-liner: 1.2.3
       webextension-polyfill: 0.7.0
+      yup: 0.32.8
       z-schema: 5.0.0
       zod: 3.0.0-alpha.4
     devDependencies:
@@ -379,6 +382,8 @@ importers:
       expect-puppeteer: ^4.4.0
       fake-indexeddb: ^3.1.2
       file-loader: ^6.2.0
+      formik: ^2.2.6
+      formik-material-ui: ^3.0.1
       fuse.js: ^6.4.3
       gun: 0.2020.520
       html-webpack-plugin: ^5.0.0-beta.4
@@ -459,6 +464,7 @@ importers:
       webpack-extension-manifest-plugin: ^0.6.0
       webpack-notifier: ^1.12.0
       webpack-target-webextension: ^0.4.0
+      yup: ^0.32.8
       z-schema: ^5.0.0
       zod: ^3.0.0-alpha.4
   packages/shared:
@@ -2379,6 +2385,12 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-EvX/BvMMJRAA3jZgILWgbsrHwBQvllC5T8B29McyME8DvkdOxk4ujESfrMvME8IHSDvWXrmMXxPvA/lx2gqPLQ==
+  /@babel/runtime/7.12.13:
+    dependencies:
+      regenerator-runtime: 0.13.7
+    dev: false
+    resolution:
+      integrity: sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
   /@babel/runtime/7.12.5:
     dependencies:
       regenerator-runtime: 0.13.7
@@ -10983,6 +10995,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==
+  /deepmerge/2.2.1:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
   /deepmerge/4.2.2:
     dev: true
     engines:
@@ -13272,6 +13290,31 @@ packages:
       node: '>=0.4.x'
     resolution:
       integrity: sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+  /formik-material-ui/3.0.1_formik@2.2.6:
+    dependencies:
+      formik: 2.2.6
+    dev: false
+    peerDependencies:
+      '@material-ui/core': '>=4.0.0'
+      formik: '>=2.0.0'
+      react: '>=16.8.0'
+      tiny-warning: '>=1.0.2'
+    resolution:
+      integrity: sha512-N8oxZIdhY70npRv86IfF6Zaaps9RL3a37XRdq02WDroB3XZC1mXs6lA/zQ09ZYFWYJp/UjI80SKVpVa/xJOJJA==
+  /formik/2.2.6:
+    dependencies:
+      deepmerge: 2.2.1
+      hoist-non-react-statics: 3.3.2
+      lodash: 4.17.20
+      lodash-es: 4.17.20
+      react-fast-compare: 2.0.4
+      tiny-warning: 1.0.3
+      tslib: 1.14.1
+    dev: false
+    peerDependencies:
+      react: '>=16.8.0'
+    resolution:
+      integrity: sha512-Kxk2zQRafy56zhLmrzcbryUpMBvT0tal5IvcifK5+4YNGelKsnrODFJ0sZQRMQboblWNym4lAW3bt+tf2vApSA==
   /forwarded/0.1.2:
     engines:
       node: '>= 0.6'
@@ -17913,6 +17956,10 @@ packages:
   /nano-json-stream-parser/0.1.2:
     resolution:
       integrity: sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=
+  /nanoclone/0.2.1:
+    dev: false
+    resolution:
+      integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
   /nanoid/3.1.20:
     dev: true
     engines:
@@ -19560,6 +19607,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  /property-expr/2.0.4:
+    dev: false
+    resolution:
+      integrity: sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
   /property-information/5.6.0:
     dependencies:
       xtend: 4.0.2
@@ -20175,6 +20226,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==
+  /react-fast-compare/2.0.4:
+    dev: false
+    resolution:
+      integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
   /react-fast-compare/3.2.0:
     dev: true
     resolution:
@@ -23352,6 +23407,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=
+  /toposort/2.0.2:
+    dev: false
+    resolution:
+      integrity: sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
   /tosource/1.0.0:
     dev: true
     engines:
@@ -25799,6 +25858,20 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+  /yup/0.32.8:
+    dependencies:
+      '@babel/runtime': 7.12.13
+      '@types/lodash': 4.14.168
+      lodash: 4.17.20
+      lodash-es: 4.17.20
+      nanoclone: 0.2.1
+      property-expr: 2.0.4
+      toposort: 2.0.2
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==
   /z-schema/5.0.0:
     dependencies:
       lodash.get: 4.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,7 @@ importers:
       '@ethersproject/networks': 5.0.7
       '@ethersproject/providers': 5.0.19
       '@ethersproject/solidity': 5.0.8
+      '@hookform/resolvers': 1.3.4_react-hook-form@6.15.1
       '@msgpack/msgpack': 2.3.0
       '@openzeppelin/contracts': 3.3.0
       '@popperjs/core': 2.6.0
@@ -200,6 +201,7 @@ importers:
       react-draggable: 4.4.3
       react-feather: 2.0.9
       react-highlight-words: 0.17.0
+      react-hook-form: 6.15.1
       react-i18next: 11.8.5_i18next@19.8.5
       react-middle-ellipsis: 1.1.0
       react-router: 5.2.0
@@ -226,6 +228,7 @@ importers:
       webcrypto-liner: 1.2.3
       webextension-polyfill: 0.7.0
       z-schema: 5.0.0
+      zod: 3.0.0-alpha.4
     devDependencies:
       '@dimensiondev/webextension-shim': 0.0.3-20201120022530-b318b89
       '@pmmmwh/react-refresh-webpack-plugin': 0.4.3_a16822dab3ce6e2b05b029223ee2977b
@@ -305,6 +308,7 @@ importers:
       '@ethersproject/networks': ^5.0.4
       '@ethersproject/providers': ^5.0.9
       '@ethersproject/solidity': ^5.0.4
+      '@hookform/resolvers': ^1.3.4
       '@msgpack/msgpack': ^2.3.0
       '@openzeppelin/contracts': ^3.2.0
       '@pmmmwh/react-refresh-webpack-plugin': ^0.4.3
@@ -409,6 +413,7 @@ importers:
       react-draggable: ^4.4.3
       react-feather: ^2.0.9
       react-highlight-words: ^0.17.0
+      react-hook-form: ^6.15.1
       react-i18next: ^11.8.4
       react-middle-ellipsis: ^1.1.0
       react-refresh: ^0.9.0
@@ -455,6 +460,7 @@ importers:
       webpack-notifier: ^1.12.0
       webpack-target-webextension: ^0.4.0
       z-schema: ^5.0.0
+      zod: ^3.0.0-alpha.4
   packages/shared:
     dependencies:
       async-call-rpc: 5.0.0
@@ -3308,6 +3314,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
+  /@hookform/resolvers/1.3.4_react-hook-form@6.15.1:
+    dependencies:
+      react-hook-form: 6.15.1
+    dev: false
+    peerDependencies:
+      react-hook-form: '>=6.6.0'
+    resolution:
+      integrity: sha512-K56VLSInXNIT/r14pkzRn1FJclqzGOWqpe3Bf0kz2Hf98ZOmRRFh4fhB7F3ofqCQ03CEQQkV44CTg7ql6nEvEg==
   /@icons/material/0.2.4:
     dev: true
     peerDependencies:
@@ -4945,30 +4959,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-vS4DfA2Avvl7JNQymO4e3RUNoTWIGVfZJ70Irnd6PTAZNojbCXTYuigDavrmyf83F3g5rQpwmSAPjuoi/X/FRA==
-  /@storybook/client-api/5.3.21_regenerator-runtime@0.13.7:
-    dependencies:
-      '@storybook/addons': 5.3.21_regenerator-runtime@0.13.7
-      '@storybook/channel-postmessage': 5.3.21
-      '@storybook/channels': 5.3.21
-      '@storybook/client-logger': 5.3.21
-      '@storybook/core-events': 5.3.21
-      '@storybook/csf': 0.0.1
-      '@types/webpack-env': 1.16.0
-      core-js: 3.8.3
-      eventemitter3: 4.0.7
-      global: 4.4.0
-      is-plain-object: 3.0.1
-      lodash: 4.17.20
-      memoizerific: 1.11.3
-      qs: 6.9.6
-      stable: 0.1.8
-      ts-dedent: 1.2.0
-      util-deprecate: 1.0.2
-    dev: true
-    peerDependencies:
-      regenerator-runtime: '*'
-    resolution:
-      integrity: sha512-vS4DfA2Avvl7JNQymO4e3RUNoTWIGVfZJ70Irnd6PTAZNojbCXTYuigDavrmyf83F3g5rQpwmSAPjuoi/X/FRA==
   /@storybook/client-api/6.1.15:
     dependencies:
       '@storybook/addons': 6.1.15
@@ -5130,7 +5120,7 @@ packages:
       '@babel/preset-env': 7.12.11
       '@storybook/addons': 5.3.21_regenerator-runtime@0.13.7
       '@storybook/channel-postmessage': 5.3.21
-      '@storybook/client-api': 5.3.21_regenerator-runtime@0.13.7
+      '@storybook/client-api': 5.3.21
       '@storybook/client-logger': 5.3.21
       '@storybook/core-events': 5.3.21
       '@storybook/csf': 0.0.1
@@ -13137,6 +13127,20 @@ packages:
     resolution:
       integrity: sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==
   /follow-redirects/1.13.2:
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    resolution:
+      integrity: sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+  /follow-redirects/1.13.2_debug@4.3.1:
+    dependencies:
+      debug: 4.3.1_supports-color@6.1.0
+    dev: true
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -14488,7 +14492,7 @@ packages:
   /http-proxy/1.18.1_debug@4.3.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.13.2
+      follow-redirects: 1.13.2_debug@4.3.1
       requires-port: 1.0.0
     dev: true
     engines:
@@ -20247,6 +20251,12 @@ packages:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0
     resolution:
       integrity: sha512-uX1Qh5IGjnLuJT0Zok234QDwRC8h4hcVMnB99Cb7aquB1NlPPDiWKm0XpSZOTdSactvnClCk8LOmVlP+75dgHA==
+  /react-hook-form/6.15.1:
+    dev: false
+    peerDependencies:
+      react: ^16.8.0 || ^17
+    resolution:
+      integrity: sha512-bL0LQuQ3OlM3JYfbacKtBPLOHhmgYz8Lj6ivMrvu2M6e1wnt4sbGRtPEPYCc/8z3WDbjrMwfAfLX92OsB65pFA==
   /react-hotkeys/2.0.0:
     dependencies:
       prop-types: 15.7.2
@@ -23011,7 +23021,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@4.4.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -25819,6 +25829,10 @@ packages:
       node: '>= 10'
     resolution:
       integrity: sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==
+  /zod/3.0.0-alpha.4:
+    dev: false
+    resolution:
+      integrity: sha512-pOtx1/JRT4NQ3K0wlnVAFDMY6Kvsb0xIMZvAaVzZBDUFKUS6OgZtrztcpI5NqCB4KMexcbgXgKxgpOpia9SFSw==
   /zwitch/1.0.5:
     dev: true
     resolution:


### PR DESCRIPTION
# Form library


|                    | [React-hook-form](https://react-hook-form.com/)                                                       | [Formik](https://formik.org/)                                                                | [React-final-form](https://final-form.org/react) |
|--------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------|------------------|
| Typescript support | ✔                                                                     | ✔                                                                     | ❓                |
| How to use         | hook                                                             | Component,Render props, hoc, hooks（Not the best choice）               | Component,hooks  |
| Validation         | HTML standard for form validation and other schema validation library | HTML standard for form validation And other schema validation library | ❓                |

Maskbook currently does not use third-party form component library.

Material-UI recommends four form libraries:

1. react-hook-form
2. formik
3. ~~redux-form~~
4. react-final-form

First, we can exclude the redux-form, because it depends on redux.

Second, I think react-final-form also should be excluded, because it does not have a good type support and better validation support.

There are two libraries here:

* React-hook-form: 
  1. Built with `typescript`, type support
  2. Uncontrolled & controlled
  3. Support third-part UI libraries
  4. Mininum re-render, better performance (default mode)
  5. Recommend using hook or `Controller` Component
  6. Provides `resolvers` to obtain third-party schema validation libraries, like `yup`, `zod`, `Superstruct`.
  7. Provides `DevTool` help view field values or errors in the form

   
* Formik: 
  1. Built with `typescript`, type support
  2. Controlled
  3. Support third-part UI libraries
  4. Support class components
  5. Self-contained `yup` support

  
  Here is the code example for them:
  
  [react-hook-form](https://github.com/react-hook-form/react-hook-form/tree/master/examples)
  [formik](https://github.com/formium/formik/tree/master/examples)