### PR TITLE
fix: postInspector fails to find the original tweet if there is a retweet of it

### DIFF
--- a/packages/maskbook/src/social-network-adaptor/twitter.com/utils/fetch.ts
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/utils/fetch.ts
@@ -112,7 +112,10 @@ export const postIdParser = (node: HTMLElement) => {
                 node.closest('article > div')?.querySelector<HTMLAnchorElement>('a[href*="status"]'),
             ),
         )
-        return idNode ? parseId(idNode.href) : parseId(location.href)
+        const isRetweet = !!node.querySelector('[data-testid=socialContext]')
+        const pid = idNode ? parseId(idNode.href) : parseId(location.href)
+        // You can't retweet a tweet or a retweet, but only cancel retweeting
+        return isRetweet ? `retweet:${pid}` : pid
     }
 }
 


### PR DESCRIPTION
fixes #3161


![image](https://user-images.githubusercontent.com/1141198/118616598-6c313700-b7f4-11eb-86f2-2ecf45c9dfd3.png)
