### PR TITLE
fix: hint info in wallet creation dialog being covered by the activated confirm button

### DIFF
--- a/packages/maskbook/src/extension/options-page/DashboardDialogs/Wallet.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardDialogs/Wallet.tsx
@@ -153,18 +153,20 @@ const useWalletImportDialogStyle = makeStyles((theme: Theme) =>
             fontSize: 12,
             fontWeight: 500,
             textAlign: 'center',
-            backgroundColor: '#FFD5B3',
+            backgroundColor: '#EFF5FF',
             color: 'black',
             padding: '8px 22px',
-            margin: '24px -36px 0',
+            margin: '8px 0 0',
             [theme.breakpoints.down('sm')]: {
-                margin: '24px -16px 0',
+                margin: '8px 0 0',
             },
+            position: 'relative',
+            zIndex: 1,
         },
         notificationIcon: {
             width: 16,
             height: 16,
-            color: '#FF9138',
+            color: theme.palette.primary.main,
         },
     }),
 )
@@ -212,11 +214,11 @@ export function DashboardWalletImportDialog(props: WrappedDialogProps<object>) {
                             sx={{
                                 display: 'flex',
                                 alignItems: 'center',
-                                justifyContent: 'center',
                             }}>
                             <FormControlLabel
                                 control={
                                     <Checkbox
+                                        color="primary"
                                         checked={confirmed}
                                         onChange={() => setConfirmed((confirmed) => !confirmed)}
                                     />
@@ -313,7 +315,7 @@ export function DashboardWalletImportDialog(props: WrappedDialogProps<object>) {
             },
         ],
         state,
-        height: 112,
+        height: 'auto',
     }
 
     const [, setCreateWalletDialogOpen] = useRemoteControlledDialog(WalletMessages.events.createWalletDialogUpdated)

--- a/packages/maskbook/src/extension/options-page/DashboardDialogs/Wallet.tsx
+++ b/packages/maskbook/src/extension/options-page/DashboardDialogs/Wallet.tsx
@@ -153,15 +153,10 @@ const useWalletImportDialogStyle = makeStyles((theme: Theme) =>
             fontSize: 12,
             fontWeight: 500,
             textAlign: 'center',
-            backgroundColor: '#EFF5FF',
-            color: 'black',
+            backgroundColor: theme.palette.mode === 'dark' ? '#17191D' : '#EFF5FF',
             padding: '8px 22px',
-            margin: '8px 0 0',
-            [theme.breakpoints.down('sm')]: {
-                margin: '8px 0 0',
-            },
-            position: 'relative',
-            zIndex: 1,
+            margin: theme.spacing(1, 0, 0),
+            borderRadius: '4px',
         },
         notificationIcon: {
             width: 16,


### PR DESCRIPTION
update some style as well after communicating with @xiazhiming 

<!-- Please refer to the related issue number -->
closes #2826

| | |
|--|--|
| ![image](https://user-images.githubusercontent.com/1141198/114827105-dcfec100-9dfa-11eb-965f-c5d837f131d6.png) | ![image](https://user-images.githubusercontent.com/1141198/114827134-e720bf80-9dfa-11eb-97ca-c62d04b1da64.png) |
| ![image](https://user-images.githubusercontent.com/1141198/114827059-cfe1d200-9dfa-11eb-9a71-fed4f43e2240.png) | ![image](https://user-images.githubusercontent.com/1141198/114827172-eee06400-9dfa-11eb-84cd-638419435123.png) |

