### PR TITLE
fix: rm swap amount decimal when slide

### DIFF
--- a/packages/maskbook/src/plugins/ITO/UI/ClaimDialog.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/ClaimDialog.tsx
@@ -230,8 +230,8 @@ export function ClaimDialog(props: ClaimDialogProps) {
                             .dividedBy(ratio)
                             .multipliedBy(Math.pow(10, claimToken.decimals))
                         if (tAmount.isGreaterThan(maxSwapAmount)) return
-                        setTokenAmount(tAmount)
-                        setClaimAmount(tAmount.multipliedBy(ratio))
+                        setTokenAmount(tAmount.dp(0))
+                        setClaimAmount(tAmount.multipliedBy(ratio).dp(0))
                         setInputAmountForUI(swapAmount)
                     }}
                 />


### PR DESCRIPTION
Remove the unacceptable decimal for the calculating result of swap token when slide.

the unacceptable decimal would cause error when approve token:

<img src="https://user-images.githubusercontent.com/63733714/107013753-b8241700-67d5-11eb-9cd7-deb388f414de.png" width=600 />



```
console.log(tAmount.multipliedBy(ratio)) 
console.log(tAmount.multipliedBy(ratio).dp(0)) 

// 79388027.0000000000000000000000004
// 79388027
```