### PR TITLE
feat: new concurrent mode helper

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
     "async-call-rpc": "^5.0.0",
     "bignumber.js": "^9.0.1",
     "immer": "^9.0.1",
+    "jotai": "^0.16.0",
     "ts-results": "^3.1.1",
     "typeson": "^6.0.0",
     "typeson-registry": "^1.0.0-alpha.38",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,4 +3,5 @@ export { IdentifierMap, ReadonlyIdentifierMap } from './Identifier/IdentifierMap
 export * from './Identifier/type'
 export * from './i18n/register-ns'
 export * from './react/createGlobalState'
+export * from './react/createAsync'
 export * from './ShadowRoot'

--- a/packages/shared/src/react/createAsync.ts
+++ b/packages/shared/src/react/createAsync.ts
@@ -1,0 +1,31 @@
+import { atom, useAtom } from 'jotai'
+import { useRef, unstable_useTransition, useCallback } from 'react'
+import { Result } from 'ts-results'
+import type {} from 'react/experimental'
+
+export type SuspendedAsync<Args extends unknown[], R> = readonly [
+    result: Result<R, unknown>,
+    newArgs: (...args: Args) => void,
+    isPending: boolean,
+]
+
+export function createSuspended<Args extends unknown[], R>(f: (...args: Args) => Promise<R>) {
+    return function useAsyncSuspended(opts: { init: Args }): SuspendedAsync<Args, R> {
+        const [startTransition, isPending] = unstable_useTransition()
+
+        const { args, result } = useRef(createAtom(f, opts.init)).current
+        const [, applyArgs] = useAtom(args)
+
+        return [
+            useAtom(result)[0],
+            useCallback((...a: Args) => startTransition(() => void applyArgs(a)), []),
+            isPending,
+        ]
+    }
+}
+
+function createAtom<Args extends unknown[], R>(f: (...args: Args) => Promise<R>, init: Args) {
+    const args = atom(init)
+    const result = atom((get) => Result.wrapAsync(() => f(...get(args))))
+    return { result, args }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,7 @@ importers:
       async-call-rpc: ^5.0.0
       bignumber.js: ^9.0.1
       immer: ^9.0.1
+      jotai: ^0.16.0
       ts-results: ^3.1.1
       typeson: ^6.0.0
       typeson-registry: ^1.0.0-alpha.38
@@ -501,6 +502,7 @@ importers:
       async-call-rpc: 5.0.0
       bignumber.js: 9.0.1
       immer: 9.0.1
+      jotai: 0.16.0_immer@9.0.1
       ts-results: 3.1.1
       typeson: 6.0.0
       typeson-registry: 1.0.0-alpha.39
@@ -13917,6 +13919,28 @@ packages:
       - ts-node
       - utf-8-validate
     dev: true
+
+  /jotai/0.16.0_immer@9.0.1:
+    resolution: {integrity: sha512-1DjHUnTWIZD9Qh/cM+snmgJbI13AYccqfcDu0Vs8+sXHfzUi6zNyJUKfmJAjTH6vM4y81ljooTj8jSLyQauQuw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      immer: '*'
+      optics-ts: '*'
+      react: '>=16.8'
+      react-query: '*'
+      xstate: '*'
+    peerDependenciesMeta:
+      immer:
+        optional: true
+      optics-ts:
+        optional: true
+      react-query:
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      immer: 9.0.1
+    dev: false
 
   /js-combinatorics/0.5.5:
     resolution: {integrity: sha512-WglFY9EQvwndNhuJLxxyjnC16649lfZly/G3M3zgQMwcWlJDJ0Jn9niPWeYjnLXwWOEycYVxR2Tk98WLeFkrcw==}


### PR DESCRIPTION
[jotai](https://github.com/pmndrs/jotai) is a ~concurrent-mode-ready~ library that supports async computation. I'm not intended to switch to jotai everywhere cause IMO React `useState` is good enough but I use it as an internal of our concurrent mode helper.

If you have read our current implementation (packages\shared\src\react\createGlobalState.ts and packages\shared\src\react\createResource.ts) you will find it's very complex.

Here I introduced a new API `createSuspended`. Here is how it used like


```ts
const useSomeAsyncTask = createSuspended(async (arg: string) => {
    return arg
})
function useComp() {
    const [data, update, isPending] = useSomeAsyncTask({ init: [''] })
    data.unwrap().toUpperCase()
    update('new text')
    isPending // same as useTransition
}
```

It can create a concurrent mode hook for async tasks. The hook needs an `init` argument to do the first time fetching and by the second time you need to call `update` (the 2nd argument) to trigger a suspended update.

The `data` returns in `Result<T, E>` the checked exception style to make sure you always checked the result. The third parameter is the same as the 2nd return of the React `useTransition` hook.

I don't have time to test this so I mark it as a draft for now. How do you think this API is designed? cc @zhouhanseng @nuanyang233 @guanbinrui