### PR TITLE
feat: support theme access in icons package close #3153

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,6 +4,9 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "sideEffects": false,
+  "dependencies": {
+    "@dimensiondev/maskbook-theme": "workspace:*"
+  },
   "devDependencies": {
     "snowpack": "^3.3.5"
   },

--- a/packages/icons/utils/index.tsx
+++ b/packages/icons/utils/index.tsx
@@ -1,5 +1,5 @@
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon'
-import useTheme from '@material-ui/core/styles/useTheme'
+import { useTheme } from '@material-ui/core/styles'
 import { forwardRef, memo, ForwardedRef } from 'react'
 import type { Theme } from '@material-ui/core'
 

--- a/packages/icons/utils/index.tsx
+++ b/packages/icons/utils/index.tsx
@@ -1,5 +1,12 @@
-import SvgIcon from '@material-ui/core/SvgIcon'
-import { ReactNode, forwardRef, memo } from 'react'
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon'
+import useTheme from '@material-ui/core/styles/useTheme'
+import { forwardRef, memo, ForwardedRef } from 'react'
+import type { Theme } from '@material-ui/core'
+
+/** @internal */
+export type Size = [width: number | undefined, height: number | undefined]
+/** @internal */
+export type SvgIconRaw = JSX.Element | ((theme: Theme) => JSX.Element)
 
 /**
  * Create a icon from svg fragment
@@ -10,18 +17,43 @@ import { ReactNode, forwardRef, memo } from 'react'
  * @param defaultSize Only use this when the icon is not square. Unit: px
  * @returns A component that same type as icons from @material-ui/icons
  */
-export function createIcon(
-    name: string,
-    svg: ReactNode,
-    viewBox?: string,
-    defaultSize?: [width: number | undefined, height: number | undefined],
-): typeof SvgIcon {
+export function createIcon(name: string, svg: SvgIconRaw, viewBox?: string, defaultSize?: Size) {
     const [width, height] = defaultSize || []
     if (width === height && typeof width === 'number') throw new Error('Only define this when the icon is not a square')
-    const Icon = function Icon({ sx, ...props }: any, ref: any) {
-        const style = defaultSize ? { width, height, ...sx } : sx
-        return <SvgIcon viewBox={viewBox} {...props} ref={ref} children={svg} sx={style} />
-    } as any
+    type Component = ((props: SvgIconProps, ref: ForwardedRef<SVGSVGElement>) => JSX.Element) & {
+        displayName?: string
+    }
+
+    const Icon: Component =
+        typeof svg === 'function'
+            ? ({ sx, ...props }, ref) => {
+                  const style = defaultSize ? { width, height, ...sx } : sx
+                  return <SvgIcon viewBox={viewBox} {...props} ref={ref} children={svg(useTheme())} sx={style} />
+              }
+            : ({ sx, ...props }, ref) => {
+                  const style = defaultSize ? { width, height, ...sx } : sx
+                  return <SvgIcon viewBox={viewBox} {...props} ref={ref} children={svg} sx={style} />
+              }
     Icon.displayName = `Icon (${name})`
     return memo(forwardRef(Icon)) as unknown as typeof SvgIcon
+}
+
+/**
+ * Create a icon from svg fragment
+ * @internal
+ * @param name Name of the Icon
+ * @param light SVG content when the theme is light theme. Do not include <svg> tag
+ * @param dark SVG content when the theme is light theme. Do not include <svg> tag
+ * @param viewBox The viewbox
+ * @param defaultSize Only use this when the icon is not square. Unit: px
+ * @returns A component that same type as icons from @material-ui/icons
+ */
+export function createPaletteAwareIcon(
+    name: string,
+    light: JSX.Element,
+    dark: JSX.Element,
+    viewBox?: string,
+    defaultSize?: Size,
+) {
+    return createIcon(name, (theme) => (theme.palette.mode === 'light' ? light : dark), viewBox, defaultSize)
 }

--- a/packages/icons/utils/index.tsx
+++ b/packages/icons/utils/index.tsx
@@ -9,7 +9,7 @@ export type Size = [width: number | undefined, height: number | undefined]
 export type SvgIconRaw = JSX.Element | ((theme: Theme) => JSX.Element)
 
 /**
- * Create a icon from svg fragment
+ * Create an icon from svg fragment
  * @internal
  * @param name Name of the Icon
  * @param svg SVG content. Do not include <svg> tag
@@ -39,7 +39,7 @@ export function createIcon(name: string, svg: SvgIconRaw, viewBox?: string, defa
 }
 
 /**
- * Create a icon from svg fragment
+ * Create an icon from svg fragment
  * @internal
  * @param name Name of the Icon
  * @param light SVG content when the theme is light theme. Do not include <svg> tag

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,7 +183,10 @@ importers:
 
   packages/icons:
     specifiers:
+      '@dimensiondev/maskbook-theme': workspace:*
       snowpack: ^3.3.5
+    dependencies:
+      '@dimensiondev/maskbook-theme': link:../theme
     devDependencies:
       snowpack: 3.3.5
 


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #3153 

This PR do the following changes:

Before:

```ts
export function createIcon(
    name: string,
    svg: React.ReactNode,
    viewBox?: string,
    defaultSize?: Size
): typeof SvgIcon
```

After:

```ts
export function createIcon(
    name: string,
    svg: JSX.Element | ((theme: Theme) => JSX.Element),
    viewBox?: string,
    defaultSize?: Size
): typeof SvgIcon

export function createPaletteAwareIcon(
    name: string,
    light: JSX.Element,
    dark: JSX.Element,
    viewBox?: string,
    defaultSize?: Size
): typeof SvgIcon
```