### PR TITLE
refactor: invoke SelectERC20TokenDialog by message center

### DIFF
--- a/packages/maskbook/src/extension/options-page/DashboardComponents/FixedTokenList.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardComponents/FixedTokenList.tsx
@@ -13,7 +13,6 @@ import { useStylesExtends } from '../../../components/custom-ui-helper'
 import { isSameAddress } from '../../../web3/helpers'
 import { TokenInList } from './TokenInList'
 import type { ERC20TokenDetailed, EtherTokenDetailed } from '../../../web3/types'
-import { useEtherTokenDetailed } from '../../../web3/hooks/useEtherTokenDetailed'
 
 const useStyles = makeStyles((theme) =>
     createStyles({
@@ -23,7 +22,6 @@ const useStyles = makeStyles((theme) =>
 )
 
 export interface FixedTokenListProps extends withClasses<KeysInferFromUseStyles<typeof useStyles>> {
-    useEther?: boolean
     keyword?: string
     whitelist?: string[]
     blacklist?: string[]
@@ -41,7 +39,6 @@ export function FixedTokenList(props: FixedTokenListProps) {
         blacklist: excludeTokens = [],
         selectedTokens = [],
         tokens = [],
-        useEther = false,
         onSubmit,
         FixedSizeListProps,
     } = props
@@ -49,7 +46,6 @@ export function FixedTokenList(props: FixedTokenListProps) {
     //#region search tokens
     const ERC20_TOKEN_LISTS = useConstant(CONSTANTS, 'ERC20_TOKEN_LISTS')
     const [address, setAddress] = useState('')
-    const { value: etherTokenDetailed } = useEtherTokenDetailed()
     const { state, tokensDetailed: erc20TokensDetailed } = useERC20TokensDetailedFromTokenLists(
         ERC20_TOKEN_LISTS,
         keyword,
@@ -57,53 +53,44 @@ export function FixedTokenList(props: FixedTokenListProps) {
     //#endregion
 
     //#region UI helpers
-    const renderList = useCallback(
-        (fetchedTokens: (EtherTokenDetailed | ERC20TokenDetailed)[]) => {
-            const filteredTokens = fetchedTokens.filter(
-                (x) =>
-                    (!includeTokens.length || includeTokens.some((y) => isSameAddress(y, x.address))) &&
-                    (!excludeTokens.length || !excludeTokens.some((y) => isSameAddress(y, x.address))),
-            )
-            const renderTokens = uniqBy([...filteredTokens, ...tokens], (x) => x.address.toLowerCase())
-            return (
-                <FixedSizeList
-                    className={classes.list}
-                    width="100%"
-                    height={100}
-                    overscanCount={4}
-                    itemSize={50}
-                    itemData={{
-                        tokens: renderTokens,
-                        selected: [address, ...selectedTokens],
-                        onSelect(address: string) {
-                            const token = renderTokens.find((token) => isSameAddress(token.address, address))
-                            if (!token) return
-                            setAddress(token.address)
-                            onSubmit?.(token)
-                        },
-                    }}
-                    itemCount={renderTokens.length}
-                    {...FixedSizeListProps}>
-                    {TokenInList}
-                </FixedSizeList>
-            )
-        },
-        [address, includeTokens, excludeTokens, selectedTokens, tokens, TokenInList, onSubmit],
-    )
-    const renderPlaceholder = useCallback(
-        (message: string) => (
-            <Typography className={classes.placeholder} color="textSecondary">
-                {message}
-            </Typography>
-        ),
-        [],
+    const renderPlaceholder = (message: string) => (
+        <Typography className={classes.placeholder} color="textSecondary">
+            {message}
+        </Typography>
     )
     //#endregion
 
     if (state === TokenListsState.LOADING_TOKEN_LISTS) return renderPlaceholder('Loading token lists...')
     if (state === TokenListsState.LOADING_SEARCHED_TOKEN) return renderPlaceholder('Loading token...')
-    if (useEther && etherTokenDetailed && (!keyword || 'ether'.includes(keyword.toLowerCase())))
-        return renderList([etherTokenDetailed, ...erc20TokensDetailed])
-    if (erc20TokensDetailed.length) return renderList(erc20TokensDetailed)
-    return renderPlaceholder('No token found')
+    if (!erc20TokensDetailed.length) return renderPlaceholder('No token found')
+
+    const filteredTokens = erc20TokensDetailed.filter(
+        (x) =>
+            (!includeTokens.length || includeTokens.some((y) => isSameAddress(y, x.address))) &&
+            (!excludeTokens.length || !excludeTokens.some((y) => isSameAddress(y, x.address))),
+    )
+    const renderTokens = uniqBy([...tokens, ...filteredTokens], (x) => x.address.toLowerCase())
+
+    return (
+        <FixedSizeList
+            className={classes.list}
+            width="100%"
+            height={100}
+            overscanCount={4}
+            itemSize={50}
+            itemData={{
+                tokens: renderTokens,
+                selected: [address, ...selectedTokens],
+                onSelect(address: string) {
+                    const token = renderTokens.find((token) => isSameAddress(token.address, address))
+                    if (!token) return
+                    setAddress(token.address)
+                    onSubmit?.(token)
+                },
+            }}
+            itemCount={renderTokens.length}
+            {...FixedSizeListProps}>
+            {TokenInList}
+        </FixedSizeList>
+    )
 }

--- a/packages/maskbook/src/extension/options-page/DashboardComponents/FixedTokenList.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardComponents/FixedTokenList.tsx
@@ -25,10 +25,10 @@ const useStyles = makeStyles((theme) =>
 export interface FixedTokenListProps extends withClasses<KeysInferFromUseStyles<typeof useStyles>> {
     useEther?: boolean
     keyword?: string
-    includeTokens?: string[]
-    excludeTokens?: string[]
-    selectedTokens?: string[]
+    whitelist?: string[]
+    blacklist?: string[]
     tokens?: (ERC20TokenDetailed | EtherTokenDetailed)[]
+    selectedTokens?: string[]
     onSubmit?(token: EtherTokenDetailed | ERC20TokenDetailed): void
     FixedSizeListProps?: Partial<FixedSizeListProps>
 }
@@ -37,8 +37,8 @@ export function FixedTokenList(props: FixedTokenListProps) {
     const classes = useStylesExtends(useStyles(), props)
     const {
         keyword,
-        includeTokens = [],
-        excludeTokens = [],
+        whitelist: includeTokens = [],
+        blacklist: excludeTokens = [],
         selectedTokens = [],
         tokens = [],
         useEther = false,
@@ -59,15 +59,12 @@ export function FixedTokenList(props: FixedTokenListProps) {
     //#region UI helpers
     const renderList = useCallback(
         (fetchedTokens: (EtherTokenDetailed | ERC20TokenDetailed)[]) => {
-            let tokens_ = fetchedTokens
-            tokens_ = includeTokens.length
-                ? tokens_.filter((x) => includeTokens.some((y) => isSameAddress(y, x.address)))
-                : tokens_
-            tokens_ = excludeTokens.length
-                ? tokens_.filter((x) => !excludeTokens.some((y) => isSameAddress(y, x.address)))
-                : tokens_
-            const renderTokens = uniqBy([...tokens_, ...tokens], (x) => x.address.toLowerCase())
-
+            const filteredTokens = fetchedTokens.filter(
+                (x) =>
+                    (!includeTokens.length || includeTokens.some((y) => isSameAddress(y, x.address))) &&
+                    (!excludeTokens.length || !excludeTokens.some((y) => isSameAddress(y, x.address))),
+            )
+            const renderTokens = uniqBy([...filteredTokens, ...tokens], (x) => x.address.toLowerCase())
             return (
                 <FixedSizeList
                     className={classes.list}

--- a/packages/maskbook/src/extension/options-page/DashboardDialogs/Wallet.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardDialogs/Wallet.tsx
@@ -92,7 +92,7 @@ export function ERC20PredefinedTokenSelector(props: ERC20PredefinedTokenSelector
             <FixedTokenList
                 classes={{ list: classes.list, placeholder: classes.placeholder }}
                 keyword={keyword}
-                excludeTokens={excludeTokens}
+                blacklist={excludeTokens}
                 onSubmit={(token) => token.type === EthereumTokenType.ERC20 && onTokenChange?.(token)}
                 FixedSizeListProps={{
                     height: 192,

--- a/packages/maskbook/src/plugins/Ethereum/UI/SelectERC20TokenDialog.tsx
+++ b/packages/maskbook/src/plugins/Ethereum/UI/SelectERC20TokenDialog.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { makeStyles, createStyles, Theme, DialogContent, TextField } from '@material-ui/core'
 import { InjectedDialog } from '../../../components/shared/InjectedDialog'
 import { useI18N } from '../../../utils/i18n-next-ui'
 import { useStylesExtends } from '../../../components/custom-ui-helper'
-import { FixedTokenList } from '../../../extension/options-page/DashboardComponents/FixedTokenList'
+import { FixedTokenList, FixedTokenListProps } from '../../../extension/options-page/DashboardComponents/FixedTokenList'
 import type { ERC20TokenDetailed, EtherTokenDetailed } from '../../../web3/types'
+import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControlledDialog'
+import { WalletMessages } from '../../Wallet/messages'
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -42,23 +44,43 @@ export function SelectERC20TokenDialog(props: SelectERC20TokenDialogProps) {
     const { t } = useI18N()
     const classes = useStylesExtends(useStyles(), props)
 
-    const {
-        open,
-        disableSearchBar = false,
-        includeTokens,
-        excludeTokens,
-        selectedTokens,
-        tokens = [],
-        onSubmit,
-        onClose,
-    } = props
-
     //#region search tokens
     const [keyword, setKeyword] = useState('')
     //#endregion
 
+    //#region remote controlled dialog
+    const [disableEther, setDisableEther] = useState(true)
+    const [disableSearchBar, setDisableSearchBar] = useState(false)
+    const [FixedTokenListProps, setFixedTokenListProps] = useState<FixedTokenListProps | null>(null)
+
+    const [open, setOpen] = useRemoteControlledDialog(WalletMessages.events.selectERC20TokenDialogUpdated, (ev) => {
+        if (!ev.open) return
+        setDisableEther(ev.disableEther ?? true)
+        setDisableSearchBar(ev.disableSearchBar ?? false)
+        setFixedTokenListProps(ev.FixedTokenListProps ?? null)
+    })
+    const onSubmit = useCallback(
+        (token: EtherTokenDetailed | ERC20TokenDetailed) => {
+            setOpen({
+                open: false,
+                token,
+            })
+        },
+        [setOpen],
+    )
+    const onClose = useCallback(() => {
+        setOpen({
+            open: false,
+        })
+    }, [setOpen])
+    //#endregion
+
     return (
-        <InjectedDialog open={open} onClose={onClose} title="Select a Token" DialogProps={{ maxWidth: 'xs' }}>
+        <InjectedDialog
+            open={open}
+            onClose={onClose}
+            title={t('plugin_wallet_select_a_token')}
+            DialogProps={{ maxWidth: 'xs' }}>
             <DialogContent>
                 {!disableSearchBar ? (
                     <TextField
@@ -74,15 +96,13 @@ export function SelectERC20TokenDialog(props: SelectERC20TokenDialogProps) {
                     classes={{ list: classes.list, placeholder: classes.placeholder }}
                     useEther
                     keyword={keyword}
-                    tokens={tokens}
-                    includeTokens={includeTokens}
-                    excludeTokens={excludeTokens}
-                    selectedTokens={selectedTokens}
                     onSubmit={onSubmit}
+                    {...FixedTokenListProps}
                     FixedSizeListProps={{
                         height: disableSearchBar ? 350 : 288,
                         itemSize: 52,
                         overscanCount: 4,
+                        ...FixedTokenListProps?.FixedSizeListProps,
                     }}
                 />
             </DialogContent>

--- a/packages/maskbook/src/plugins/Ethereum/UI/SelectTokenDialog.tsx
+++ b/packages/maskbook/src/plugins/Ethereum/UI/SelectTokenDialog.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme: Theme) =>
     }),
 )
 
-export interface SelectERC20TokenDialogProps extends withClasses<never> {
+export interface SelectTokenDialogProps extends withClasses<never> {
     open?: boolean
     includeTokens?: string[]
     excludeTokens?: string[]
@@ -41,7 +41,7 @@ export interface SelectERC20TokenDialogProps extends withClasses<never> {
     onClose?: () => void
 }
 
-export function SelectERC20TokenDialog(props: SelectERC20TokenDialogProps) {
+export function SelectTokenDialog(props: SelectTokenDialogProps) {
     const { t } = useI18N()
     const classes = useStylesExtends(useStyles(), props)
 
@@ -57,7 +57,7 @@ export function SelectERC20TokenDialog(props: SelectERC20TokenDialogProps) {
     const [disableSearchBar, setDisableSearchBar] = useState(false)
     const [FixedTokenListProps, setFixedTokenListProps] = useState<FixedTokenListProps | null>(null)
 
-    const [open, setOpen] = useRemoteControlledDialog(WalletMessages.events.selectERC20TokenDialogUpdated, (ev) => {
+    const [open, setOpen] = useRemoteControlledDialog(WalletMessages.events.selectTokenDialogUpdated, (ev) => {
         if (!ev.open) return
         setId(ev.uuid)
         setDisableEther(ev.disableEther ?? true)

--- a/packages/maskbook/src/plugins/Ethereum/messages.ts
+++ b/packages/maskbook/src/plugins/Ethereum/messages.ts
@@ -4,7 +4,7 @@ import { createPluginMessage } from '../utils/createPluginMessage'
 import { createPluginRPC } from '../utils/createPluginRPC'
 import { PLUGIN_IDENTIFIER } from './constants'
 
-type SelectERC20TokenDialogEvent =
+type SelectTokenDialogEvent =
     | {
           open: true
           address?: string
@@ -42,7 +42,7 @@ interface EthereumMessage {
     /**
      * Select token dialog
      */
-    selectERC20TokenDialogUpdated: SelectERC20TokenDialogEvent
+    selectERC20TokenDialogUpdated: SelectTokenDialogEvent
 
     /**
      * Unlock token dialog

--- a/packages/maskbook/src/plugins/Gitcoin/apis/index.ts
+++ b/packages/maskbook/src/plugins/Gitcoin/apis/index.ts
@@ -39,7 +39,7 @@ export interface GitcoinGrant {
 
 export async function fetchGrant(id: string) {
     if (!/\d+/.test(id)) return
-    const response = await fetch(`${GITCOIN_API_GRANTS_V1}/${id}`)
+    const response = await fetch(`${GITCOIN_API_GRANTS_V1}${id}/`)
     const { grants } = (await response.json()) as {
         grants: GitcoinGrant
         status: number

--- a/packages/maskbook/src/plugins/ITO/UI/ClaimDialog.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/ClaimDialog.tsx
@@ -7,7 +7,7 @@ import ActionButton from '../../../extension/options-page/DashboardComponents/Ac
 import { ERC20TokenDetailed, EtherTokenDetailed, EthereumTokenType } from '../../../web3/types'
 import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControlledDialog'
 import { TransactionStateType } from '../../../web3/hooks/useTransactionState'
-import { SelectERC20TokenDialogEvent, WalletMessages, WalletRPC } from '../../Wallet/messages'
+import { SelectTokenDialogEvent, WalletMessages, WalletRPC } from '../../Wallet/messages'
 import { TokenAmountPanel } from '../../../web3/UI/TokenAmountPanel'
 import { useTokenBalance } from '../../../web3/hooks/useTokenBalance'
 import { useClaimCallback } from '../hooks/useClaimCallback'
@@ -125,10 +125,10 @@ export function ClaimDialog(props: ClaimDialogProps) {
 
     //#region select token
     const [id] = useState(uuid())
-    const [, setSelectERC20TokenDialogOpen] = useRemoteControlledDialog(
-        WalletMessages.events.selectERC20TokenDialogUpdated,
+    const [, setSelectTokenDialogOpen] = useRemoteControlledDialog(
+        WalletMessages.events.selectTokenDialogUpdated,
         useCallback(
-            (ev: SelectERC20TokenDialogEvent) => {
+            (ev: SelectTokenDialogEvent) => {
                 if (ev.open || !ev.token || ev.uuid !== id) return
                 const at = exchangeTokens.findIndex((x) => isSameAddress(x.address, token.address))
                 const ratio = new BigNumber(payload.exchange_amounts[at * 2]).dividedBy(
@@ -152,7 +152,7 @@ export function ClaimDialog(props: ClaimDialogProps) {
         ),
     )
     const onSelectTokenChipClick = useCallback(() => {
-        setSelectERC20TokenDialogOpen({
+        setSelectTokenDialogOpen({
             open: true,
             uuid: id,
             disableEther: !exchangeTokens.some((x) => isETH(x.address)),

--- a/packages/maskbook/src/plugins/ITO/UI/ExchangeTokenPanel.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/ExchangeTokenPanel.tsx
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid'
 import { useCallback, useEffect, useState } from 'react'
 import { makeStyles, createStyles, Paper, IconButton } from '@material-ui/core'
 import AddIcon from '@material-ui/icons/AddOutlined'
@@ -7,11 +8,10 @@ import { useTokenBalance } from '../../../web3/hooks/useTokenBalance'
 import { useConstant } from '../../../web3/hooks/useConstant'
 import { ERC20TokenDetailed, EthereumTokenType, EtherTokenDetailed } from '../../../web3/types'
 import { TokenAmountPanel } from '../../../web3/UI/TokenAmountPanel'
-import { useChainId } from '../../../web3/hooks/useChainState'
 import type { TokenAmountPanelProps } from '../../../web3/UI/TokenAmountPanel'
-import { ITO_CONSTANTS } from '../constants'
 import { CONSTANTS } from '../../../web3/constants'
-import { SelectERC20TokenDialog } from '../../Ethereum/UI/SelectERC20TokenDialog'
+import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControlledDialog'
+import { WalletMessages, SelectERC20TokenDialogEvent } from '../../Wallet/messages'
 
 const useStyles = makeStyles((theme) =>
     createStyles({
@@ -82,22 +82,29 @@ export function ExchangeTokenPanel(props: ExchangetokenPanelProps) {
 
     const classes = useStyles()
 
-    //#region select token
-    const [openSelectERC20TokenDialog, setOpenSelectERC20TokenDialog] = useState(false)
-    const onTokenChipClick = useCallback(() => {
-        setOpenSelectERC20TokenDialog(true)
-    }, [])
-    const onSelectERC20TokenDialogClose = useCallback(() => {
-        setOpenSelectERC20TokenDialog(false)
-    }, [])
-    const onSelectERC20TokenDialogSubmit = useCallback(
-        (token: EtherTokenDetailed | ERC20TokenDetailed) => {
-            onExchangeTokenChange(token, dataIndex)
-            onSelectERC20TokenDialogClose()
-        },
-        [dataIndex, onExchangeTokenChange, onSelectERC20TokenDialogClose],
+    //#region select token dialog
+    const [id] = useState(uuid())
+    const [, setSelectERC20TokenDialogOpen] = useRemoteControlledDialog(
+        WalletMessages.events.selectERC20TokenDialogUpdated,
+        useCallback(
+            (ev: SelectERC20TokenDialogEvent) => {
+                if (ev.open || !ev.token || ev.uuid !== id) return
+                onExchangeTokenChange(ev.token, dataIndex)
+            },
+            [id, dataIndex],
+        ),
     )
-
+    const onSelectTokenChipClick = useCallback(() => {
+        setSelectERC20TokenDialogOpen({
+            open: true,
+            uuid: id,
+            disableEther: !isSell,
+            FixedTokenListProps: {
+                blacklist: excludeTokensAddress,
+                selectedTokens: [exchangeToken?.address ?? '', ...selectedTokensAddress],
+            },
+        })
+    }, [id, isSell, exchangeToken, excludeTokensAddress.sort().join(), selectedTokensAddress.sort().join()])
     //#endregion
 
     //#region balance
@@ -123,46 +130,36 @@ export function ExchangeTokenPanel(props: ExchangetokenPanelProps) {
     const ETH_ADDRESS = useConstant(CONSTANTS, 'ETH_ADDRESS')
 
     return (
-        <>
-            <Paper className={classes.line}>
-                <TokenAmountPanel
-                    classes={{ root: classes.input }}
-                    label={label}
-                    amount={inputAmountForUI}
-                    disableBalance={disableBalance}
-                    balance={disableBalance || loadingTokenBalance ? '0' : tokenBalance}
-                    token={exchangeToken}
-                    onAmountChange={onAmountChangeForUI}
-                    SelectTokenChip={{
-                        loading: false,
-                        ChipProps: {
-                            onClick: onTokenChipClick,
-                        },
-                    }}
-                    TextFieldProps={{
-                        disabled: !exchangeToken,
-                    }}
-                    {...props.TokenAmountPanelProps}
-                />
-                {showAdd ? (
-                    <IconButton onClick={onAdd} className={classes.button}>
-                        <AddIcon color="primary" />
-                    </IconButton>
-                ) : null}
-                {showRemove ? (
-                    <IconButton onClick={onRemove} className={classes.button}>
-                        <RemoveIcon color="secondary" />
-                    </IconButton>
-                ) : null}
-            </Paper>
-            <SelectERC20TokenDialog
-                open={openSelectERC20TokenDialog}
-                includeTokens={[]}
-                excludeTokens={isSell ? [ETH_ADDRESS, ...excludeTokensAddress] : excludeTokensAddress}
-                selectedTokens={[exchangeToken?.address ?? '', ...selectedTokensAddress]}
-                onSubmit={onSelectERC20TokenDialogSubmit}
-                onClose={onSelectERC20TokenDialogClose}
+        <Paper className={classes.line}>
+            <TokenAmountPanel
+                classes={{ root: classes.input }}
+                label={label}
+                amount={inputAmountForUI}
+                disableBalance={disableBalance}
+                balance={disableBalance || loadingTokenBalance ? '0' : tokenBalance}
+                token={exchangeToken}
+                onAmountChange={onAmountChangeForUI}
+                SelectTokenChip={{
+                    loading: false,
+                    ChipProps: {
+                        onClick: onSelectTokenChipClick,
+                    },
+                }}
+                TextFieldProps={{
+                    disabled: !exchangeToken,
+                }}
+                {...props.TokenAmountPanelProps}
             />
-        </>
+            {showAdd ? (
+                <IconButton onClick={onAdd} className={classes.button}>
+                    <AddIcon color="primary" />
+                </IconButton>
+            ) : null}
+            {showRemove ? (
+                <IconButton onClick={onRemove} className={classes.button}>
+                    <RemoveIcon color="secondary" />
+                </IconButton>
+            ) : null}
+        </Paper>
     )
 }

--- a/packages/maskbook/src/plugins/ITO/UI/ExchangeTokenPanel.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/ExchangeTokenPanel.tsx
@@ -11,7 +11,7 @@ import { TokenAmountPanel } from '../../../web3/UI/TokenAmountPanel'
 import type { TokenAmountPanelProps } from '../../../web3/UI/TokenAmountPanel'
 import { CONSTANTS } from '../../../web3/constants'
 import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControlledDialog'
-import { WalletMessages, SelectERC20TokenDialogEvent } from '../../Wallet/messages'
+import { WalletMessages, SelectTokenDialogEvent } from '../../Wallet/messages'
 
 const useStyles = makeStyles((theme) =>
     createStyles({
@@ -84,10 +84,10 @@ export function ExchangeTokenPanel(props: ExchangetokenPanelProps) {
 
     //#region select token dialog
     const [id] = useState(uuid())
-    const [, setSelectERC20TokenDialogOpen] = useRemoteControlledDialog(
-        WalletMessages.events.selectERC20TokenDialogUpdated,
+    const [, setSelectTokenDialogOpen] = useRemoteControlledDialog(
+        WalletMessages.events.selectTokenDialogUpdated,
         useCallback(
-            (ev: SelectERC20TokenDialogEvent) => {
+            (ev: SelectTokenDialogEvent) => {
                 if (ev.open || !ev.token || ev.uuid !== id) return
                 onExchangeTokenChange(ev.token, dataIndex)
             },
@@ -95,7 +95,7 @@ export function ExchangeTokenPanel(props: ExchangetokenPanelProps) {
         ),
     )
     const onSelectTokenChipClick = useCallback(() => {
-        setSelectERC20TokenDialogOpen({
+        setSelectTokenDialogOpen({
             open: true,
             uuid: id,
             disableEther: !isSell,

--- a/packages/maskbook/src/plugins/RedPacket/UI/RedPacketForm.tsx
+++ b/packages/maskbook/src/plugins/RedPacket/UI/RedPacketForm.tsx
@@ -34,12 +34,12 @@ import ActionButton from '../../../extension/options-page/DashboardComponents/Ac
 import { TransactionStateType } from '../../../web3/hooks/useTransactionState'
 import type { RedPacketJSONPayload } from '../types'
 import { resolveChainName } from '../../../web3/pipes'
-import { SelectERC20TokenDialogEvent, WalletMessages } from '../../Wallet/messages'
+import { SelectTokenDialogEvent, WalletMessages } from '../../Wallet/messages'
 import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControlledDialog'
 import { useEtherTokenDetailed } from '../../../web3/hooks/useEtherTokenDetailed'
 import { useTokenBalance } from '../../../web3/hooks/useTokenBalance'
 import { EthereumMessages } from '../../Ethereum/messages'
-import { SelectERC20TokenDialog } from '../../Ethereum/UI/SelectERC20TokenDialog'
+import { SelectTokenDialog } from '../../Ethereum/UI/SelectTokenDialog'
 
 const useStyles = makeStyles((theme) =>
     createStyles({
@@ -85,10 +85,10 @@ export function RedPacketForm(props: RedPacketFormProps) {
     const { value: etherTokenDetailed } = useEtherTokenDetailed()
     const [token = etherTokenDetailed, setToken] = useState<EtherTokenDetailed | ERC20TokenDetailed | undefined>()
     const [id] = useState(uuid())
-    const [, setOpenSelectERC20TokenDialog] = useRemoteControlledDialog(
-        WalletMessages.events.selectERC20TokenDialogUpdated,
+    const [, setSelectTokenDialogOpen] = useRemoteControlledDialog(
+        WalletMessages.events.selectTokenDialogUpdated,
         useCallback(
-            (ev: SelectERC20TokenDialogEvent) => {
+            (ev: SelectTokenDialogEvent) => {
                 if (ev.open || !ev.token || ev.uuid !== id) return
                 setToken(ev.token)
             },
@@ -96,7 +96,7 @@ export function RedPacketForm(props: RedPacketFormProps) {
         ),
     )
     const onSelectTokenChipClick = useCallback(() => {
-        setOpenSelectERC20TokenDialog({
+        setSelectTokenDialogOpen({
             open: true,
             uuid: id,
             disableEther: false,

--- a/packages/maskbook/src/plugins/RedPacket/UI/RedPacketForm.tsx
+++ b/packages/maskbook/src/plugins/RedPacket/UI/RedPacketForm.tsx
@@ -34,7 +34,7 @@ import ActionButton from '../../../extension/options-page/DashboardComponents/Ac
 import { TransactionStateType } from '../../../web3/hooks/useTransactionState'
 import type { RedPacketJSONPayload } from '../types'
 import { resolveChainName } from '../../../web3/pipes'
-import { WalletMessages } from '../../Wallet/messages'
+import { SelectERC20TokenDialogEvent, WalletMessages } from '../../Wallet/messages'
 import { useRemoteControlledDialog } from '../../../utils/hooks/useRemoteControlledDialog'
 import { useEtherTokenDetailed } from '../../../web3/hooks/useEtherTokenDetailed'
 import { useTokenBalance } from '../../../web3/hooks/useTokenBalance'
@@ -84,20 +84,27 @@ export function RedPacketForm(props: RedPacketFormProps) {
     //#region select token
     const { value: etherTokenDetailed } = useEtherTokenDetailed()
     const [token = etherTokenDetailed, setToken] = useState<EtherTokenDetailed | ERC20TokenDetailed | undefined>()
-    const [openSelectERC20TokenDialog, setOpenSelectERC20TokenDialog] = useState(false)
-    const onTokenChipClick = useCallback(() => {
-        setOpenSelectERC20TokenDialog(true)
-    }, [])
-    const onSelectERC20TokenDialogClose = useCallback(() => {
-        setOpenSelectERC20TokenDialog(false)
-    }, [])
-    const onSelectERC20TokenDialogSubmit = useCallback(
-        (token: EtherTokenDetailed | ERC20TokenDetailed) => {
-            setToken(token)
-            onSelectERC20TokenDialogClose()
-        },
-        [onSelectERC20TokenDialogClose],
+    const [id] = useState(uuid())
+    const [, setOpenSelectERC20TokenDialog] = useRemoteControlledDialog(
+        WalletMessages.events.selectERC20TokenDialogUpdated,
+        useCallback(
+            (ev: SelectERC20TokenDialogEvent) => {
+                if (ev.open || !ev.token || ev.uuid !== id) return
+                setToken(ev.token)
+            },
+            [id],
+        ),
     )
+    const onSelectTokenChipClick = useCallback(() => {
+        setOpenSelectERC20TokenDialog({
+            open: true,
+            uuid: id,
+            disableEther: false,
+            FixedTokenListProps: {
+                selectedTokens: token ? [token.address] : [],
+            },
+        })
+    }, [id, token?.address])
     //#endregion
 
     //#region packet settings
@@ -131,6 +138,7 @@ export function RedPacketForm(props: RedPacketFormProps) {
         token?.address ?? '',
     )
     //#endregion
+
     //#region approve ERC20
     const HappyRedPacketContractAddress = useConstant(RED_PACKET_CONSTANTS, 'HAPPY_RED_PACKET_ADDRESS')
     const [approveState, approveCallback] = useERC20TokenApproveCallback(
@@ -159,7 +167,6 @@ export function RedPacketForm(props: RedPacketFormProps) {
     //#endregion
 
     //#region remote controlled transaction dialog
-    // close the transaction dialog
     const [_, setTransactionDialogOpen] = useRemoteControlledDialog(
         EthereumMessages.events.transactionDialogUpdated,
         (ev) => {
@@ -297,7 +304,7 @@ export function RedPacketForm(props: RedPacketFormProps) {
                     SelectTokenChip={{
                         loading: loadingTokenBalance,
                         ChipProps: {
-                            onClick: onTokenChipClick,
+                            onClick: onSelectTokenChipClick,
                         },
                     }}
                 />
@@ -341,14 +348,6 @@ export function RedPacketForm(props: RedPacketFormProps) {
                     {`Send ${formatBalance(totalAmount, token.decimals ?? 0)} ${token.symbol}`}
                 </ActionButton>
             )}
-            <SelectERC20TokenDialog
-                open={openSelectERC20TokenDialog}
-                includeTokens={[]}
-                excludeTokens={[token.address]}
-                selectedTokens={[]}
-                onSubmit={onSelectERC20TokenDialogSubmit}
-                onClose={onSelectERC20TokenDialogClose}
-            />
         </>
     )
 }

--- a/packages/maskbook/src/plugins/Trader/UI/trader/Trader.tsx
+++ b/packages/maskbook/src/plugins/Trader/UI/trader/Trader.tsx
@@ -27,11 +27,11 @@ import { useTradeStateComputed } from '../../trader/useTradeStateComputed'
 import { useTokenBalance } from '../../../../web3/hooks/useTokenBalance'
 import { getActivatedUI } from '../../../../social-network/ui'
 import { EthereumMessages } from '../../../Ethereum/messages'
-import { SelectERC20TokenDialog } from '../../../Ethereum/UI/SelectERC20TokenDialog'
+import { SelectTokenDialog } from '../../../Ethereum/UI/SelectTokenDialog'
 import { EthereumBlockNumber } from '../../../../web3/UI/EthereumBlockNumber'
 import Services from '../../../../extension/service'
 import { useAsyncRetry, useTimeoutFn } from 'react-use'
-import { SelectERC20TokenDialogEvent, WalletMessages } from '../../../Wallet/messages'
+import { SelectTokenDialogEvent, WalletMessages } from '../../../Wallet/messages'
 
 const useStyles = makeStyles((theme) => {
     return createStyles({
@@ -166,10 +166,10 @@ export function Trader(props: TraderProps) {
     //#region select token
     const excludeTokens = [inputToken, outputToken].filter(Boolean).map((x) => x?.address) as string[]
     const [focusedTokenPanelType, setFocusedTokenPanelType] = useState(TokenPanelType.Input)
-    const [, setOpenSelectERC20TokenDialog] = useRemoteControlledDialog(
-        WalletMessages.events.selectERC20TokenDialogUpdated,
+    const [, setSelectTokenDialogOpen] = useRemoteControlledDialog(
+        WalletMessages.events.selectTokenDialogUpdated,
         useCallback(
-            (ev: SelectERC20TokenDialogEvent) => {
+            (ev: SelectTokenDialogEvent) => {
                 if (ev.open || !ev.token || ev.uuid !== String(focusedTokenPanelType)) return
                 dispatchTradeStore({
                     type:
@@ -185,7 +185,7 @@ export function Trader(props: TraderProps) {
     const onTokenChipClick = useCallback(
         (type: TokenPanelType) => {
             setFocusedTokenPanelType(type)
-            setOpenSelectERC20TokenDialog({
+            setSelectTokenDialogOpen({
                 open: true,
                 uuid: String(type),
                 disableEther: false,

--- a/packages/maskbook/src/plugins/Wallet/define.tsx
+++ b/packages/maskbook/src/plugins/Wallet/define.tsx
@@ -1,3 +1,4 @@
+import { SelectERC20TokenDialog } from '../Ethereum/UI/SelectERC20TokenDialog'
 import { PluginConfig, PluginStage, PluginScope } from '../types'
 import { PLUGIN_IDENTIFIER } from './constants'
 import { SelectProviderDialog } from './UI/SelectProviderDialog'
@@ -15,6 +16,7 @@ export const WalletPluginDefine: PluginConfig = {
             <>
                 <SelectWalletDialog />
                 <SelectProviderDialog />
+                <SelectERC20TokenDialog />
                 <WalletStatusDialog />
                 <WalletConnectQRCodeDialog />
             </>
@@ -25,6 +27,7 @@ export const WalletPluginDefine: PluginConfig = {
             <>
                 <SelectWalletDialog />
                 <SelectProviderDialog />
+                <SelectERC20TokenDialog />
                 <WalletStatusDialog />
                 <WalletConnectQRCodeDialog />
             </>

--- a/packages/maskbook/src/plugins/Wallet/define.tsx
+++ b/packages/maskbook/src/plugins/Wallet/define.tsx
@@ -1,4 +1,4 @@
-import { SelectERC20TokenDialog } from '../Ethereum/UI/SelectERC20TokenDialog'
+import { SelectTokenDialog } from '../Ethereum/UI/SelectTokenDialog'
 import { PluginConfig, PluginStage, PluginScope } from '../types'
 import { PLUGIN_IDENTIFIER } from './constants'
 import { SelectProviderDialog } from './UI/SelectProviderDialog'
@@ -16,7 +16,7 @@ export const WalletPluginDefine: PluginConfig = {
             <>
                 <SelectWalletDialog />
                 <SelectProviderDialog />
-                <SelectERC20TokenDialog />
+                <SelectTokenDialog />
                 <WalletStatusDialog />
                 <WalletConnectQRCodeDialog />
             </>
@@ -27,7 +27,7 @@ export const WalletPluginDefine: PluginConfig = {
             <>
                 <SelectWalletDialog />
                 <SelectProviderDialog />
-                <SelectERC20TokenDialog />
+                <SelectTokenDialog />
                 <WalletStatusDialog />
                 <WalletConnectQRCodeDialog />
             </>

--- a/packages/maskbook/src/plugins/Wallet/messages.ts
+++ b/packages/maskbook/src/plugins/Wallet/messages.ts
@@ -1,3 +1,4 @@
+import type { FixedTokenListProps } from '../../extension/options-page/DashboardComponents/FixedTokenList'
 import type { ERC20TokenDetailed, EtherTokenDetailed } from '../../web3/types'
 import { createPluginMessage } from '../utils/createPluginMessage'
 import { createPluginRPC } from '../utils/createPluginRPC'
@@ -36,28 +37,9 @@ type WalletConnectQRCodeDialogEvent =
 type SelectERC20TOkenDialogEvent =
     | {
           open: true
-
-          /**
-           * Specific an array of detailed tokens that must be included in the final token list.
-           */
-          tokens?: (EtherTokenDetailed | ERC20TokenDetailed)[]
-
-          /**
-           *  Specific an array of token that only be included in the final token list.
-           */
-          whitelist?: string[]
-
-          /**
-           * Specific an array of token that must be excluded in the final token list.
-           */
-          backlist?: string[]
-
-          /**
-           * Specific an array of token address that selected in the final token list.
-           */
-          selectedTokens?: string[]
-
+          disableEther?: boolean
           disableSearchBar?: boolean
+          FixedTokenListProps?: Omit<FixedTokenListProps, 'onSubmit'>
       }
     | {
           open: false

--- a/packages/maskbook/src/plugins/Wallet/messages.ts
+++ b/packages/maskbook/src/plugins/Wallet/messages.ts
@@ -30,7 +30,7 @@ export type WalletConnectQRCodeDialogEvent =
           open: false
       }
 
-export type SelectERC20TokenDialogEvent =
+export type SelectTokenDialogEvent =
     | {
           open: true
           uuid: string
@@ -65,9 +65,9 @@ interface WalletMessage {
     walletStatusDialogUpdated: WalletStatusDialogEvent
 
     /**
-     * Select ERC20 token dialog
+     * Select token dialog
      */
-    selectERC20TokenDialogUpdated: SelectERC20TokenDialogEvent
+    selectTokenDialogUpdated: SelectTokenDialogEvent
 
     /**
      * WalletConnect QR Code dialog

--- a/packages/maskbook/src/plugins/Wallet/messages.ts
+++ b/packages/maskbook/src/plugins/Wallet/messages.ts
@@ -4,7 +4,7 @@ import { createPluginMessage } from '../utils/createPluginMessage'
 import { createPluginRPC } from '../utils/createPluginRPC'
 import { PLUGIN_IDENTIFIER } from './constants'
 
-type SelectProviderDialogEvent =
+export type SelectProviderDialogEvent =
     | {
           open: true
       }
@@ -13,19 +13,15 @@ type SelectProviderDialogEvent =
           address?: string
       }
 
-type SelectWalletDialogEvent =
-    | {
-          open: true
-      }
-    | {
-          open: false
-      }
-
-type WalletStatusDialogEvent = {
+export type SelectWalletDialogEvent = {
     open: boolean
 }
 
-type WalletConnectQRCodeDialogEvent =
+export type WalletStatusDialogEvent = {
+    open: boolean
+}
+
+export type WalletConnectQRCodeDialogEvent =
     | {
           open: true
           uri: string
@@ -34,15 +30,17 @@ type WalletConnectQRCodeDialogEvent =
           open: false
       }
 
-type SelectERC20TOkenDialogEvent =
+export type SelectERC20TokenDialogEvent =
     | {
           open: true
+          uuid: string
           disableEther?: boolean
           disableSearchBar?: boolean
           FixedTokenListProps?: Omit<FixedTokenListProps, 'onSubmit'>
       }
     | {
           open: false
+          uuid: string
 
           /**
            * The selected detailed token.
@@ -69,7 +67,7 @@ interface WalletMessage {
     /**
      * Select ERC20 token dialog
      */
-    selectERC20TokenDialogUpdated: SelectERC20TOkenDialogEvent
+    selectERC20TokenDialogUpdated: SelectERC20TokenDialogEvent
 
     /**
      * WalletConnect QR Code dialog

--- a/packages/maskbook/src/plugins/Wallet/messages.ts
+++ b/packages/maskbook/src/plugins/Wallet/messages.ts
@@ -1,3 +1,4 @@
+import type { ERC20TokenDetailed, EtherTokenDetailed } from '../../web3/types'
 import { createPluginMessage } from '../utils/createPluginMessage'
 import { createPluginRPC } from '../utils/createPluginRPC'
 import { PLUGIN_IDENTIFIER } from './constants'
@@ -32,6 +33,41 @@ type WalletConnectQRCodeDialogEvent =
           open: false
       }
 
+type SelectERC20TOkenDialogEvent =
+    | {
+          open: true
+
+          /**
+           * Specific an array of detailed tokens that must be included in the final token list.
+           */
+          tokens?: (EtherTokenDetailed | ERC20TokenDetailed)[]
+
+          /**
+           *  Specific an array of token that only be included in the final token list.
+           */
+          whitelist?: string[]
+
+          /**
+           * Specific an array of token that must be excluded in the final token list.
+           */
+          backlist?: string[]
+
+          /**
+           * Specific an array of token address that selected in the final token list.
+           */
+          selectedTokens?: string[]
+
+          disableSearchBar?: boolean
+      }
+    | {
+          open: false
+
+          /**
+           * The selected detailed token.
+           */
+          token?: EtherTokenDetailed | ERC20TokenDetailed
+      }
+
 interface WalletMessage {
     /**
      * Select wallet dialog
@@ -49,15 +85,20 @@ interface WalletMessage {
     walletStatusDialogUpdated: WalletStatusDialogEvent
 
     /**
+     * Select ERC20 token dialog
+     */
+    selectERC20TokenDialogUpdated: SelectERC20TOkenDialogEvent
+
+    /**
      * WalletConnect QR Code dialog
      */
     walletConnectQRCodeDialogUpdated: WalletConnectQRCodeDialogEvent
 
     walletsUpdated: void
-
     tokensUpdated: void
     rpc: unknown
 }
+
 if (module.hot) module.hot.accept()
 export const WalletMessages = createPluginMessage<WalletMessage>(PLUGIN_IDENTIFIER)
 export const WalletRPC = createPluginRPC(PLUGIN_IDENTIFIER, () => import('./services'), WalletMessages.events.rpc)

--- a/packages/maskbook/src/web3/UI/EthereumERC20TokenApprovedBoundary.tsx
+++ b/packages/maskbook/src/web3/UI/EthereumERC20TokenApprovedBoundary.tsx
@@ -50,17 +50,17 @@ export function EthereumERC20TokenApprovedBoundary(props: EthereumERC20TokenAppr
     }, [transactionState.type, enqueueSnackbar])
 
     // not a valid erc20 token, please given token as undefined
-    if (!token) return <Grid xs={12}>{children}</Grid>
+    if (!token) return <Grid container>{children}</Grid>
 
     if (approveState === ApproveState.UNKNOWN)
         return (
-            <Grid xs={12}>
+            <Grid container>
                 <ActionButton className={classes.button} fullWidth variant="contained" size="large" loading disabled />
             </Grid>
         )
     if (approveState === ApproveState.FAILED)
         return (
-            <Grid xs={12}>
+            <Grid container>
                 <ActionButton
                     className={classes.button}
                     fullWidth
@@ -73,7 +73,7 @@ export function EthereumERC20TokenApprovedBoundary(props: EthereumERC20TokenAppr
         )
     if (approveState === ApproveState.INSUFFICIENT_BALANCE)
         return (
-            <Grid xs={12}>
+            <Grid container>
                 <ActionButton className={classes.button} fullWidth variant="contained" size="large" disabled>
                     {`Insufficent ${token.symbol ?? token.name ?? 'Token'} Balance`}
                 </ActionButton>
@@ -109,13 +109,13 @@ export function EthereumERC20TokenApprovedBoundary(props: EthereumERC20TokenAppr
         )
     if (approveState === ApproveState.PENDING || approveState === ApproveState.UPDATING)
         return (
-            <Grid xs={12}>
+            <Grid container>
                 <ActionButton className={classes.button} fullWidth variant="contained" size="large" disabled>
                     {`${approveState === ApproveState.PENDING ? 'Unlocking' : 'Updating'} ${token.symbol ?? 'Token'}…`}
                 </ActionButton>
             </Grid>
         )
-    if (approveState === ApproveState.APPROVED) return <Grid xs={12}>{children}</Grid>
+    if (approveState === ApproveState.APPROVED) return <Grid container>{children}</Grid>
 
     unreachable(approveState)
 }

--- a/packages/maskbook/src/web3/UI/EthereumWalletConnectedBoundary.tsx
+++ b/packages/maskbook/src/web3/UI/EthereumWalletConnectedBoundary.tsx
@@ -37,7 +37,7 @@ export function EthereumWalletConnectedBoundary(props: EthereumWalletConnectedBo
 
     if (!account)
         return (
-            <Grid xs={12}>
+            <Grid container>
                 <ActionButton className={classes.button} fullWidth variant="contained" size="large" onClick={onConnect}>
                     {t('plugin_wallet_connect_a_wallet')}
                 </ActionButton>
@@ -45,11 +45,11 @@ export function EthereumWalletConnectedBoundary(props: EthereumWalletConnectedBo
         )
     if (!chainIdValid)
         return (
-            <Grid xs={12}>
+            <Grid container>
                 <ActionButton className={classes.button} disabled fullWidth variant="contained" size="large">
                     {t('plugin_wallet_invalid_network')}
                 </ActionButton>
             </Grid>
         )
-    return <Grid xs={12}>{children}</Grid>
+    return <Grid container>{children}</Grid>
 }


### PR DESCRIPTION
## Usage

```ts
const [, setOpenSelectERC20TokenDialog] = useRemoteControlledDialog(WalletMessages.events.selectERC20TokenDialogUpdated, useCallback((ev) => {
    if (ev.open || !ev.token) return
    // the user has already selected a token from the built-in token list.
}, []))

const onTokenChipClick = useCallback(() => {
    // the user clicked the token selector chip
}, [])
```