### PR TITLE
chore: revamp snapshot

### DIFF
--- a/packages/maskbook/src/plugins/Snapshot/UI/LoadingCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/LoadingCard.tsx
@@ -21,6 +21,7 @@ export function LoadingCard(props: React.PropsWithChildren<{ title: string }>) {
                 <SnapshotCard title={props.title}>
                     {new Array(2).fill(0).map((_, i) => (
                         <Skeleton
+                            key={i}
                             className={classes.skeleton}
                             animation="wave"
                             variant="rectangular"

--- a/packages/maskbook/src/plugins/Snapshot/UI/LoadingCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/LoadingCard.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+import { createStyles, makeStyles, Skeleton } from '@material-ui/core'
+import { SnapshotCard } from './SnapshotCard'
+
+const useStyles = makeStyles((theme) => {
+    return createStyles({
+        skeleton: {
+            margin: theme.spacing(1),
+            '&:first-child': {
+                marginTop: theme.spacing(2),
+            },
+        },
+    })
+})
+
+export function LoadingCard(props: React.PropsWithChildren<{ title: string }>) {
+    const classes = useStyles()
+    return (
+        <Suspense
+            fallback={
+                <SnapshotCard title={props.title}>
+                    {new Array(2).fill(0).map((_, i) => (
+                        <Skeleton
+                            className={classes.skeleton}
+                            animation="wave"
+                            variant="rectangular"
+                            width={i === 0 ? '80%' : '60%'}
+                            height={15}></Skeleton>
+                    ))}
+                </SnapshotCard>
+            }>
+            {props.children}
+        </Suspense>
+    )
+}

--- a/packages/maskbook/src/plugins/Snapshot/UI/LoadingFailCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/LoadingFailCard.tsx
@@ -2,7 +2,7 @@ import { Component } from 'react'
 import { SnapshotCard } from './SnapshotCard'
 import { Typography, Button } from '@material-ui/core'
 
-export class NetworkFail extends Component<{ title: string; retry: () => void; isFullPluginDown?: boolean }> {
+export class LoadingFailCard extends Component<{ title: string; retry: () => void; isFullPluginDown?: boolean }> {
     static getDerivedStateFromError(error: unknown) {
         return { error }
     }

--- a/packages/maskbook/src/plugins/Snapshot/UI/PostInspector.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/PostInspector.tsx
@@ -1,7 +1,7 @@
 import { SnapshotContext } from '../context'
 import { getProposalIdentifier } from '../helpers'
 import { Snapshot } from './Snapshot'
-import { NetworkFail } from './NetworkFail'
+import { LoadingFailCard } from './LoadingFailCard'
 import { useRetry } from '../hooks/useRetry'
 
 export interface PostInspectorProps {
@@ -13,9 +13,9 @@ export function PostInspector(props: PostInspectorProps) {
     const retry = useRetry()
     return (
         <SnapshotContext.Provider value={identifier}>
-            <NetworkFail title="" isFullPluginDown={true} retry={retry}>
+            <LoadingFailCard title="" isFullPluginDown={true} retry={retry}>
                 <Snapshot />
-            </NetworkFail>
+            </LoadingFailCard>
         </SnapshotContext.Provider>
     )
 }

--- a/packages/maskbook/src/plugins/Snapshot/UI/ProgressTab.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/ProgressTab.tsx
@@ -1,22 +1,14 @@
 import { ResultCard } from './ResultCard'
 import { VotesCard } from './VotesCard'
-import { NetworkFail } from './NetworkFail'
 import { InformationCard } from './InformationCard'
 import { SnapshotTab } from './SnapshotTab'
-import { useI18N } from '../../../utils/i18n-next-ui'
 
-export function ProgressTab(props: { retry: () => void }) {
-    const { t } = useI18N()
-
+export function ProgressTab() {
     return (
         <SnapshotTab>
             <InformationCard />
-            <NetworkFail title={t('plugin_snapshot_result_title')} retry={props.retry}>
-                <ResultCard />
-            </NetworkFail>
-            <NetworkFail title={t('plugin_snapshot_votes_title')} retry={props.retry}>
-                <VotesCard />
-            </NetworkFail>
+            <ResultCard />
+            <VotesCard />
         </SnapshotTab>
     )
 }

--- a/packages/maskbook/src/plugins/Snapshot/UI/ProposalTab.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/ProposalTab.tsx
@@ -1,12 +1,19 @@
+import { useContext } from 'react'
 import { VotingCard } from './VotingCard'
+import { useProposal } from '../hooks/useProposal'
 import { SnapshotTab } from './SnapshotTab'
 import { ReadMeCard } from './ReadmeCard'
+import { SnapshotContext } from '../context'
 
 export function ProposalTab() {
+    const identifier = useContext(SnapshotContext)
+    const {
+        payload: { proposal },
+    } = useProposal(identifier.id)
     return (
         <SnapshotTab>
             <ReadMeCard />
-            <VotingCard />
+            {proposal.isEnd ? null : <VotingCard />}
         </SnapshotTab>
     )
 }

--- a/packages/maskbook/src/plugins/Snapshot/UI/ResultCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/ResultCard.tsx
@@ -186,9 +186,15 @@ function Loading(props: React.PropsWithChildren<{}>) {
 
 function Fail(props: React.PropsWithChildren<{}>) {
     const { t } = useI18N()
+    const identifier = useContext(SnapshotContext)
+    const {
+        payload: { proposal },
+    } = useProposal(identifier.id)
     const retry = useRetry()
     return (
-        <LoadingFailCard title={t('plugin_snapshot_result_title')} retry={retry}>
+        <LoadingFailCard
+            title={proposal.isEnd ? t('plugin_snapshot_result_title') : t('plugin_snapshot_current_result_title')}
+            retry={retry}>
             {props.children}
         </LoadingFailCard>
     )

--- a/packages/maskbook/src/plugins/Snapshot/UI/ResultCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/ResultCard.tsx
@@ -10,6 +10,9 @@ import { useVotes } from '../hooks/useVotes'
 import { useResults } from '../hooks/useResults'
 import { SnapshotCard } from './SnapshotCard'
 import { parse } from 'json2csv'
+import { useRetry } from '../hooks/useRetry'
+import { LoadingFailCard } from './LoadingFailCard'
+import { LoadingCard } from './LoadingCard'
 
 const choiceMaxWidth = 240
 
@@ -62,10 +65,10 @@ const StyledLinearProgress = withStyles({
     },
 })(LinearProgress)
 
-export function ResultCard() {
+function Content() {
     const identifier = useContext(SnapshotContext)
     const {
-        payload: { proposal, message },
+        payload: { proposal },
     } = useProposal(identifier.id)
     const { payload: votes } = useVotes(identifier)
     const {
@@ -164,5 +167,39 @@ export function ResultCard() {
                 </Button>
             ) : null}
         </SnapshotCard>
+    )
+}
+
+function Loading(props: React.PropsWithChildren<{}>) {
+    const { t } = useI18N()
+    const identifier = useContext(SnapshotContext)
+    const {
+        payload: { proposal },
+    } = useProposal(identifier.id)
+    return (
+        <LoadingCard
+            title={proposal.isEnd ? t('plugin_snapshot_result_title') : t('plugin_snapshot_current_result_title')}>
+            {props.children}
+        </LoadingCard>
+    )
+}
+
+function Fail(props: React.PropsWithChildren<{}>) {
+    const { t } = useI18N()
+    const retry = useRetry()
+    return (
+        <LoadingFailCard title={t('plugin_snapshot_result_title')} retry={retry}>
+            {props.children}
+        </LoadingFailCard>
+    )
+}
+
+export function ResultCard() {
+    return (
+        <Loading>
+            <Fail>
+                <Content />
+            </Fail>
+        </Loading>
     )
 }

--- a/packages/maskbook/src/plugins/Snapshot/UI/Snapshot.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/Snapshot.tsx
@@ -4,7 +4,6 @@ import { SnapshotContext } from '../context'
 import { useProposal } from '../hooks/useProposal'
 import { ProposalTab } from './ProposalTab'
 import { ProgressTab } from './ProgressTab'
-import { useRetry } from '../hooks/useRetry'
 
 const useStyles = makeStyles((theme) => {
     return {
@@ -63,8 +62,6 @@ export function Snapshot() {
         <Tab className={classes.tab} key="proposal" label="Proposal" />,
         <Tab className={classes.tab} key="progress" label="Progress" />,
     ]
-    const retry = useRetry()
-
     return (
         <Card className={classes.root} elevation={0}>
             <CardHeader
@@ -105,7 +102,7 @@ export function Snapshot() {
                 </Tabs>
                 <Paper className={classes.body}>
                     {tabIndex === 0 ? <ProposalTab /> : null}
-                    {tabIndex === 1 ? <ProgressTab retry={retry} /> : null}
+                    {tabIndex === 1 ? <ProgressTab /> : null}
                 </Paper>
             </CardContent>
         </Card>

--- a/packages/maskbook/src/plugins/Snapshot/UI/Vote.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/Vote.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Box, makeStyles } from '@material-ui/core'
 import { useBlockie } from '../../../web3/hooks/useBlockie'
-import type { Vote as VoteType } from '../types'
+import type { VoteItem as VoteType } from '../types'
 
 const useStlyes = makeStyles(() => ({
     avatar: {

--- a/packages/maskbook/src/plugins/Snapshot/UI/VotesCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/VotesCard.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import classNames from 'classnames'
-import type { Vote } from '../types'
+import type { VoteItem } from '../types'
 import millify from 'millify'
 import { Avatar, List, makeStyles, Typography, ListItem, Badge, Box, Link } from '@material-ui/core'
 import { resolveIPFSLink, resolveAddressLinkOnEtherscan } from '../../../web3/pipes'
@@ -82,7 +82,7 @@ function Content() {
                 </Badge>
             }>
             <List className={classes.list}>
-                {voteEntries.map((voteEntry: [string, Vote]) => {
+                {voteEntries.map((voteEntry: [string, VoteItem]) => {
                     return (
                         <ListItem className={classes.listItem} key={voteEntry[0]}>
                             <Link

--- a/packages/maskbook/src/plugins/Snapshot/UI/VotesCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/VotesCard.tsx
@@ -11,6 +11,9 @@ import { SnapshotCard } from './SnapshotCard'
 import { EthereumBlockie } from '../../../web3/UI/EthereumBlockie'
 import { useChainId } from '../../../web3/hooks/useBlockNumber'
 import { useI18N } from '../../../utils/i18n-next-ui'
+import { useRetry } from '../hooks/useRetry'
+import { LoadingFailCard } from './LoadingFailCard'
+import { LoadingCard } from './LoadingCard'
 
 const useStyles = makeStyles((theme) => {
     return {
@@ -59,7 +62,7 @@ const useStyles = makeStyles((theme) => {
     }
 })
 
-export function VotesCard() {
+function Content() {
     const chainId = useChainId()
     const identifier = useContext(SnapshotContext)
     const { payload: votes } = useVotes(identifier)
@@ -112,5 +115,30 @@ export function VotesCard() {
                 })}
             </List>
         </SnapshotCard>
+    )
+}
+
+function Loading(props: React.PropsWithChildren<{}>) {
+    const { t } = useI18N()
+    return <LoadingCard title={t('plugin_snapshot_votes_title')}>{props.children}</LoadingCard>
+}
+
+function Fail(props: React.PropsWithChildren<{}>) {
+    const { t } = useI18N()
+    const retry = useRetry()
+    return (
+        <LoadingFailCard title={t('plugin_snapshot_votes_title')} retry={retry}>
+            {props.children}
+        </LoadingFailCard>
+    )
+}
+
+export function VotesCard() {
+    return (
+        <Loading>
+            <Fail>
+                <Content />
+            </Fail>
+        </Loading>
     )
 }

--- a/packages/maskbook/src/plugins/Snapshot/UI/VotingCard.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/UI/VotingCard.tsx
@@ -12,6 +12,7 @@ import { usePower } from '../hooks/usePower'
 import { EthereumWalletConnectedBoundary } from '../../../web3/UI/EthereumWalletConnectedBoundary'
 import { VoteConfirmDialog } from './VoteConfirmDialog'
 import { useSnackbarCallback } from '../../../extension/options-page/DashboardDialogs/Base'
+import { useRetry } from '../hooks/useRetry'
 
 const useStyles = makeStyles((theme) => {
     return {
@@ -47,7 +48,7 @@ export function VotingCard() {
     const [choice, setChoice] = useState(0)
     const [open, setOpen] = useState(false)
     const [loading, setLoading] = useState(false)
-
+    const retry = useRetry()
     const onVoteConfirm = useSnackbarCallback(
         () => {
             setLoading(true)
@@ -57,6 +58,7 @@ export function VotingCard() {
         () => {
             setLoading(false)
             setOpen(false)
+            retry()
         },
         (_err: Error) => setLoading(false),
         void 0,

--- a/packages/maskbook/src/plugins/Snapshot/apis/index.ts
+++ b/packages/maskbook/src/plugins/Snapshot/apis/index.ts
@@ -1,6 +1,6 @@
 import ss from '@snapshot-labs/snapshot.js'
 import { ChainId } from '../../../web3/types'
-import type { Votes, Proposal, Profile3Box, ProposalMessage, ProposalIdentifier, VoteSuccess } from '../types'
+import type { VoteItemList, Proposal, Profile3Box, ProposalMessage, ProposalIdentifier, VoteSuccess } from '../types'
 import Services from '../../../extension/service'
 
 export async function fetchProposal(id: string) {
@@ -16,7 +16,7 @@ export async function fetchAllVotesOfProposal(id: string, space: string) {
     const response = await fetch(`https://hub.snapshot.page/api/${space}/proposal/${id}`, {
         method: 'GET',
     })
-    const result: Votes = await response.json()
+    const result: VoteItemList = await response.json()
     return result
 }
 

--- a/packages/maskbook/src/plugins/Snapshot/define.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/define.tsx
@@ -53,6 +53,7 @@ function Renderer({ url }: { url: string }) {
             <Suspense
                 fallback={new Array(2).fill(0).map((_, i) => (
                     <Skeleton
+                        key={i}
                         className={classes.skeleton}
                         animation="wave"
                         variant="rectangular"

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useProposal.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useProposal.ts
@@ -3,8 +3,8 @@ import type { Proposal, ProposalMessage } from '../types'
 import { useSuspense } from '../../../utils/hooks/useSuspense'
 
 const cache = new Map<string, [0, Promise<void>] | [1, { proposal: Proposal; message: ProposalMessage }] | [2, Error]>()
-export function proposalErrorRetry() {
-    cache.forEach(([status], id) => status === 2 && cache.delete(id))
+export function proposalRetry() {
+    cache.forEach(([_status], id) => cache.delete(id))
 }
 export function useProposal(id: string) {
     return useSuspense<{ proposal: Proposal; message: ProposalMessage }, [string]>(id, [id], cache, Suspender)

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useProposal.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useProposal.ts
@@ -4,7 +4,7 @@ import { useSuspense } from '../../../utils/hooks/useSuspense'
 
 const cache = new Map<string, [0, Promise<void>] | [1, { proposal: Proposal; message: ProposalMessage }] | [2, Error]>()
 export function proposalRetry() {
-    cache.forEach(([_status], id) => cache.delete(id))
+    Array.from(cache.keys()).forEach((id) => cache.delete(id))
 }
 export function useProposal(id: string) {
     return useSuspense<{ proposal: Proposal; message: ProposalMessage }, [string]>(id, [id], cache, Suspender)

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useProposal.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useProposal.ts
@@ -4,7 +4,9 @@ import { useSuspense } from '../../../utils/hooks/useSuspense'
 
 const cache = new Map<string, [0, Promise<void>] | [1, { proposal: Proposal; message: ProposalMessage }] | [2, Error]>()
 export function proposalRetry() {
-    Array.from(cache.keys()).forEach((id) => cache.delete(id))
+    for (const key of cache.keys()) {
+        cache.delete(key)
+    }
 }
 export function useProposal(id: string) {
     return useSuspense<{ proposal: Proposal; message: ProposalMessage }, [string]>(id, [id], cache, Suspender)

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
@@ -1,4 +1,4 @@
-import type { ProposalIdentifier, ProposalResult, Votes } from '../types'
+import type { ProposalIdentifier, ProposalResult, VoteItemList } from '../types'
 import { useSuspense } from '../../../utils/hooks/useSuspense'
 import { useProposal } from './useProposal'
 import { useVotes } from './useVotes'
@@ -52,6 +52,6 @@ async function Suspender(identifier: ProposalIdentifier) {
     return { results, totalPower }
 }
 
-function voteForChoice(votes: Votes, i: number) {
+function voteForChoice(votes: VoteItemList, i: number) {
     return Object.values(votes).filter((vote) => vote.msg.payload.choice === i + 1)
 }

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
@@ -8,7 +8,7 @@ const cache = new Map<
     [0, Promise<void>] | [1, { results: ProposalResult[]; totalPower: number }] | [2, Error]
 >()
 export function resultsRetry() {
-    cache.forEach(([_status], id) => cache.delete(id))
+    Array.from(cache.keys()).forEach((id) => cache.delete(id))
 }
 export function useResults(identifier: ProposalIdentifier) {
     return useSuspense<{ results: ProposalResult[]; totalPower: number }, [ProposalIdentifier]>(

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
@@ -8,7 +8,9 @@ const cache = new Map<
     [0, Promise<void>] | [1, { results: ProposalResult[]; totalPower: number }] | [2, Error]
 >()
 export function resultsRetry() {
-    Array.from(cache.keys()).forEach((id) => cache.delete(id))
+    for (const key of cache.keys()) {
+        cache.delete(key)
+    }
 }
 export function useResults(identifier: ProposalIdentifier) {
     return useSuspense<{ results: ProposalResult[]; totalPower: number }, [ProposalIdentifier]>(

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useResults.ts
@@ -7,8 +7,8 @@ const cache = new Map<
     string,
     [0, Promise<void>] | [1, { results: ProposalResult[]; totalPower: number }] | [2, Error]
 >()
-export function resultsErrorRetry() {
-    cache.forEach(([status], id) => status === 2 && cache.delete(id))
+export function resultsRetry() {
+    cache.forEach(([_status], id) => cache.delete(id))
 }
 export function useResults(identifier: ProposalIdentifier) {
     return useSuspense<{ results: ProposalResult[]; totalPower: number }, [ProposalIdentifier]>(

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useRetry.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useRetry.ts
@@ -1,15 +1,15 @@
 import { useCallback } from 'react'
 import { useUpdate } from 'react-use'
-import { proposalErrorRetry } from '../hooks/useProposal'
-import { votesErrorRetry } from '../hooks/useVotes'
-import { resultsErrorRetry } from '../hooks/useResults'
+import { proposalRetry } from '../hooks/useProposal'
+import { votesRetry } from '../hooks/useVotes'
+import { resultsRetry } from '../hooks/useResults'
 
 export function useRetry() {
     const forceUpdate = useUpdate()
     return useCallback(() => {
-        proposalErrorRetry()
-        votesErrorRetry()
-        resultsErrorRetry()
+        proposalRetry()
+        votesRetry()
+        resultsRetry()
         forceUpdate()
     }, [])
 }

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useRetry.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useRetry.ts
@@ -1,13 +1,11 @@
 import { useCallback } from 'react'
 import { useUpdate } from 'react-use'
-import { proposalRetry } from '../hooks/useProposal'
 import { votesRetry } from '../hooks/useVotes'
 import { resultsRetry } from '../hooks/useResults'
 
 export function useRetry() {
     const forceUpdate = useUpdate()
     return useCallback(() => {
-        proposalRetry()
         votesRetry()
         resultsRetry()
         forceUpdate()

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
@@ -7,7 +7,9 @@ import { ChainId } from '../../../web3/types'
 
 const cache = new Map<string, [0, Promise<void>] | [1, Votes] | [2, Error]>()
 export function votesRetry() {
-    Array.from(cache.keys()).forEach((id) => cache.delete(id))
+    for (const key of cache.keys()) {
+        cache.delete(key)
+    }
 }
 export function useVotes(identifier: ProposalIdentifier) {
     return useSuspense<Votes, [ProposalIdentifier]>(identifier.id, [identifier], cache, Suspender)

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
@@ -6,8 +6,8 @@ import { useBlockNumber } from '../../../web3/hooks/useBlockNumber'
 import { ChainId } from '../../../web3/types'
 
 const cache = new Map<string, [0, Promise<void>] | [1, Votes] | [2, Error]>()
-export function votesErrorRetry() {
-    cache.forEach(([status], id) => status === 2 && cache.delete(id))
+export function votesRetry() {
+    cache.forEach(([_status], id) => cache.delete(id))
 }
 export function useVotes(identifier: ProposalIdentifier) {
     return useSuspense<Votes, [ProposalIdentifier]>(identifier.id, [identifier], cache, Suspender)

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
@@ -1,18 +1,18 @@
 import { PluginSnapshotRPC } from '../messages'
-import type { Votes, ProposalIdentifier, Vote } from '../types'
+import type { VoteItemList, ProposalIdentifier, VoteItem } from '../types'
 import { useSuspense } from '../../../utils/hooks/useSuspense'
 import { useProposal } from './useProposal'
 import { useBlockNumber } from '../../../web3/hooks/useBlockNumber'
 import { ChainId } from '../../../web3/types'
 
-const cache = new Map<string, [0, Promise<void>] | [1, Votes] | [2, Error]>()
+const cache = new Map<string, [0, Promise<void>] | [1, VoteItemList] | [2, Error]>()
 export function votesRetry() {
     for (const key of cache.keys()) {
         cache.delete(key)
     }
 }
 export function useVotes(identifier: ProposalIdentifier) {
-    return useSuspense<Votes, [ProposalIdentifier]>(identifier.id, [identifier], cache, Suspender)
+    return useSuspense<VoteItemList, [ProposalIdentifier]>(identifier.id, [identifier], cache, Suspender)
 }
 async function Suspender(identifier: ProposalIdentifier) {
     const blockNumber = useBlockNumber(ChainId.Mainnet)
@@ -28,7 +28,7 @@ async function Suspender(identifier: ProposalIdentifier) {
 
     const votes = Object.fromEntries(
         Object.entries(rawVotes)
-            .map((voteEntry: [string, Vote]) => {
+            .map((voteEntry: [string, VoteItem]) => {
                 voteEntry[1].scores = message.payload.metadata.strategies.map(
                     (_strategy, i) => scores[i][voteEntry[1].address] || 0,
                 )

--- a/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
+++ b/packages/maskbook/src/plugins/Snapshot/hooks/useVotes.ts
@@ -7,7 +7,7 @@ import { ChainId } from '../../../web3/types'
 
 const cache = new Map<string, [0, Promise<void>] | [1, Votes] | [2, Error]>()
 export function votesRetry() {
-    cache.forEach(([_status], id) => cache.delete(id))
+    Array.from(cache.keys()).forEach((id) => cache.delete(id))
 }
 export function useVotes(identifier: ProposalIdentifier) {
     return useSuspense<Votes, [ProposalIdentifier]>(identifier.id, [identifier], cache, Suspender)

--- a/packages/maskbook/src/plugins/Snapshot/types.ts
+++ b/packages/maskbook/src/plugins/Snapshot/types.ts
@@ -60,7 +60,7 @@ export interface ProposalMessage {
 /**
  * Payload of a vote
  */
-export interface Vote {
+export interface VoteItem {
     choice: string
     address: string
     authorIpfsHash: string
@@ -85,8 +85,8 @@ export interface Vote {
     }
 }
 
-export type Votes = {
-    [key in string]: Vote
+export type VoteItemList = {
+    [key in string]: VoteItem
 }
 
 export interface ProposalResult {


### PR DESCRIPTION
Revamp suspense related. Display loading UI for single card rather than whole plugin when only single card is loading.

From:

<img src="https://user-images.githubusercontent.com/63733714/117238146-f7a6e180-ae5e-11eb-8487-74381cd7afbe.png" width=400 />

to:

<img src="https://user-images.githubusercontent.com/63733714/117237834-53249f80-ae5e-11eb-817e-1696880377d3.png" width=400 />

<img src="https://user-images.githubusercontent.com/63733714/117237666-00e37e80-ae5e-11eb-8895-0a09cbc10e78.png" width=400 />


