### PR TITLE
fix: disallow other package manager lock-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,7 @@ common/autoinstallers/*/.npmrc
 
 # Mac
 .DS_Store
+
+# Disallow other package manager lock-file
+/package-lock.json
+/yarn.lock


### PR DESCRIPTION
Avoid uploads by third-party contributors the non pnpm lock file