### PR TITLE
chore: hide injected toolbar on mobile, enable trader on mobile

### DIFF
--- a/packages/maskbook/src/social-network/ui.ts
+++ b/packages/maskbook/src/social-network/ui.ts
@@ -17,6 +17,7 @@ import type { PostInfo } from './PostInfo'
 import type { InjectedDialogProps } from '../components/shared/InjectedDialog'
 import { editMetadata } from '../protocols/typed-message'
 import type { ReadonlyIdentifierMap } from '../database/IdentifierMap'
+import { Flags } from '../utils/flags'
 
 //#region SocialNetworkUI
 export interface SocialNetworkUIDefinition
@@ -292,7 +293,7 @@ export function activateSocialNetworkUI(): void {
                 ui.init()
                 ui.resolveLastRecognizedIdentity()
                 ui.injectPostBox()
-                ui.injectToolbar()
+                if (Flags.toolbar_enabled) ui.injectToolbar()
                 ui.injectSetupPrompt()
                 ui.injectPageInspector()
                 ui.collectPeople()

--- a/packages/maskbook/src/utils/flags.ts
+++ b/packages/maskbook/src/utils/flags.ts
@@ -32,7 +32,7 @@ export const Flags = {
     /** Prohibit the use of test networks in production */
     wallet_network_strict_mode_enabled: process.env.NODE_ENV === 'production' && !betaOrInsiderOnly,
     transak_enabled: webOnly,
-    trader_enabled: webOnly,
+    trader_enabled: true,
     trader_zrx_enabled: webOnly,
     trader_all_api_cached_enabled: devOnly,
     gitcoin_enabled: webOnly,
@@ -45,6 +45,7 @@ export const Flags = {
     airdrop_enabled: webOnly,
     airdrop_composition_dialog_enabled: false,
     metamask_support_enabled: webOnly,
+    toolbar_enabled: webOnly,
     /* construct LBP for all ERC20 tokens */
     LBP_whitelist_enabled: process.env.NODE_ENV === 'production',
     //#endregion


### PR DESCRIPTION
The injected toolbar breaks Twitter's mobile layout, let's hide it before we have a compatible design on mobile.