### PR TITLE
chore: ito show button even sold out or expired

### DIFF
--- a/packages/maskbook/src/plugins/ITO/UI/ITO.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/ITO.tsx
@@ -515,9 +515,16 @@ export function ITO(props: ITO_Props) {
             </Card>
 
             <Box className={classes.actionFooter}>
-                {(total_remaining.isZero() && !isBuyer && !canWithdraw) ||
-                loadingTradeInfo ||
-                loadingAvailability ? null : !account || !chainIdValid ? (
+                {total_remaining.isZero() && !isBuyer && !canWithdraw ? (
+                    <ActionButton
+                        disabled
+                        onClick={() => undefined}
+                        variant="contained"
+                        size="large"
+                        className={classes.actionButton}>
+                        {t('plugin_ito_status_out_of_stock')}
+                    </ActionButton>
+                ) : loadingTradeInfo || loadingAvailability ? null : !account || !chainIdValid ? (
                     <ActionButton onClick={onConnect} variant="contained" size="large" className={classes.actionButton}>
                         {t('plugin_wallet_connect_a_wallet')}
                     </ActionButton>
@@ -550,7 +557,16 @@ export function ITO(props: ITO_Props) {
                             {t('plugin_ito_share')}
                         </ActionButton>
                     )
-                ) : listOfStatus.includes(ITO_Status.expired) ? null : listOfStatus.includes(ITO_Status.waited) ? (
+                ) : listOfStatus.includes(ITO_Status.expired) ? (
+                    <ActionButton
+                        disabled
+                        onClick={() => undefined}
+                        variant="contained"
+                        size="large"
+                        className={classes.actionButton}>
+                        {t('plugin_ito_expired')}
+                    </ActionButton>
+                ) : listOfStatus.includes(ITO_Status.waited) ? (
                     <ActionButton onClick={onShare} variant="contained" size="large" className={classes.actionButton}>
                         {t('plugin_ito_share')}
                     </ActionButton>


### PR DESCRIPTION
Showing disabled button with hint when ITO was expired or out of stock, otherwise some users who didn't get the chance to buy would not willing to accept the fact and complain or even censure revengefully.