### PR TITLE
feat: new api for cross-env settings

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dimensiondev/maskbook-shared",
   "dependencies": {
+    "@dimensiondev/holoflows-kit": "0.8.0-20201215084554-2f9e757",
     "async-call-rpc": "^5.0.0",
     "bignumber.js": "^9.0.1",
     "immer": "^8.0.1",

--- a/packages/shared/src/state/known.ts
+++ b/packages/shared/src/state/known.ts
@@ -1,0 +1,9 @@
+/**
+ * All known state. Note clients should handle unknown state gracefully.
+ */
+export interface PersistentStateStore {
+    debugMode: boolean
+}
+export interface NamespacedBinding {
+    currentImagePayloadStatus: 'test'
+}

--- a/packages/shared/src/state/state.ts
+++ b/packages/shared/src/state/state.ts
@@ -1,0 +1,257 @@
+import type { EventBasedChannel } from 'async-call-rpc'
+import type { NamespacedBinding, PersistentStateStore } from './known'
+export interface StateDetail<T> {
+    /** defaultValue of the state */
+    defaultValue: T
+    type: 'global' | 'namespace'
+    /**
+     * Should this item be stored in the host or it will be dropped once the host goes offline
+     * @defaultValue false
+     */
+    persistent: boolean
+    isValidValue?(val: unknown): boolean
+    /** If this is set, this state will be treated as a "visible" one (e.g. appears in the settings page.) */
+    i18n?: {
+        /** If the client failed to find the string, here is the fallback */
+        fallbackString: string
+        /** The i18n key for this state. */
+        key: string
+    }
+}
+export type HostConfig = {
+    getPersistentedState(namespace: string | null, name: string): Promise<unknown>
+    setPersistentedState(namespace: string | null, name: string, value: unknown): Promise<unknown>
+    /** It should broadcast messages to all clients */
+    channel: EventBasedChannel
+}
+
+export type HostReturn = {
+    registerState(uniqueKey: string, detail: StateDetail<unknown>): void
+}
+import { isEqual } from 'lodash-es'
+
+/**
+ * Only call this in the background page, thanks!
+ */
+export function createStateHost({ channel, getPersistentedState, setPersistentedState }: HostConfig): HostReturn {
+    const definitions = new Map<string, StateDetail<unknown>>()
+    type InternalState = {
+        ready: boolean
+        readonly readyPromise: Promise<void>
+        version: number
+        value: unknown
+        resolve(): void
+    }
+    const store = new Map<string, InternalState>()
+    channel.on((data) => {
+        if (!isInternalMessage(data)) return
+        if (data[0] === InternalMessageTypeEnum.syncRequest) {
+            publishUnqualifiedValue(data[1])
+            return
+        } else if (data[0] === InternalMessageTypeEnum.sync) {
+            const [, unqualifiedKey, value] = data
+            const state = store.get(unqualifiedKey)!
+            // skip update
+            if (state.ready && isEqual(state.value, value)) return
+
+            const qualifiedName = getQualifiedName(unqualifiedKey)
+            const def = definitions.get(qualifiedName[1])!
+            const isValid =
+                def.isValidValue &&
+                (def.isValidValue(value) ||
+                    console.warn('An invalid write to the ', ...qualifiedName, 'which value is', value))
+            if (isValid) {
+                if (def.persistent) {
+                    setPersistentedState(...qualifiedName, value).catch((e) =>
+                        console.error('Failed to store state:', ...qualifiedName, e),
+                    )
+                }
+                writeUnqualifiedState(unqualifiedKey, value)
+            }
+            publishUnqualifiedValue(unqualifiedKey)
+        }
+    })
+    return {
+        registerState(uniqueKey, detail) {
+            if (definitions.has(uniqueKey)) throw new TypeError('No duplicated state name.')
+            definitions.set(uniqueKey, detail)
+            initState(uniqueKey, detail)
+        },
+    }
+    function publishUnqualifiedValue(key: string) {
+        const state = store.get(key)
+        if (!state) return
+        state.readyPromise.then(() => channel.send(makeSyncMessage(key, store.get(key)!.value)))
+    }
+    function initState(key: string, detail: StateDetail<unknown>) {
+        if (detail.persistent) {
+            let resolve: any
+            const readyPromise = new Promise<void>((r, reject) => {
+                resolve = r
+                loadPersistentState(key, detail).then(r, reject)
+            })
+            store.set(key, {
+                ready: false,
+                readyPromise,
+                resolve,
+                value: detail.defaultValue,
+                version: Date.now(),
+            })
+        } else {
+            store.set(key, {
+                ready: true,
+                readyPromise: Promise.resolve(),
+                resolve: () => {},
+                value: detail.defaultValue,
+                version: Date.now(),
+            })
+        }
+        // Send sync signal
+        store.get(key)!.readyPromise.then(() => {
+            channel.send(makeSyncMessage(key, store.get(key)!.value))
+        })
+    }
+    async function loadPersistentState(key: string, detail: StateDetail<unknown>) {
+        const value = await getPersistentedState(...getQualifiedName(key)).catch((e) => {
+            console.error(`Internal state ${key} failed to fetch the persistent value.`, e)
+            return detail.defaultValue
+        })
+        writeUnqualifiedState(key, value)
+    }
+    function writeUnqualifiedState(key: string, value: unknown) {
+        const state = store.get(key)!
+        state.value = value
+        state.version = Date.now()
+        state.ready = true
+        state.resolve()
+    }
+}
+
+export type ClientReturn = {
+    globalBindings: {
+        [key in keyof PersistentStateStore]: Readonly<StateBinding<PersistentStateStore[key]>>
+    }
+    createNamespacedBinding(
+        namespace: string,
+    ): {
+        [key in keyof NamespacedBinding]: Readonly<StateBinding<NamespacedBinding>>
+    }
+}
+export type StateBinding<T> = {
+    ready: boolean
+    readyPromise: Promise<void>
+    /** Value IS undefined if this state binding is NOT ready and there is NO default value in the ClientConfig. */
+    value: T
+    addListener(callback: (newValue: T, oldValue: T) => void): void
+    // This is important for concurrent-mode safe,
+    // the version-value pair must be immutable so it's safe to create a snapshot
+    version: number
+}
+type All = PersistentStateStore & NamespacedBinding
+export type ClientConfig = {
+    channel: EventBasedChannel
+    defaultValues?: Partial<{ [key in keyof All]: All[key] }>
+}
+/**
+ *
+ * @param connection A connection that connects to the settings store
+ */
+export function createStateClient({ channel, defaultValues }: ClientConfig): ClientReturn {
+    const states = new Map<string, StateBinding<unknown>>()
+    channel.on((data) => {
+        if (!isInternalMessage(data)) return
+        if (data[0] === InternalMessageTypeEnum.sync) {
+            getBinding(...getQualifiedName(data[1])).setNewValue(data[2])
+        }
+    })
+    function getBinding(ns: string | null, key: string) {
+        const unqualifiedKey = createUnqualifiedName(ns, key)
+        if (!states.has(unqualifiedKey)) {
+            const defaultValue = (defaultValues as any)?.[key]
+            states.set(unqualifiedKey, new StateBindingImpl(defaultValue))
+        }
+        return states.get(unqualifiedKey) as StateBindingImpl<unknown>
+    }
+    function createBindingProxy(ns: string | null) {
+        return new Proxy({ __proto__: null } as any, {
+            get(target, key) {
+                if (typeof key !== 'string') throw new TypeError('Cannot have a non-string name')
+                if (target[key]) return target[key]
+                const unqualifiedKey = createUnqualifiedName(ns, key)
+                channel.send(makeSyncRequestMessage(unqualifiedKey))
+                return (target[key] = getBinding(ns, key))
+            },
+        })
+    }
+    return {
+        globalBindings: createBindingProxy(null),
+        createNamespacedBinding: (ns) => createBindingProxy(ns),
+    }
+}
+class StateBindingImpl<T> implements StateBinding<T> {
+    constructor(public value: T) {}
+    ready = false
+    version = Date.now()
+    private listeners = new Set<Function>()
+    resolve = () => {}
+    readyPromise = new Promise<void>((r) => (this.resolve = r))
+    addListener(f: Function) {
+        this.listeners.add(f)
+        return () => this.listeners.delete(f)
+    }
+    setNewValue(value: T) {
+        if (isEqual(value, this.value) && this.ready) return // skip
+        this.version = Date.now()
+        this.ready = true
+        this.value = value
+        this.resolve()
+        for (const f of this.listeners) {
+            try {
+                f()
+            } catch (e) {
+                console.error(e)
+            }
+        }
+    }
+}
+//#region internals
+function makeSyncMessage(...args: SyncMessage): InternalMessageType {
+    return [InternalMessageTypeEnum.sync, ...args]
+}
+function makeSyncRequestMessage(...args: SyncRequestMessage): InternalMessageType {
+    return [InternalMessageTypeEnum.syncRequest, ...args]
+}
+function isInternalMessage(x: unknown): x is InternalMessageType {
+    return Array.isArray(x)
+}
+
+const enum InternalMessageTypeEnum {
+    syncRequest,
+    sync,
+}
+type SyncRequestMessage = [key: string]
+type SyncMessage = [key: string, newValue: unknown]
+type InternalMessageType =
+    // Client => Host, host should send a sync signal
+    | [type: InternalMessageTypeEnum.syncRequest, ...rest: SyncRequestMessage]
+    // Host => Client, client should update local store and dispatch events if differ
+    // Client => Host, update, will trigger a reverse sync again
+    | [type: InternalMessageTypeEnum.sync, ...rest: SyncMessage]
+
+/**
+ * The namespace:state_name pair is encoded to the form of:
+ * ":namespace;state_name"
+ *
+ * The global state is encoded to the form of:
+ * "*;state_name"
+ */
+function getQualifiedName(x: string): [string | null, string] {
+    const nsIndex = x.indexOf(';')
+    const ns = x.slice(1, nsIndex)
+    const key = x.slice(nsIndex + 1)
+    return [ns === '' ? null : ns, key]
+}
+function createUnqualifiedName(ns: string | null, name: string) {
+    return `${ns === null ? '*' : ns};${name}`
+}
+//#endregion

--- a/packages/shared/src/state/use-site.ts
+++ b/packages/shared/src/state/use-site.ts
@@ -1,0 +1,38 @@
+import { createStateHost, createStateClient } from './state'
+import { WebExtensionMessage, Environment, MessageTarget } from '@dimensiondev/holoflows-kit'
+const event = new WebExtensionMessage<{ state: any }>({ domain: 'state' })
+// host, on background scripts
+const { registerState } = createStateHost({
+    async getPersistentedState(name: string) {
+        // return browser.storage.local.get(...)
+    },
+    async setPersistentedState(name: string, val: unknown) {
+        // return browser.storage.local.set(...)
+    },
+    channel: event.events.state.bind(MessageTarget.Broadcast),
+})
+registerState('debugMode', {
+    defaultValue: false,
+    type: 'global',
+    persistent: true,
+    i18n: {
+        fallbackString: 'test',
+        key: 'test',
+    },
+})
+
+// client
+const channelToBg = event.events.state.bind(Environment.ManifestBackground)
+const {
+    globalBindings: { debugMode },
+    createNamespacedBinding,
+} = createStateClient({ channel: channelToBg, defaultValues: { debugMode: false } })
+
+debugMode.addListener(console.log)
+debugMode.ready
+debugMode.readyPromise.then(() => console.log(debugMode.value))
+debugMode.version // for react
+debugMode.value
+
+const twitter = createNamespacedBinding('twitter.com')
+twitter.currentImagePayloadStatus.addListener // same interface as debugMode

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,7 @@ importers:
       z-schema: ^5.0.0
   packages/shared:
     dependencies:
+      '@dimensiondev/holoflows-kit': 0.8.0-20201215084554-2f9e757
       async-call-rpc: 5.0.0
       bignumber.js: 9.0.1
       immer: 8.0.1
@@ -504,6 +505,7 @@ importers:
       typeson: 5.18.2
       typeson-registry: 1.0.0-alpha.39
     specifiers:
+      '@dimensiondev/holoflows-kit': 0.8.0-20201215084554-2f9e757
       async-call-rpc: ^5.0.0
       bignumber.js: ^9.0.1
       immer: ^8.0.1
@@ -2777,6 +2779,21 @@ packages:
     resolution:
       integrity: sha512-tJiUcLqVGhod0QhrHelcwrhDaTlOOi9r1dsywkeaC0ue1uusblt63Rr5a8RrKIqclS/dB6zdeQxZOuFurkYBow==
       tarball: download/@dimensiondev/common-protocols/1.6.0-20201027083702-d0ae6e2/6ce508fba448b0ecafe5c35af65722219c4d8ecb30915c6cd39b494a2bbd9088
+  /@dimensiondev/holoflows-kit/0.8.0-20201215084554-2f9e757:
+    dependencies:
+      '@servie/events': 1.0.0
+      async-call-rpc: 4.2.1
+      event-iterator: 2.0.0
+      jsx-jsonml-devtools-renderer: 1.4.3
+      lodash-es: 4.17.21
+      memorize-decorator: 0.2.4
+      tslib: 2.1.0
+    dev: false
+    peerDependencies:
+      webextension-polyfill: '*'
+    resolution:
+      integrity: sha1-zUa/ga7W14U+EHYTMpTCnqfgNPo=
+      tarball: download/@dimensiondev/holoflows-kit/0.8.0-20201215084554-2f9e757/5fedf4ae98792b5b33e08a3182d5d38aac57da06134769edd71acae35f097079
   /@dimensiondev/holoflows-kit/0.8.0-20210302070358-e90c55c:
     dependencies:
       '@servie/events': 1.0.0
@@ -5084,6 +5101,30 @@ packages:
     dev: true
     resolution:
       integrity: sha512-vS4DfA2Avvl7JNQymO4e3RUNoTWIGVfZJ70Irnd6PTAZNojbCXTYuigDavrmyf83F3g5rQpwmSAPjuoi/X/FRA==
+  /@storybook/client-api/5.3.21_regenerator-runtime@0.13.7:
+    dependencies:
+      '@storybook/addons': 5.3.21_regenerator-runtime@0.13.7
+      '@storybook/channel-postmessage': 5.3.21
+      '@storybook/channels': 5.3.21
+      '@storybook/client-logger': 5.3.21
+      '@storybook/core-events': 5.3.21
+      '@storybook/csf': 0.0.1
+      '@types/webpack-env': 1.16.0
+      core-js: 3.9.1
+      eventemitter3: 4.0.7
+      global: 4.4.0
+      is-plain-object: 3.0.1
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.9.6
+      stable: 0.1.8
+      ts-dedent: 1.2.0
+      util-deprecate: 1.0.2
+    dev: true
+    peerDependencies:
+      regenerator-runtime: '*'
+    resolution:
+      integrity: sha512-vS4DfA2Avvl7JNQymO4e3RUNoTWIGVfZJ70Irnd6PTAZNojbCXTYuigDavrmyf83F3g5rQpwmSAPjuoi/X/FRA==
   /@storybook/client-api/6.1.20:
     dependencies:
       '@storybook/addons': 6.1.20
@@ -5246,7 +5287,7 @@ packages:
       '@babel/preset-env': 7.13.9
       '@storybook/addons': 5.3.21_regenerator-runtime@0.13.7
       '@storybook/channel-postmessage': 5.3.21
-      '@storybook/client-api': 5.3.21
+      '@storybook/client-api': 5.3.21_regenerator-runtime@0.13.7
       '@storybook/client-logger': 5.3.21
       '@storybook/core-events': 5.3.21
       '@storybook/csf': 0.0.1
@@ -13288,20 +13329,6 @@ packages:
     resolution:
       integrity: sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==
   /follow-redirects/1.13.3:
-    dev: false
-    engines:
-      node: '>=4.0'
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    resolution:
-      integrity: sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
-  /follow-redirects/1.13.3_debug@4.3.1:
-    dependencies:
-      debug: 4.3.1_supports-color@6.1.0
-    dev: true
     engines:
       node: '>=4.0'
     peerDependencies:
@@ -14630,7 +14657,7 @@ packages:
   /http-proxy/1.18.1_debug@4.3.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.13.3_debug@4.3.1
+      follow-redirects: 1.13.3
       requires-port: 1.0.0
     dev: true
     engines:


### PR DESCRIPTION
close #1884 

This is a draft. You can see the API shape (RFC cc @guanbinrui @septs @zhouhanseng @nuanyang233) on the usage site at packages/shared/src/state/use-site.ts

The new API is generally compatible with the current API shape but

- React concurrent-mode safe (version field, useMutableSource)
- Allow split the API model so isolate mode dashboard can use those infras
- Add non-persistent storage (see #1884)