### PR TITLE
fix: theme color got updated according to wrong element

### DIFF
--- a/packages/maskbook/src/social-network-adaptor/twitter.com/utils/selector.ts
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/utils/selector.ts
@@ -18,9 +18,9 @@ const querySelectorAll = <T extends E>(selector: string) => {
 export const rootSelector: () => LiveSelector<E, true> = () => querySelector<E>('#react-root')
 
 export const composeAnchorSelector: () => LiveSelector<HTMLAnchorElement, true> = () =>
-    querySelector<HTMLAnchorElement>('a[href="/compose/tweet"]')
+    querySelector<HTMLAnchorElement>('header[role=banner] a[href="/compose/tweet"]')
 export const composeAnchorTextSelector: () => LiveSelector<HTMLAnchorElement, true> = () =>
-    querySelector<HTMLAnchorElement>('a[href="/compose/tweet"] div[dir]')
+    querySelector<HTMLAnchorElement>('header[role=banner] a[href="/compose/tweet"] div[dir]')
 
 export const postEditorContentInPopupSelector: () => LiveSelector<E, true> = () =>
     querySelector<E>('[aria-labelledby="modal-header"] > div:first-child > div:nth-child(3)')


### PR DESCRIPTION
theme color got updated according to `a[href=/compose/tweet]`.
When retweet menu which also contains an `a[href=/compose/tweet]`,
pop up, theme color got updated by the menu wrongly.

fixes: #3168
