### PR TITLE
fix: 0x api data wrong

### DIFF
--- a/packages/maskbook/src/plugins/Trader/trader/0x/useTradeComputed.ts
+++ b/packages/maskbook/src/plugins/Trader/trader/0x/useTradeComputed.ts
@@ -12,14 +12,18 @@ export function useTradeComputed(
     return useMemo(() => {
         if (!trade) return null
         if (!inputToken || !outputToken) return null
+        const inputAmount = new BigNumber(trade.sellAmount)
+        const executionPrice = new BigNumber(trade.buyTokenToEthRate).dividedBy(
+            new BigNumber(trade.sellTokenToEthRate)
+        )
+        const outputAmount = inputAmount.multipliedBy(executionPrice).dp(0)
         return {
             strategy,
             inputToken,
             outputToken,
-            inputAmount: new BigNumber(trade.sellAmount),
-            outputAmount: new BigNumber(trade.buyAmount),
-            executionPrice: new BigNumber(trade.price),
-
+            inputAmount,
+            outputAmount,
+            executionPrice,
             fee: new BigNumber(trade.minimumProtocolFee),
             maximumSold: new BigNumber(trade.sellAmount),
             minimumReceived: new BigNumber(trade.buyAmount),

--- a/packages/maskbook/src/plugins/Trader/trader/0x/useTradeComputed.ts
+++ b/packages/maskbook/src/plugins/Trader/trader/0x/useTradeComputed.ts
@@ -13,9 +13,7 @@ export function useTradeComputed(
         if (!trade) return null
         if (!inputToken || !outputToken) return null
         const inputAmount = new BigNumber(trade.sellAmount)
-        const executionPrice = new BigNumber(trade.buyTokenToEthRate).dividedBy(
-            new BigNumber(trade.sellTokenToEthRate)
-        )
+        const executionPrice = new BigNumber(trade.buyTokenToEthRate).dividedBy(new BigNumber(trade.sellTokenToEthRate))
         const outputAmount = inputAmount.multipliedBy(executionPrice).dp(0)
         return {
             strategy,

--- a/packages/maskbook/src/plugins/Trader/trader/0x/useTradeComputed.ts
+++ b/packages/maskbook/src/plugins/Trader/trader/0x/useTradeComputed.ts
@@ -24,8 +24,7 @@ export function useTradeComputed(
             executionPrice,
             fee: new BigNumber(trade.minimumProtocolFee),
             maximumSold: new BigNumber(trade.sellAmount),
-            minimumReceived: new BigNumber(trade.buyAmount),
-
+            minimumReceived: outputAmount,
             priceImpactWithoutFee: new BigNumber(0),
 
             // not supported fields
@@ -34,7 +33,7 @@ export function useTradeComputed(
             // minimumProtocolFee
             priceImpact: new BigNumber(0),
 
-            trade_: trade,
+            trade_: { ...trade, buyAmount: outputAmount.toFixed() },
         } as TradeComputed<SwapQuoteResponse>
     }, [trade, strategy, inputToken, outputToken])
 }

--- a/packages/maskbook/src/plugins/Trader/types/0x.ts
+++ b/packages/maskbook/src/plugins/Trader/types/0x.ts
@@ -69,6 +69,8 @@ export interface SwapQuoteResponse {
     orders: SwapOrder[]
     estimatedGasTokenRefund: string
     allowanceTarget: string
+    buyTokenToEthRate: string
+    sellTokenToEthRate: string
 }
 
 export interface SwapValidationErrorResponse {


### PR DESCRIPTION
close https://github.com/DimensionDev/Maskbook/issues/2394
close https://github.com/DimensionDev/Maskbook/issues/2392

Try DAI => MUSE, when input 0.1 DAI, the price is 2.044 * 10 ** -15, when input 10 the price is 2.044 * 10 ** -13, and whatever you input 0.1 1 or 10, buyAmount is always 2044, this is obviously wrong. 

I find that `res.buyTokenToEthRate` and `res.sellTokenToEthRate` is basically a fixed number, and using it can calculate out the correct price and buyAmount which is identify as other providers.