### PR TITLE
fix: WalletConnect QR code too large on mobile

### DIFF
--- a/packages/maskbook/src/plugins/Wallet/UI/WalletConnectQRCodeDialog/QRCodeModel.tsx
+++ b/packages/maskbook/src/plugins/Wallet/UI/WalletConnectQRCodeDialog/QRCodeModel.tsx
@@ -29,7 +29,7 @@ export const QRCodeModel: React.FC<{ uri: string }> = ({ uri }) => {
             <Typography className={classes.tip} color="textSecondary">
                 {t('plugin_wallet_qr_code_with_wallet_connect')}
             </Typography>
-            <QRCode text={uri} options={{ width: 400 }} canvasProps={{ style }} />
+            <QRCode text={uri} canvasProps={{ style }} />
         </Grid>
     )
 }


### PR DESCRIPTION
After modification, the QR code looks as following:
1. On Chrome:
<img width="1109" alt="Snipaste_2021-03-05_11-32-07" src="https://user-images.githubusercontent.com/7972003/110105918-f23c0500-7de3-11eb-9bf6-f6f6f75e00ae.png">

2. On Mobile:
![Simulator Screen Shot - iPhone 12 - 2021-03-05 at 18 52 49](https://user-images.githubusercontent.com/7972003/110105953-01bb4e00-7de4-11eb-95ad-3fd18b95a054.png)
