### PR TITLE
fix: when parsing an url string without a valid protocol, prepend a 'https://'

### DIFF
--- a/packages/maskbook/src/plugins/NFT/utils.ts
+++ b/packages/maskbook/src/plugins/NFT/utils.ts
@@ -16,8 +16,11 @@ function checkUrl(url: URL): boolean {
 
 export function getRelevantUrl(textContent: string): URL | null {
     const urls = parseURL(textContent)
+    const protocol = "https://"
     for (let url of urls) {
-        let _url = new URL(url)
+        // url may not include protocol, but URL(url) always requires an url string with protocol
+        let urlWithProtocol = url.startsWith(protocol) ? url : protocol + url
+        let _url = new URL(urlWithProtocol)
         if (checkUrl(_url)) return _url
     }
     return null

--- a/packages/maskbook/src/plugins/NFT/utils.ts
+++ b/packages/maskbook/src/plugins/NFT/utils.ts
@@ -16,7 +16,7 @@ function checkUrl(url: URL): boolean {
 
 export function getRelevantUrl(textContent: string): URL | null {
     const urls = parseURL(textContent)
-    const protocol = "https://"
+    const protocol = 'https://'
     for (let url of urls) {
         // url may not include protocol, but URL(url) always requires an url string with protocol
         let urlWithProtocol = url.startsWith(protocol) ? url : protocol + url

--- a/packages/maskbook/src/utils/flags.ts
+++ b/packages/maskbook/src/utils/flags.ts
@@ -27,7 +27,7 @@ export const Flags = {
     has_native_welcome_ui: appOnly,
     /** Firefox has a special API that can inject to the document with a higher permission. */
     requires_injected_script_run_directly: process.env.target === 'firefox',
-    support_eth_network_switch: betaOrInsiderOnly,
+    support_eth_network_switch: true,
     //#region Experimental features
     image_payload_marked_as_beta: appOnly,
     /** Prohibit the use of test networks in production */

--- a/packages/maskbook/src/utils/flags.ts
+++ b/packages/maskbook/src/utils/flags.ts
@@ -27,7 +27,7 @@ export const Flags = {
     has_native_welcome_ui: appOnly,
     /** Firefox has a special API that can inject to the document with a higher permission. */
     requires_injected_script_run_directly: process.env.target === 'firefox',
-    support_eth_network_switch: true,
+    support_eth_network_switch: betaOrInsiderOnly,
     //#region Experimental features
     image_payload_marked_as_beta: appOnly,
     /** Prohibit the use of test networks in production */


### PR DESCRIPTION
fix #2399 