### PR TITLE
RFC: new payload v-37 and TypedMessage binary format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,7 +53,7 @@
         "editor.defaultFormatter": "redhat.vscode-yaml"
     },
     "[markdown]": {
-        "editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.wordWrap": "on",
         "editor.quickSuggestions": true
     }

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -1,0 +1,48 @@
+# Payload v-37
+
+## Motivation
+
+The current using v-38 is not prepared for TypedMessage and binary data. That makes our payload wasting space.
+
+## Design target
+
+- Must be a binary format.
+- Must be compatible with both future and past. (Old client can parse the extended v-37 payload though may not be able to use it. New client can parse the old payload).
+
+## Design
+
+`PayloadAlpha37` is a extendable tuple type. To omit the field name, the compressed output can have a smaller size.
+
+Future extensions must appended to the end of the tuple, client must ignore the unknown new items in the tuple.
+
+Here is the definition of `PayloadAlpha37`. (Note, the syntax is named tuple in TypeScript and it won't appears in the real data.)
+
+```typescript
+type PayloadAlpha37 = [
+  version: -37,
+  // If it is in the SocialNetworkEnum
+  // we can save more space
+  authorNetwork: UTF8String | SocialNetworkEnum,
+  authorID: UTF8String,
+  authorPublicKey: ArrayBuffer,
+  // authorPublicKeyCurve: ???,
+  encryption: Encryption,
+  iv: ArrayBuffer,
+  // This should be the binary payload of TypedMessage.
+  message: ArrayBuffer,
+]
+// false means public shared to everyone.
+type Encryption =
+  | false
+  | [
+      OwnerAESKeyEncrypted: ArrayBuffer,
+      // false means not using e... encryption
+      // e...PublicKey: false | [publicKey: ArrayBuffer, curve: ???]
+    ]
+enum SocialNetworkEnum {
+  Facebook = 0,
+  Twitter = 1,
+}
+```
+
+Use [msgpack](https://github.com/msgpack/msgpack/blob/master/spec.md) to compress the `PayloadAlpha37` into a binary format.

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -13,7 +13,9 @@ Playground: copy [the playground file](./000-TypedMessage-and-Payload-37-playgro
 
 To avoid reinvention of a new binary format, this RFC chooses to convert data into a format that can be represented in the MessagePack binary format.
 
-Type `Integer`, `Float`, `Nil`, `Boolean`, `String`, `Binary`, `Array` and `Map` is defined in the [msgpack specification](https://github.com/msgpack/msgpack/blob/master/spec.md). Other type defined in this RFC is written in the TypeScript syntax.
+Type `Integer`, `Float`, `Nil`, `Boolean`, `String`, `Binary`, `Array` and `Map` is defined in the [msgpack specification][msgpack-spec]. Other type defined in this RFC is written in the TypeScript syntax.
+
+[msgpack-spec]: https://github.com/msgpack/msgpack/blob/master/spec.md
 
 To avoid encoding field names into the binary (this is space-wasting), this RFC chooses to use tuple (`Array` in MessagePack), in which the order of the fields represented its meaning.
 
@@ -88,7 +90,7 @@ enum PublicKeyAlgorithmEnum {
 This field represents the format version.
 
 The first and the current binary version is `-37`.
-The implementation MUST fail when the version is less than -37 (e.g. `-38`).
+The implementation MUST fail when the version is less than `-37` (e.g. `-38`).
 
 #### `authorNetwork` field
 
@@ -116,7 +118,9 @@ The implementation MUST fail if the algorithm is not supported.
 
 This field represents the public key of the author.
 
-The value is in the DER encoding of the SubjectPublicKeyInfo (`spki`) structure from [RFC5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.7).
+The value is in the DER encoding of the SubjectPublicKeyInfo (`spki`) structure from [RFC 5280][rfc5280].
+
+[rfc5280]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.7
 
 #### `encryption` field
 
@@ -188,7 +192,9 @@ The implementation MUST fail when the decryption result is NOT a valid TypedMess
 
 ### `secp256k1`
 
-When `spki` is mentioned in this spec, the implementation MUST be able to recognize the SubjectPublicKeyInfo of the curve [`secp256k1`](https://en.bitcoin.it/wiki/Secp256k1). This curve is widely used in the Mask Network.
+When `spki` is mentioned in this spec, the implementation MUST be able to recognize the SubjectPublicKeyInfo of the curve [`secp256k1`][secp256k1]. This curve is widely used in the Mask Network.
+
+[secp256k1]: https://en.bitcoin.it/wiki/Secp256k1
 
 Here is an example of the `secp256k1` public key in Binary.
 
@@ -211,7 +217,10 @@ Here is an example of the `secp256k1` public key in Binary.
 type AES_KEY = [alg: String, k: String]
 ```
 
-This type is used in this specification to represent section 6.4 of a [JsonWebKey](https://datatracker.ietf.org/doc/html/rfc7518) of [AES family key](https://datatracker.ietf.org/doc/html/rfc7518#section-6.4).
+This type is used in this specification to represent section 6.4 of a [JsonWebKey][rfc7518] of [AES family key][rfc7518-aes-family-key].
+
+[rfc7518]: https://datatracker.ietf.org/doc/html/rfc7518
+[rfc7518-aes-family-key]: https://datatracker.ietf.org/doc/html/rfc7518#section-6.4
 
 The implementation MUST fail when the `alg` is not recognized as a known algorithm.
 The implementation MUST fail when the `k` is not valid for the given `alg`.

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -157,7 +157,7 @@ type PeerToPeerEncrypted = [
   kind: EncryptionKind.PeerToPeer,
   ownerAESKeyEncrypted: Binary,
   iv: Binary,
-  authorEphemeralPublicKey: Binary[],
+  authorEphemeralPublicKey: Map<PublicKeyAlgorithmEnum, Binary>,
 ]
 ```
 
@@ -171,9 +171,12 @@ This field represents the iv used to encrypt the message.
 
 ###### `authorEphemeralPublicKey` field
 
-This field is an Array of the DER encoding of the SubjectPublicKeyInfo (`spki`) structure from [RFC5280].
+This field is a Map of the DER encoding of the SubjectPublicKeyInfo (`spki`) structure from [RFC5280].
 
-The implementation MUST NOT fail when an item is Binary but not a recognizable SubjectPublicKeyInfo.
+The key indicates its format.
+
+The implementation MUST NOT fail when an unknown key appears.
+The implementation MUST ignore the invalid key for the given public key format.
 
 This field is used to support ephemeral encryption with different curves.
 

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -1,48 +1,225 @@
-# Payload v-37
-
-## Motivation
-
-The current using v-38 is not prepared for TypedMessage and binary data. That makes our payload wasting space.
+# Payload version -37
 
 ## Design target
 
-- Must be a binary format.
-- Must be compatible with both future and past. (Old client can parse the extended v-37 payload though may not be able to use it. New client can parse the old payload).
+- MUST be a binary format.
+- MUST be compatible with both forward compatible and backward compatible.
 
 ## Design
 
-`PayloadAlpha37` is a extendable tuple type. To omit the field name, the compressed output can have a smaller size.
+### Encoding
 
-Future extensions must appended to the end of the tuple, client must ignore the unknown new items in the tuple.
+To avoid reinvention of a new binary format, this RFC chooses to convert data into a format that can be represented in the MessagePack binary format.
 
-Here is the definition of `PayloadAlpha37`. (Note, the syntax is named tuple in TypeScript and it won't appears in the real data.)
+Type `Integer`, `Float`, `Nil`, `Boolean`, `String`, `Binary`, `Array` and `Map` is defined in the [msgpack specification](https://github.com/msgpack/msgpack/blob/master/spec.md). Other type defined in this RFC is written in the TypeScript syntax.
+
+To avoid encoding field names into the binary (this is space-wasting), this RFC chooses to use tuple (`Array` in MessagePack), in which the order of the fields represented its meaning.
+
+In extra, we define the following helper types:
+
+```typescript
+type Number = Integer | Float
+type Any = Integer | Nil | Boolean | Float | String | Binary | Array<Any> | Map
+```
+
+In this specification, any form of MessagePack extension (like a timestamp) is NOT used. An implementation MAY treat data including extensions as invalid.
+
+`Array` in this specification is used as `Tuple` with an arbitrary size, which means items in the Array don't have to be the same type.
+
+e.g. `[1, "string"]` is a valid Array that has the type `Array<String | Integer>`.
+If the order is meaningful, the type should be `[Integer, String]`.
+
+All Tuple in this specification MUST be treated as non-fixed length. This means `[1, "string", true]` is valid when `[Integer, String]` is required. An implementation MUST NOT fail due to the extra item unless especially specified.
+
+### `SignatureContainer`
+
+This is the top-most data type.
+
+```typescript
+type SignatureContainer = [version: Integer, payload: Binary, signature: Binary]
+```
+
+#### `version` field
+
+This field represents the signature container version.
+
+The first and the current version is `0`.
+The implementation MUST fail when the version is not `0`.
+
+#### `payload` field
+
+This field represents the `Payload37` type encoded by the MessagePack.
+
+The implementation MUST fail when the payload is not a `Payload37` after decoding.
+
+#### `signature` field
+
+This field represents the EC signature of the payload.
+
+### `Payload37`
 
 ```typescript
 type PayloadAlpha37 = [
-  version: -37,
-  // If it is in the SocialNetworkEnum
-  // we can save more space
-  authorNetwork: UTF8String | SocialNetworkEnum,
-  authorID: UTF8String,
-  authorPublicKey: ArrayBuffer,
-  // authorPublicKeyCurve: ???,
+  version: Integer,
+  authorNetwork: String | SocialNetworkEnum,
+  authorID: String,
+  authorPublicKey: Binary,
   encryption: Encryption,
-  iv: ArrayBuffer,
-  // This should be the binary payload of TypedMessage.
-  message: ArrayBuffer,
+  data: Binary,
 ]
-// false means public shared to everyone.
-type Encryption =
-  | false
-  | [
-      OwnerAESKeyEncrypted: ArrayBuffer,
-      // false means not using e... encryption
-      // e...PublicKey: false | [publicKey: ArrayBuffer, curve: ???]
-    ]
 enum SocialNetworkEnum {
   Facebook = 0,
   Twitter = 1,
+  Instgram = 2,
+  Minds = 3,
 }
 ```
 
-Use [msgpack](https://github.com/msgpack/msgpack/blob/master/spec.md) to compress the `PayloadAlpha37` into a binary format.
+#### `version` field
+
+This field represents the format version.
+
+The first and the current binary version is `-37`.
+The implementation MUST fail when the version is less than -37 (e.g. `-38`).
+
+#### `authorNetwork` field
+
+This field represents the social network that the author of this payload belongs to.
+
+When it is `SocialNetworkEnum`, it represents a SocialNetwork that is supported by the Mask Network.
+
+When it is `String`, it represents a SocialNetwork cannot be expressed within the enum. e.g. A decentralized SNS like Mastodon.
+
+#### `authorID` field
+
+This field represents the identifiable ID of the author of this payload belongs to. In the case of an anonymous post, this field should be an empty string.
+
+#### `authorPublicKey` field
+
+This field represents the public key of the author.
+
+The value is in the DER encoding of the SubjectPublicKeyInfo (`spki`) structure from [RFC5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.7).
+
+#### `encryption` field
+
+This field represents how this payload is encrypted. There are two types of encryption, `PublicEncrypted` and `PeerToPeerEncrypted`
+
+```typescript
+type Encryption = PublicEncrypted | PeerToPeerEncrypted
+enum EncryptionKind = {
+  Public = 0,
+  PeerToPeer = 1,
+}
+```
+
+The `Encryption` type is a tagged Tuple (the first item is the tag).
+The implementation MUST fail when the first item is not recognizable.
+
+##### `PublicEncrypted`
+
+This type represents this payload is encrypted, but the AES key is shared with everyone (and encoded in the payload).
+Which means the message is NOT shared.
+
+```typescript
+type PublicShared = [kind: EncryptionKind.Public, AES_KEY: AES_KEY, iv: Binary]
+```
+
+###### `AES_KEY`
+
+This field represents the AES key of this payload.
+
+###### `iv` field
+
+This field represents the iv used to encrypt the message.
+
+##### `PeerToPeerEncrypted`
+
+```typescript
+type PeerToPeerEncrypted = [
+  kind: EncryptionKind.PeerToPeer,
+  ownerAESKeyEncrypted: Binary,
+  iv: Binary,
+  authorEphemeralPublicKey: Binary[],
+]
+```
+
+###### `ownerAESKeyEncrypted` field
+
+This field represents an encrypted AES key of this payload that is encrypted with the author's local key (local key is a Mask Network concept).
+
+###### `iv` field
+
+This field represents the iv used to encrypt the message.
+
+###### `authorEphemeralPublicKey` field
+
+This field is an Array of the DER encoding of the SubjectPublicKeyInfo (`spki`) structure from [RFC5280].
+
+The implementation MUST NOT fail when an item is Binary but not a recognizable SubjectPublicKeyInfo.
+
+This field is used to support ephemeral encryption with different curves.
+
+#### `data` field
+
+This field represents the encrypted result of a [TypedMessage binary format](./000-TypedMessage-binary-format.md).
+
+The implementation MUST fail when the decryption result is NOT a valid TypedMessage.
+
+### `secp256k1`
+
+When `spki` is mentioned in this spec, the implementation MUST be able to recognize the SubjectPublicKeyInfo of the curve [`secp256k1`](https://en.bitcoin.it/wiki/Secp256k1). This curve is widely used in the Mask Network.
+
+Here is an example of the `secp256k1` public key in Binary.
+
+```plaintext
+[
+   48,  86,  48,  16,   6,   7,  42, 134,  72, 206,  61,   2,
+    1,   6,   5,  43, 129,   4,   0,  10,   3,  66,   0,   4,
+  236,  81,   1, 232, 133,  60, 235, 215, 107, 253, 124,  90,
+   12,  21,  14, 139, 178, 143, 232,  52, 240, 119, 105,  91,
+  196, 232,  84,  33, 238,  69,  42, 104, 223, 226,  96, 216,
+  191, 166,  10,  63, 179, 111, 125,  99, 161, 131, 168, 172,
+  181, 245, 168, 182, 150,  19, 182, 240, 202,  62, 202, 219,
+   21, 175, 144, 205
+]
+```
+
+### `AES_KEY`
+
+```typescript
+type AES_KEY = [alg: String, k: String]
+```
+
+This type is used in this specification to represent section 6.4 of a [JsonWebKey](https://datatracker.ietf.org/doc/html/rfc7518) of [AES family key](https://datatracker.ietf.org/doc/html/rfc7518#section-6.4).
+
+The implementation MUST fail when the `alg` is not recognized as a known algorithm.
+The implementation MUST fail when the `k` is not valid for the given `alg`.
+
+#### Encoding from JsonWebKey `jwk`
+
+```js
+function fromJsonWebKey(jwk) {
+  return [jwk.alg, jwk.k]
+}
+```
+
+#### Decoding from `key`
+
+```js
+function toJsonWebKey(key) {
+  const k = { ext: true, key_ops: ['encrypt', 'decrypt'], kty: 'oct' }
+  k.alg = key[0]
+  k.k = key[1]
+  return k
+}
+```
+
+## Q&A
+
+### Why the version number is negative?
+
+The pre 1.0 version of the Mask Network extension (called Maskbook) uses `-42` as its initial payload version. The number `42` comes from the book _The Hitchhiker's Guide to the Galaxy_ and the minus sign indicates this is an early version. When a new payload format is drafted, it's a natural idea that the version number should add by 1, therefore it should be `-41`. At the time of this RFC written, the latest payload is version `-38`, therefore this RFC follows the convention to mark the version as `-37`.
+
+### Why not uses the `raw` format defined in the Web Crypto specification for AES key?
+
+According to [the Web Crypto specification](https://w3c.github.io/webcrypto/#dfn-CryptoKey-slot-handle), `raw` format is NOT standardized therefore it might have a co-operational problem.

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -1,5 +1,7 @@
 # Payload version -37
 
+Playground: copy [the playground file](./000-TypedMessage-and-Payload-37-playground.js) into a https: web page.
+
 ## Design target
 
 - MUST be a binary format.
@@ -54,7 +56,7 @@ The implementation MUST fail when the payload is not a `Payload37` after decodin
 
 #### `signature` field
 
-This field represents the EC signature of the payload.
+This field represents the EC signature of the payload. The implementation MUST use SHA-256 algorithm.
 
 ### `Payload37`
 
@@ -63,6 +65,7 @@ type PayloadAlpha37 = [
   version: Integer,
   authorNetwork: String | SocialNetworkEnum,
   authorID: String,
+  authorPublicKeyAlgorithm: String | PublicKeyAlgorithmEnum,
   authorPublicKey: Binary,
   encryption: Encryption,
   data: Binary,
@@ -72,6 +75,11 @@ enum SocialNetworkEnum {
   Twitter = 1,
   Instgram = 2,
   Minds = 3,
+}
+enum PublicKeyAlgorithmEnum {
+  ed25519 = 0,
+  secp256p1 = 1, // P-256
+  secp256k1 = 2, // K-256
 }
 ```
 
@@ -93,6 +101,16 @@ When it is `String`, it represents a SocialNetwork cannot be expressed within th
 #### `authorID` field
 
 This field represents the identifiable ID of the author of this payload belongs to. In the case of an anonymous post, this field should be an empty string.
+
+#### `authorPublicKeyAlgorithm` field
+
+This field represents the algorithm that the public key is using.
+
+When it is `PublicKeyAlgorithmEnum`, it represents a well-known asymmetric algorithm.
+
+When it is `String`, it represents a asymmetric algorithm that not covered in this specification.
+
+The implementation MUST fail if the algorithm is not supported.
 
 #### `authorPublicKey` field
 
@@ -194,6 +212,8 @@ This type is used in this specification to represent section 6.4 of a [JsonWebKe
 
 The implementation MUST fail when the `alg` is not recognized as a known algorithm.
 The implementation MUST fail when the `k` is not valid for the given `alg`.
+
+When encrypting with AES key, the implementation MUST NOT use `additionalData`, the `tagLength` MUST be 128.
 
 #### Encoding from JsonWebKey `jwk`
 

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -254,4 +254,6 @@ The pre 1.0 version of the Mask Network extension (called Maskbook) uses `-42` a
 
 ### Why not uses the `raw` format defined in the Web Crypto specification for AES key?
 
-According to [the Web Crypto specification](https://w3c.github.io/webcrypto/#dfn-CryptoKey-slot-handle), `raw` format is NOT standardized therefore it might have a co-operational problem.
+According to [the Web Crypto specification][webcrypto], `raw` format is NOT standardized therefore it might have a co-operational problem.
+
+[webcrypto]: https://w3c.github.io/webcrypto/#dfn-CryptoKey-slot-handle

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -143,7 +143,7 @@ This type represents this payload is encrypted, but the AES key is shared with e
 Which means the message is NOT shared.
 
 ```typescript
-type PublicShared = [kind: EncryptionKind.Public, AES_KEY: AES_KEY, iv: Binary]
+type PublicEncrypted = [kind: EncryptionKind.Public, AES_KEY: AES_KEY, iv: Binary]
 ```
 
 ###### `AES_KEY`

--- a/docs/rfc/000-Payload-v37.md
+++ b/docs/rfc/000-Payload-v37.md
@@ -234,7 +234,7 @@ function toJsonWebKey(key) {
 }
 ```
 
-## Q&A
+## FAQ
 
 ### Why the version number is negative?
 

--- a/docs/rfc/000-TypedMessage-and-Payload-37-playground.js
+++ b/docs/rfc/000-TypedMessage-and-Payload-37-playground.js
@@ -1,0 +1,184 @@
+// Usage: Paste this file into your browser.
+// Must be https:// or localhost.
+
+// Encode:
+// tm = await encodeTypedMessage(makeText('hello world!'))
+// result = await encodePayload37({ typedMessage: tm })
+
+// Decode:
+// decodeTypedMessage(result)
+
+var TextFormat = { PlainText: 0, Markdown: 1 }
+async function encodeTypedMessage(...messages) {
+    let MessagePack = await import('https://cdn.skypack.dev/@msgpack/msgpack')
+    let document = [0, messages]
+    let result = MessagePack.encode(document)
+    return result
+}
+function makeText(text, metadata = null, format) {
+    const m = [1, metadata, text]
+    if (format) m.push(format)
+    return m
+}
+function makeTuple(metadata = null, ...messages) {
+    return [0, metadata, messages]
+}
+/**
+ * Encode a TypedMessage into binary
+ * @param options Can have options: author, authorNetwork, authorECKey, typedMessage
+ * @returns
+ */
+async function encodePayload37(options = {}) {
+    let MessagePack = await import('https://cdn.skypack.dev/@msgpack/msgpack')
+    let {
+        author = 'example',
+        authorNetwork = 1,
+        authorECKey = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']),
+        typedMessage = new Uint8Array([
+            146, 0, 145, 148, 1, 129, 176, 99, 111, 109, 46, 101, 120, 97, 109, 112, 108, 101, 46, 116, 101, 115, 116,
+            162, 104, 105, 172, 72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 1,
+        ]),
+    } = options
+    typedMessage = await typedMessage
+
+    // Encrypt TypedMessage
+    let postAESKey = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+    let postAESKeyJWK = await crypto.subtle.exportKey('jwk', postAESKey)
+    let iv = crypto.getRandomValues(new Uint8Array(16))
+    let encryptedTypedMessage = new Uint8Array(
+        await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, postAESKey, typedMessage),
+    )
+
+    // Construct payload 37
+    let authorECPublicKey_spki = new Uint8Array(await crypto.subtle.exportKey('spki', authorECKey.publicKey))
+    let compressedJWK = [postAESKeyJWK.alg, postAESKeyJWK.k]
+    let payload37_object = [
+        -37,
+        authorNetwork,
+        author,
+        1, // P-256
+        authorECPublicKey_spki,
+        [
+            0, // public shared
+            compressedJWK,
+            iv,
+        ],
+        encryptedTypedMessage,
+    ]
+    let payload37 = MessagePack.encode(payload37_object)
+
+    // Sign
+    let signature = new Uint8Array(
+        await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, authorECKey.privateKey, payload37),
+    )
+    let signatureContainer = [0, payload37, signature]
+    let result = MessagePack.encode(signatureContainer)
+
+    let debugInfo = {
+        authorECPublicKey: authorECPublicKey_spki,
+        postAESKey: `(size ${compressedJWK.join(', ').length}) ${compressedJWK}`,
+        iv,
+        typedMessage,
+        encryptedTypedMessage,
+        payload37: payload37,
+        signature,
+        result,
+    }
+    for (let i in debugInfo) {
+        if (debugInfo[i] instanceof Uint8Array) debugInfo[i] = debugUint8Array(debugInfo[i])
+    }
+    console.table(debugInfo)
+    return result
+}
+
+async function decodePayload37(result) {
+    let MessagePack = await import('https://cdn.skypack.dev/@msgpack/msgpack')
+
+    let [signatureContainerVersion, payloadEncoded, signature] = MessagePack.decode(result)
+    let [version, authorNetwork, author, authorPublicKeyAlg, authorECPublicKey_spki, encryption, data] =
+        MessagePack.decode(payloadEncoded)
+
+    if (encryption[0] !== 0) throw new Error('PeerToPeer encryption is not supported in this demo')
+    if (authorPublicKeyAlg !== 1) throw new Error('Algorithm other than P-256 is not supported in this demo')
+
+    let authorECPublicKey = await crypto.subtle.importKey(
+        'spki',
+        authorECPublicKey_spki,
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        true,
+        ['verify'],
+    )
+    let verifyResult = await crypto.subtle.verify(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        authorECPublicKey,
+        signature,
+        payloadEncoded,
+    )
+
+    // decrypt
+    let [encryptionKind, AESKey, iv] = encryption
+    function toJsonWebKey(key) {
+        const k = { ext: true, key_ops: ['encrypt', 'decrypt'], kty: 'oct' }
+        k.alg = key[0]
+        k.k = key[1]
+        return k
+    }
+    let postAESKeyJWK = toJsonWebKey(AESKey)
+    let postAESKey = await crypto.subtle.importKey('jwk', postAESKeyJWK, { name: 'AES-GCM' }, true, [
+        'encrypt',
+        'decrypt',
+    ])
+    let decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, postAESKey, data)
+
+    // payload
+    let typedMessage = MessagePack.decode(decrypted)
+    let friendlyTypedMessage = typedMessage[1].map(debugTypedMessage)
+
+    let debugInfo = {
+        verifyResult,
+        authorNetwork,
+        author,
+        authorECPublicKey_spki,
+        iv,
+    }
+    for (let i in debugInfo) {
+        if (debugInfo[i] instanceof Uint8Array) debugInfo[i] = debugUint8Array(debugInfo[i])
+    }
+    console.table(debugInfo)
+    return friendlyTypedMessage
+}
+
+function debugUint8Array(buffer) {
+    let str = ''
+    for (let i = 0; i < buffer.byteLength; i++) {
+        str += String.fromCharCode(buffer[i])
+    }
+    return `(size ${buffer.length}) ` + btoa(str)
+}
+Object.defineProperty(Uint8Array.prototype, 'base64', {
+    configurable: true,
+    get() {
+        return debugUint8Array(this)
+    },
+})
+
+function debugTypedMessage(tm) {
+    const [kind, meta, ...rest] = tm
+    const proto = {
+        [Symbol.toStringTag]:
+            'TypedMessage' + (['Tuple', 'Text'][kind] ?? (typeof kind === 'number' ? ' ( unknown kind)' : kind)),
+    }
+    const o = { __proto__: proto }
+    if (meta) o.meta = meta
+
+    if (kind === 1) {
+        const [text, format = TextFormat.PlainText] = rest
+        o.text = text
+        o.format = format === TextFormat.Markdown ? 'Markdown' : 'PlainText'
+    } else if (kind === 0) {
+        o.items = rest[0].map(debugTypedMessage)
+    } else {
+        o.__unparsed__ = rest
+    }
+    return o
+}

--- a/docs/rfc/000-TypedMessage-and-Payload-37-playground.js
+++ b/docs/rfc/000-TypedMessage-and-Payload-37-playground.js
@@ -9,9 +9,9 @@
 // decodeTypedMessage(result)
 
 var TextFormat = { PlainText: 0, Markdown: 1 }
-async function encodeTypedMessage(...messages) {
+async function encodeTypedMessage(message) {
     let MessagePack = await import('https://cdn.skypack.dev/@msgpack/msgpack')
-    let document = [0, messages]
+    let document = [0, message]
     let result = MessagePack.encode(document)
     return result
 }
@@ -132,7 +132,7 @@ async function decodePayload37(result) {
 
     // payload
     let typedMessage = MessagePack.decode(decrypted)
-    let friendlyTypedMessage = typedMessage[1].map(debugTypedMessage)
+    let friendlyTypedMessage = debugTypedMessage(typedMessage[1])
 
     let debugInfo = {
         verifyResult,

--- a/docs/rfc/000-TypedMessage-binary-format.md
+++ b/docs/rfc/000-TypedMessage-binary-format.md
@@ -77,32 +77,3 @@ enum TextType {
 ```
 
 For unknown textType (might comes from the future version), the client must treat it as `TextType.PlainText`.
-
-### Image
-
-To limit the length of the payload, this data type is not going to support inline binary image data.
-
-```typescript
-type TypedMessageImageTuple = [
-  type: TypedMessageTypeEnum.Image
-  metadata: object | null,
-  imageType: ImageType.PNG | ImageType.JPG | ImageType.WEBP,
-  src: UTF8String,
-  width: Int,
-  height: Int
-] | [
-  type: TypedMessageTypeEnum.Image
-  metadata: object | null,
-  imageType: ImageType.SVG,
-  content: UTF8String,
-  width: Int,
-  height: Int
-]
-
-enum ImageType {
-  PNG = 0,
-  JPG = 1,
-  WEBP = 2,
-  SVG = 3
-}
-```

--- a/docs/rfc/000-TypedMessage-binary-format.md
+++ b/docs/rfc/000-TypedMessage-binary-format.md
@@ -16,7 +16,16 @@ Currently Mask only support text payload + metadata.
 This is the top-most data type.
 
 ```typescript
-type Document = [version: 1, constantTable: UTF8String[], message: TupleFormatOf<TypedMessage>]
+type Document = [
+  version: 1,
+  // constant table is reversed for metadata
+  // if the metadata key appears multiple times
+  // in the whole payload, we can refer that key
+  // by a index in the constant table.
+  // Or maybe we should use a compress algorithm like gzip?
+  constantTable: UTF8String[],
+  message: TupleFormatOf<TypedMessage>,
+]
 ```
 
 Use [msgpack](https://github.com/msgpack/msgpack/blob/master/spec.md) to compress the `Document` into a binary format.
@@ -33,10 +42,67 @@ type TypedMessageTupleBase = [
   ...rest: any[]
 ]
 enum TypedMessageTypeEnum {
-  Text = 0,
+  Compound = 0,
+  Text = 1,
+  Image = 2,
 }
+```
+
+For unknown TypedMessage type, the client should ignore the content or render a TypedMessageUnknown hint.
+
+### Compound
+
+```typescript
+type TypedMessageCompoundTuple = [
+  type: TypedMessageTypeEnum.Compound
+  metadata: object | null,
+  // Ordered
+  items: TypedMessageTuple[],
+]
 ```
 
 ### Text
 
-TBD
+```typescript
+type TypedMessageTextTuple = [
+  type: TypedMessageTypeEnum.Text
+  metadata: object | null,
+  textType: TextType,
+  content: string,
+]
+enum TextType {
+  PlainText = 0,
+  Markdown = 1
+}
+```
+
+For unknown textType (might comes from the future version), the client must treat it as `TextType.PlainText`.
+
+### Image
+
+To limit the length of the payload, this data type is not going to support inline binary image data.
+
+```typescript
+type TypedMessageImageTuple = [
+  type: TypedMessageTypeEnum.Image
+  metadata: object | null,
+  imageType: ImageType.PNG | ImageType.JPG | ImageType.WEBP,
+  src: UTF8String,
+  width: Int,
+  height: Int
+] | [
+  type: TypedMessageTypeEnum.Image
+  metadata: object | null,
+  imageType: ImageType.SVG,
+  content: UTF8String,
+  width: Int,
+  height: Int
+]
+
+enum ImageType {
+  PNG = 0,
+  JPG = 1,
+  WEBP = 2,
+  SVG = 3
+}
+```

--- a/docs/rfc/000-TypedMessage-binary-format.md
+++ b/docs/rfc/000-TypedMessage-binary-format.md
@@ -1,0 +1,42 @@
+# TypedMessage binary format
+
+## Motivation
+
+Currently Mask only support text payload + metadata.
+
+## Design target
+
+- Must be a binary format.
+- Must be compatible with both future and past. (Old client can parse the extended TypedMessage payload though may not be able to use it. New client can parse the old payload).
+
+## Design
+
+### `Document` type
+
+This is the top-most data type.
+
+```typescript
+type Document = [version: 1, constantTable: UTF8String[], message: TupleFormatOf<TypedMessage>]
+```
+
+Use [msgpack](https://github.com/msgpack/msgpack/blob/master/spec.md) to compress the `Document` into a binary format.
+
+### TypedMessage
+
+All TypedMessage must starts with the following format:
+
+```typescript
+type TypedMessageTupleBase = [
+  type: TypedMessageTypeEnum | string,
+  // Every TypedMessage can store metadata
+  metadata: object | null,
+  ...rest: any[]
+]
+enum TypedMessageTypeEnum {
+  Text = 0,
+}
+```
+
+### Text
+
+TBD

--- a/docs/rfc/000-TypedMessage-binary-format.md
+++ b/docs/rfc/000-TypedMessage-binary-format.md
@@ -48,12 +48,14 @@ When encoding, the implementation MUST use `0` as the value of this field.
 
 When decoding, the implementation MUST fail when this field is not `0`.
 
+Version less than 0 is invalid.
+
 #### Example
 
 This is an example of an empty `Document`.
 
 - Object format: `[0, []]`
-- Uint8 array: `[146, 0, 144]`
+- Binary data: `[146, 0, 144]`
 
 ### TypedMessageBase
 
@@ -114,7 +116,7 @@ When decoding, lack of content field should be treated as `TextFormat.PlainText`
 This is an example of a `Document` that contains a text message `"Hello, world"` in Markdown format with metadata `{"com.example.test": "hi"}`.
 
 - Object format: `[0, [[1, { "com.example.test": "hi" }, "Hello, world", 1]]]`
-- Uint8 array:
+- Binary data:
 
 ```plaintext
 [
@@ -145,7 +147,7 @@ This field represents an ordered list of a TypedMessage.
 This is an example of a `Document` that contains two text messages `"Hello, world"` with no metadata.
 
 - Object format: `[0, [ [0, null, [ [1, null, "Hello, world"], [1, null, "Hello, world"] ]] ]]`
-- Uint8 array:
+- Binary data:
 
 ```plaintext
  [

--- a/docs/rfc/000-TypedMessage-binary-format.md
+++ b/docs/rfc/000-TypedMessage-binary-format.md
@@ -38,8 +38,7 @@ All Tuple in this specification MUST be treated as non-fixed length. This means 
 This is the top-most data type.
 
 ```typescript
-type Document = [version: Integer, message: TypedMessageArray]
-interface TypedMessageArray extends Array<TypedMessageBase> {}
+type Document = [version: Integer, message: TypedMessageBase]
 ```
 
 #### `version` field
@@ -51,13 +50,6 @@ When encoding, the implementation MUST use `0` as the value of this field.
 When decoding, the implementation MUST fail when this field is not `0`.
 
 Version less than 0 is invalid.
-
-#### Example
-
-This is an example of an empty `Document`.
-
-- Object format: `[0, []]`
-- Binary data: `[146, 0, 144]`
 
 ### TypedMessageBase
 
@@ -117,22 +109,23 @@ When decoding, lack of content field should be treated as `TextFormat.PlainText`
 
 This is an example of a `Document` that contains a text message `"Hello, world"` in Markdown format with metadata `{"com.example.test": "hi"}`.
 
-- Object format: `[0, [[1, { "com.example.test": "hi" }, "Hello, world", 1]]]`
+- Object format: `[0, [1, { "com.example.test": "hi" }, "Hello, world", 1]]`
 - Binary data:
 
 ```plaintext
 [
-  146,   0, 145, 148,   1, 129, 176,  99,
-  111, 109,  46, 101, 120,  97, 109, 112,
-  108, 101,  46, 116, 101, 115, 116, 162,
-  104, 105, 172,  72, 101, 108, 108, 111,
-   44,  32, 119, 111, 114, 108, 100,   1
+  146,   0, 148,   1, 129, 176,  99, 111,
+  109,  46, 101, 120,  97, 109, 112, 108,
+  101,  46, 116, 101, 115, 116, 162, 104,
+  105, 172,  72, 101, 108, 108, 111,  44,
+   32, 119, 111, 114, 108, 100,   1
 ]
 ```
 
 ### TypedMessageTuple
 
 ```typescript
+interface TypedMessageArray extends Array<TypedMessageBase> {}
 type TypedMessageTuple = [
   type: TypedMessageTypeEnum.Tuple
   metadata: Map | Nil,
@@ -148,15 +141,15 @@ This field represents an ordered list of a TypedMessage.
 
 This is an example of a `Document` that contains two text messages `"Hello, world"` with no metadata.
 
-- Object format: `[0, [ [0, null, [ [1, null, "Hello, world"], [1, null, "Hello, world"] ]] ]]`
+- Object format: `[0, [0, null, [ [1, null, "Hello, world"], [1, null, "Hello, world"] ]] ]`
 - Binary data:
 
 ```plaintext
- [
-  146,   0, 145, 147,   0, 192, 146, 147,
-    1, 192, 172,  72, 101, 108, 108, 111,
-   44,  32, 119, 111, 114, 108, 100, 147,
-    1, 192, 172,  72, 101, 108, 108, 111,
-   44,  32, 119, 111, 114, 108, 100
+[
+  146,   0, 147,   0, 192, 146, 147,  1,
+  192, 172,  72, 101, 108, 108, 111, 44,
+   32, 119, 111, 114, 108, 100, 147,  1,
+  192, 172,  72, 101, 108, 108, 111, 44,
+   32, 119, 111, 114, 108, 100
 ]
 ```

--- a/docs/rfc/000-TypedMessage-binary-format.md
+++ b/docs/rfc/000-TypedMessage-binary-format.md
@@ -13,7 +13,9 @@ Playground: copy [the playground file](./000-TypedMessage-and-Payload-37-playgro
 
 To avoid reinvention of a new binary format, this RFC chooses to convert data into a format that can be represented in the MessagePack binary format.
 
-Type `Integer`, `Float`, `Nil`, `Boolean`, `String`, `Binary`, `Array` and `Map` is defined in the [msgpack specification](https://github.com/msgpack/msgpack/blob/master/spec.md). Other type defined in this RFC is written in the TypeScript syntax.
+Type `Integer`, `Float`, `Nil`, `Boolean`, `String`, `Binary`, `Array` and `Map` is defined in the [msgpack specification][msgpack-spec]. Other type defined in this RFC is written in the TypeScript syntax.
+
+[msgpack-spec]: https://github.com/msgpack/msgpack/blob/master/spec.md
 
 To avoid encoding field names into the binary (this is space-wasting), this RFC chooses to use tuple (`Array` in MessagePack), in which the order of the fields represented its meaning.
 

--- a/docs/rfc/000-TypedMessage-binary-format.md
+++ b/docs/rfc/000-TypedMessage-binary-format.md
@@ -1,5 +1,7 @@
 # TypedMessage binary format
 
+Playground: copy [the playground file](./000-TypedMessage-and-Payload-37-playground.js) into a https: web page.
+
 ## Design target
 
 - MUST be a binary format.


### PR DESCRIPTION
- TypedMessage binary format ([rendered preview](https://github.com/DimensionDev/Maskbook/blob/rfc/next-payload/docs/rfc/000-TypedMessage-binary-format.md))
- Payload 37 format ([rendered preview](https://github.com/DimensionDev/Maskbook/blob/rfc/next-payload/docs/rfc/000-Payload-v37.md))