### PR TITLE
fix: remove unnecessary inline style for drawer header

### DIFF
--- a/packages/maskbook/src/extension/options-page/DashboardComponents/Drawer.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardComponents/Drawer.tsx
@@ -148,10 +148,7 @@ export default function Drawer(props: DrawerProps) {
         <ThemeProvider theme={drawerTheme}>
             <nav className={classes.drawer}>
                 {xsMatched ? null : (
-                    <Box
-                        onClick={onDebugPage}
-                        className={classes.drawerHeader}
-                        style={{ backgroundColor: `var(--drawerBody)` }}>
+                    <Box onClick={onDebugPage} className={classes.drawerHeader}>
                         <Logo />
                     </Box>
                 )}


### PR DESCRIPTION
<!-- Please refer to the related issue number -->

The drawer header already has `background-color: var(--drawerHeader);` style declared.

![image](https://user-images.githubusercontent.com/1141198/113959506-9b4ba480-9855-11eb-911f-e2b36c6e7bbc.png)

