### PR TITLE
fix: mm locked state workaround

### DIFF
--- a/packages/maskbook/package.json
+++ b/packages/maskbook/package.json
@@ -10,7 +10,7 @@
     "@dimensiondev/maskbook-shared": "*",
     "@dimensiondev/maskbook-theme": "*",
     "@dimensiondev/matrix-js-sdk-type": "=1.0.0-20200731085604-dc2de92",
-    "@dimensiondev/metamask-extension-provider": "^3.0.0-20210125122006-86e9bae",
+    "@dimensiondev/metamask-extension-provider": "^3.0.2-20210215121518-716d309",
     "@dimensiondev/stego-js": "=0.11.1-20201027083223-8ab41be",
     "@ethersproject/address": "^5.0.4",
     "@ethersproject/contracts": "^5.0.4",

--- a/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
@@ -21,9 +21,10 @@ async function onAccountsChanged(accounts: string[]) {
     currentIsMetamaskLockedSettings.value = !(await provider!._metamask?.isUnlocked()) && accounts.length === 0
 }
 
-function onChainIdChanged(id: string) {
+async function onChainIdChanged(id: string) {
     // learn more: https://docs.metamask.io/guide/ethereum-provider.html#chain-ids and https://chainid.network/
     const chainId = Number.parseInt(id, 16) as ChainId
+    currentIsMetamaskLockedSettings.value = !(await provider!._metamask?.isUnlocked())
     currentMetaMaskChainIdSettings.value = chainId === 0 ? ChainId.Mainnet : chainId
 }
 

--- a/packages/maskbook/src/plugins/ITO/UI/ITO.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/ITO.tsx
@@ -29,6 +29,7 @@ import { useDestructCallback } from '../hooks/useDestructCallback'
 import { getAssetAsBlobURL } from '../../../utils/suspends/getAssetAsBlobURL'
 import { EthereumMessages } from '../../Ethereum/messages'
 import { usePoolPayload } from '../hooks/usePoolPayload'
+import Services from '../../../extension/service'
 
 export interface IconProps {
     size?: number
@@ -575,7 +576,13 @@ export function ITO_Loading() {
     )
 }
 
-function ITO_LoadingFailUI({ retryPoolPayload }: { retryPoolPayload: () => void }) {
+function ITO_LoadingFailUI({
+    retryPoolPayload,
+    isConnectMetaMask = false,
+}: {
+    retryPoolPayload: () => void
+    isConnectMetaMask?: boolean
+}) {
     const { t } = useI18N()
     const PoolBackground = getAssetAsBlobURL(new URL('../assets/pool-loading-background.jpg', import.meta.url))
     const classes = useStyles({})
@@ -585,7 +592,7 @@ function ITO_LoadingFailUI({ retryPoolPayload }: { retryPoolPayload: () => void 
             elevation={0}
             style={{ backgroundImage: `url(${PoolBackground})` }}>
             <Typography variant="body1" className={classes.loadingITO}>
-                {t('plugin_ito_loading_failed')}
+                {isConnectMetaMask ? '' : t('plugin_ito_loading_failed')}
             </Typography>
             <ActionButton
                 onClick={retryPoolPayload}
@@ -593,9 +600,18 @@ function ITO_LoadingFailUI({ retryPoolPayload }: { retryPoolPayload: () => void 
                 size="large"
                 color="primary"
                 className={classes.loadingITO_Button}>
-                {t('plugin_ito_loading_try_again')}
+                {isConnectMetaMask ? t('plugin_wallet_connect_to_metamask') : t('plugin_ito_loading_try_again')}
             </ActionButton>
         </Card>
+    )
+}
+
+export function ITO_ConnectMetaMask() {
+    return (
+        <ITO_LoadingFailUI
+            retryPoolPayload={async () => await Services.Ethereum.connectMetaMask()}
+            isConnectMetaMask={true}
+        />
     )
 }
 

--- a/packages/maskbook/src/plugins/ITO/UI/PostInspector.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/PostInspector.tsx
@@ -3,7 +3,10 @@ import { useChainId } from '../../../web3/hooks/useChainState'
 import { resolveChainName } from '../../../web3/pipes'
 import { poolPayloadErrorRetry } from '../hooks/usePoolPayload'
 import type { JSON_PayloadInMask } from '../types'
-import { ITO, ITO_LoadingFail } from './ITO'
+import { ITO, ITO_LoadingFail, ITO_ConnectMetaMask } from './ITO'
+import { currentIsMetamaskLockedSettings, currentSelectedWalletProviderSettings } from '../../Wallet/settings'
+import { useValueRef } from '../../../utils/hooks/useValueRef'
+import { ProviderType } from '../../../web3/types'
 
 export interface PostInspectorProps {
     payload: JSON_PayloadInMask
@@ -13,6 +16,11 @@ export function PostInspector(props: PostInspectorProps) {
     const { chain_id, pid, password } = props.payload
 
     const chainId = useChainId()
+    const currentSelectedWalletProvider = useValueRef(currentSelectedWalletProviderSettings)
+    const isMetamaskRedpacketLocked =
+        useValueRef(currentIsMetamaskLockedSettings) && currentSelectedWalletProvider === ProviderType.MetaMask
+
+    if (isMetamaskRedpacketLocked) return <ITO_ConnectMetaMask />
     if (chain_id !== chainId) return <Typography>Not available on {resolveChainName(chainId)}.</Typography>
 
     return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,7 +133,7 @@ importers:
       '@dimensiondev/maskbook-shared': link:../shared
       '@dimensiondev/maskbook-theme': link:../theme
       '@dimensiondev/matrix-js-sdk-type': 1.0.0-20200731085604-dc2de92
-      '@dimensiondev/metamask-extension-provider': 3.0.0-20210125122006-86e9bae
+      '@dimensiondev/metamask-extension-provider': 3.0.2-20210215121518-716d309
       '@dimensiondev/stego-js': 0.11.1-20201027083223-8ab41be
       '@ethersproject/address': 5.0.9
       '@ethersproject/contracts': 5.0.9
@@ -298,7 +298,7 @@ importers:
       '@dimensiondev/maskbook-shared': '*'
       '@dimensiondev/maskbook-theme': '*'
       '@dimensiondev/matrix-js-sdk-type': '=1.0.0-20200731085604-dc2de92'
-      '@dimensiondev/metamask-extension-provider': ^3.0.0-20210125122006-86e9bae
+      '@dimensiondev/metamask-extension-provider': ^3.0.2-20210215121518-716d309
       '@dimensiondev/stego-js': '=0.11.1-20201027083223-8ab41be'
       '@dimensiondev/webextension-shim': 0.0.3-20201120022530-b318b89
       '@ethersproject/address': ^5.0.4
@@ -2697,16 +2697,16 @@ packages:
     resolution:
       integrity: sha512-Br9l9LKKYXV1djdlfxOSknsVSzd56jNvc9StvPTv3eJfZPD7HbL3Yn+ikE34UR5Qs7Vga3EwtRIZIO77bb9I2g==
       tarball: download/@dimensiondev/matrix-js-sdk-type/1.0.0-20200731085604-dc2de92/f42145da27cab463133d09c9ffd300af2ba5785ec977872991e77cb99930b3fa
-  /@dimensiondev/metamask-extension-provider/3.0.0-20210125122006-86e9bae:
+  /@dimensiondev/metamask-extension-provider/3.0.2-20210215121518-716d309:
     dependencies:
       detect-browser: 3.0.1
       extension-port-stream: 1.0.0
-      inpage-provider-7: /@metamask/inpage-provider/7.0.0
-      inpage-provider-8: /@metamask/inpage-provider/8.0.3
+      inpage-provider-7: /@zhouhancheng/inpage-provider/7.0.1
+      inpage-provider-8: /@zhouhancheng/inpage-provider/8.0.4
     dev: false
     resolution:
-      integrity: sha512-47QS5imgwm/TQE4TrOxToPuZegsxH5fcAeZnTwAhqC/PDFha7sIb5x+/sA/NAYdYYAHpO3IVyBKRo0t+HL2XxQ==
-      tarball: download/@dimensiondev/metamask-extension-provider/3.0.0-20210125122006-86e9bae/bf24ae51e642593c39426673d7e8a1e37b2b807881507a3a0c66dc831ac5e403
+      integrity: sha512-ZnK39txNri0pZz0VcEdEyYbS56P8+ddNxP2TEAzYsmxQQ8oU19JznyDObPU2Tu+p9g9TAdVK9J3gxNH9dTKAwg==
+      tarball: download/@dimensiondev/metamask-extension-provider/3.0.2-20210215121518-716d309/acf466256678c7a493573ece5fafa96a5f1d224e4d7a718ef3d4751999257647
   /@dimensiondev/stego-js/0.11.1-20201027083223-8ab41be:
     dependencies:
       meow: 7.1.1
@@ -3913,34 +3913,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
-  /@metamask/inpage-provider/7.0.0:
-    dependencies:
-      eth-rpc-errors: 2.1.1
-      fast-deep-equal: 2.0.1
-      is-stream: 2.0.0
-      json-rpc-engine: 5.4.0
-      json-rpc-middleware-stream: 2.1.1
-      obj-multiplex: 1.0.0
-      obs-store: 4.0.3
-      pump: 3.0.0
-      safe-event-emitter: 1.0.1
-    deprecated: The MetaMask wallet applications only support ^8.0.0
-    dev: false
-    resolution:
-      integrity: sha512-5hR9FOwGCv6WTehWdV71M/LrPXUemn/CdlD18M96t03t/sfHP96dTtv0xV3fTO1N1RLhRNIDzowkDWYpKlb5VA==
-  /@metamask/inpage-provider/8.0.3:
-    dependencies:
-      '@metamask/object-multiplex': 1.1.0
-      '@metamask/safe-event-emitter': 2.0.0
-      eth-rpc-errors: 4.0.2
-      fast-deep-equal: 2.0.1
-      is-stream: 2.0.0
-      json-rpc-engine: 6.1.0
-      json-rpc-middleware-stream: 3.0.0
-      pump: 3.0.0
-    dev: false
-    resolution:
-      integrity: sha512-pj9tGNoS1edohuRJzxOuILRqRrQTdgu5mJwMwa9wuOZIMQLFZtr3g2T6vayPBwoNkE1FzLhs/osUqaVQDRfDvQ==
   /@metamask/object-multiplex/1.1.0:
     dependencies:
       end-of-stream: 1.4.4
@@ -7437,6 +7409,33 @@ packages:
     dev: true
     resolution:
       integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+  /@zhouhancheng/inpage-provider/7.0.1:
+    dependencies:
+      eth-rpc-errors: 2.1.1
+      fast-deep-equal: 2.0.1
+      is-stream: 2.0.0
+      json-rpc-engine: 6.1.0
+      json-rpc-middleware-stream: 2.1.1
+      obj-multiplex: 1.0.0
+      obs-store: 4.0.3
+      pump: 3.0.0
+      safe-event-emitter: 1.0.1
+    dev: false
+    resolution:
+      integrity: sha512-Z3pnoFwO/CIWWPzrsYofFjPiK2q3lTbgqMpJ6/uAq7EkH4noTgCbIZWJbPFKktbxf0TMKB36+RT6npfnlEnBow==
+  /@zhouhancheng/inpage-provider/8.0.4:
+    dependencies:
+      '@metamask/object-multiplex': 1.1.0
+      '@metamask/safe-event-emitter': 2.0.0
+      eth-rpc-errors: 4.0.2
+      fast-deep-equal: 2.0.1
+      is-stream: 2.0.0
+      json-rpc-engine: 6.1.0
+      json-rpc-middleware-stream: 3.0.0
+      pump: 3.0.0
+    dev: false
+    resolution:
+      integrity: sha512-Stw47QFos4RaEjep2J84xFvi2GVmKCQbweLQwdAIRIi5x7lSmQ7RI3T2pci1fFblcaqaWmauK3C59ZFdexc99w==
   /JSONSelect/0.2.1:
     dev: true
     engines:
@@ -12267,12 +12266,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MY3zAa5ZF8hvgQu1HOF9agaK5GgigBRGpTJ8H0oVlE0NqMu13CW6syyjLXdeIDCGQTbUeHliU1z9dVmvMKx1Tg==
-  /eth-rpc-errors/3.0.0:
-    dependencies:
-      fast-safe-stringify: 2.0.7
-    dev: false
-    resolution:
-      integrity: sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==
   /eth-rpc-errors/4.0.2:
     dependencies:
       fast-safe-stringify: 2.0.7
@@ -16334,13 +16327,6 @@ packages:
   /json-parse-even-better-errors/2.3.1:
     resolution:
       integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-  /json-rpc-engine/5.4.0:
-    dependencies:
-      eth-rpc-errors: 3.0.0
-      safe-event-emitter: 1.0.1
-    dev: false
-    resolution:
-      integrity: sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==
   /json-rpc-engine/6.1.0:
     dependencies:
       '@metamask/safe-event-emitter': 2.0.0


### PR DESCRIPTION
Issue: https://github.com/MetaMask/metamask-extension/issues/10368

`inpage-provider` pkg workaround: https://github.com/DimensionDev/extension-provider/pull/5

Fix the issue that when metamask has locked, but ITO still shown, which leads to errors in the further using:

<img src="https://user-images.githubusercontent.com/63733714/107947940-1e771980-6fce-11eb-90b4-deb64567c01e.png" width=700 />

Now with https://github.com/DimensionDev/extension-provider/pull/5, we can detect the lock event. unlock event still can't be detected, but it's almost okay since ITO displays as below image as soon as lock happens(whether manually or automatically lock), click the button to connect the metamask and the following unlock event can be detected, because `Services.Ethereum.connectMetaMask()` creates a new provider first:

<img src="https://user-images.githubusercontent.com/63733714/107948666-1f5c7b00-6fcf-11eb-9368-6f429e2dbc73.png" width=600 />






