### PR TITLE
fix: material-ui@5-alpha.29 makes paper look lighter on dark mode

### DIFF
--- a/packages/maskbook/src/components/InjectedComponents/ToolboxHint.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/ToolboxHint.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
                 ? 'rgba(255, 255, 255, 0.2) 0px 0px 15px, rgba(255, 255, 255, 0.15) 0px 0px 3px 1px'
                 : 'rgba(101, 119, 134, 0.2) 0px 0px 15px, rgba(101, 119, 134, 0.15) 0px 0px 3px 1px'
         }`,
+        backgroundImage: 'none',
     },
     menu: {
         paddingTop: 0,

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/customization/custom.ts
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/customization/custom.ts
@@ -137,6 +137,7 @@ export const useInjectedDialogClassesOverwriteTwitter = makeStyles((theme) =>
         paper: {
             width: '600px !important',
             boxShadow: 'none',
+            backgroundImage: 'none',
             [`@media (max-width: ${theme.breakpoints.values.sm}px)`]: {
                 '&': {
                     display: 'block !important',


### PR DESCRIPTION
refs:
- https://github.com/mui-org/material-ui/commit/1f267fabe0dcf8a816b5ddbd89b1cf9dd2d6435a
- https://github.com/mui-org/material-ui/blob/58c7e708a419bc8895774e964b8ef00b55d045ac/packages/material-ui/src/Paper/Paper.js#L72-L75

![image](https://user-images.githubusercontent.com/1141198/117239714-de536480-ae61-11eb-88be-e3f84a6e3dd4.png)

