### PR TITLE
fix: redpacket ropsten address

### DIFF
--- a/packages/maskbook/src/plugins/RedPacket/constants.ts
+++ b/packages/maskbook/src/plugins/RedPacket/constants.ts
@@ -7,7 +7,7 @@ export const RedPacketPluginID = 'com.maskbook.red_packet'
 export const RED_PACKET_CONSTANTS = {
     HAPPY_RED_PACKET_ADDRESS: {
         [ChainId.Mainnet]: '0x26760783c12181efa3c435aee4ae686c53bdddbb',
-        [ChainId.Ropsten]: '0x26760783c12181efa3c435aee4ae686c53bdddbb',
+        [ChainId.Ropsten]: '0x6d84e4863c0530bc0bb4291ef0ff454a40660ca3',
         [ChainId.Rinkeby]: '0x575f906db24154977c7361c2319e2b25e897e3b6',
         [ChainId.Kovan]: '',
         [ChainId.Gorli]: '',


### PR DESCRIPTION
The old redpacket ropsten address `0x26760783c12181efa3c435aee4ae686c53bdddbb` is obviously wrong that it is as same as mainnet.

I deploy on ropsten again using the current mainnet [contract](https://etherscan.io/tx/0xd940a784416feabbca0cb20c81ed9e1d762d39f62d28e619cc5b4900ca25975b)