### PR TITLE
feat: add requestBrowserPermission

### DIFF
--- a/packages/maskbook/src/UIRoot.tsx
+++ b/packages/maskbook/src/UIRoot.tsx
@@ -4,7 +4,7 @@ import { I18nextProvider } from 'react-i18next'
 import i18nNextInstance from './utils/i18n-next'
 import { ErrorBoundary, ErrorBoundaryBuildInfoContext } from '@dimensiondev/maskbook-theme'
 import { buildInfoMarkdown } from './extension/background-script/Jobs/PrintBuildFlags'
-import { StyledEngineProvider, ThemeProvider } from '@material-ui/core'
+import { CssBaseline, StyledEngineProvider, ThemeProvider } from '@material-ui/core'
 import { StylesProvider } from '@material-ui/styles'
 import { useClassicMaskTheme } from './utils/theme'
 
@@ -29,7 +29,10 @@ export function MaskUIRoot(JSX: JSX.Element) {
     return MaskUIRootWithinShadow(
         <StyledEngineProvider injectFirst>
             <StylesProvider>
-                <ThemeProvider theme={useClassicMaskTheme()}>{JSX}</ThemeProvider>
+                <ThemeProvider theme={useClassicMaskTheme()}>
+                    <CssBaseline />
+                    {JSX}
+                </ThemeProvider>
             </StylesProvider>
         </StyledEngineProvider>,
     )

--- a/packages/maskbook/src/extension/background-script/HelperService.ts
+++ b/packages/maskbook/src/extension/background-script/HelperService.ts
@@ -1,4 +1,5 @@
 import { memoizePromise } from '../../utils/memoize'
+import { constructRequestPermissionURL } from '../popups'
 
 const cache = new Map<string, string>()
 export const resolveTCOLink = memoizePromise(
@@ -38,4 +39,28 @@ export function saveAsFileFromBuffer(file: BufferSource, mimeType: string, fileN
     const blob = new Blob([file], { type: mimeType })
     const url = URL.createObjectURL(blob)
     saveAsFileFromUrl(url, fileName)
+}
+
+export async function requestBrowserPermission(permission: browser.permissions.Permissions) {
+    if (await browser.permissions.contains(permission)) return true
+    try {
+        return await browser.permissions.request(permission)
+    } catch {
+        // which means we're on Firefox.
+        // Chrome allows permission request from the background.
+    }
+    const popup = await browser.windows.create({
+        height: 600,
+        width: 350,
+        type: 'popup',
+        url: constructRequestPermissionURL(permission),
+    })
+    return new Promise((resolve) => {
+        browser.windows.onRemoved.addListener(function listener(windowID: number) {
+            if (windowID === popup.id) {
+                resolve(browser.permissions.contains(permission))
+                browser.windows.onRemoved.removeListener(listener)
+            }
+        })
+    })
 }

--- a/packages/maskbook/src/extension/options-page/Route.ts
+++ b/packages/maskbook/src/extension/options-page/Route.ts
@@ -6,7 +6,6 @@ export enum DashboardRoute {
     Settings = '/settings',
     Plugins = '/plugins',
     Setup = '/setup',
-    RequestPermission = '/request-permission',
 }
 
 export enum DashboardWalletRoute {

--- a/packages/maskbook/src/extension/options-page/index.tsx
+++ b/packages/maskbook/src/extension/options-page/index.tsx
@@ -29,7 +29,6 @@ import { DashboardRoute } from './Route'
 import { SSRRenderer } from '../../utils/SSRRenderer'
 
 import Services from '../service'
-import { RequestPermissionPage } from '../../components/RequestPermission/RequestPermission'
 import { grey } from '@material-ui/core/colors'
 import { DashboardSnackbarProvider } from './DashboardComponents/DashboardSnackbar'
 import { SetupStep } from './SetupStep'
@@ -207,8 +206,6 @@ function DashboardUI() {
                 <Route path={DashboardRoute.Plugins} component={withErrorBoundary(DashboardPluginsRouter)} />
                 <Route path={DashboardRoute.Settings} component={withErrorBoundary(DashboardSettingsRouter)} />
                 <Route path={DashboardRoute.Setup} component={withErrorBoundary(DashboardSetupRouter)} />
-                {/* // TODO: this page should be boardless */}
-                <Route path={DashboardRoute.RequestPermission} component={withErrorBoundary(RequestPermissionPage)} />
                 <Redirect
                     path="*"
                     to={Flags.has_no_browser_tab_ui && xsMatched ? DashboardRoute.Nav : DashboardRoute.Personas}

--- a/packages/maskbook/src/extension/popups/RequestPermission/RequestPermission.tsx
+++ b/packages/maskbook/src/extension/popups/RequestPermission/RequestPermission.tsx
@@ -11,30 +11,41 @@ import {
     DialogActions,
     DialogContent,
 } from '@material-ui/core'
-import { useLocation } from 'react-router-dom'
+
 const useStyles = makeStyles((theme: Theme) => ({
     root: {
         margin: theme.spacing(2, 2, 2, 2),
     },
 }))
-interface RequestPermissionProps {
-    permission: browser.permissions.Permissions
+export interface RequestPermissionProps extends browser.permissions.Permissions {
     onRequestApprove(): void
     onCancel(): void
 }
 export function RequestPermission(props: RequestPermissionProps) {
     const classes = useStyles()
+    const { origins, permissions } = props
     return (
         <Card className={classes.root}>
             <DialogTitle>Mask needs the following permissions</DialogTitle>
             <DialogContent>
-                <List dense subheader={<ListSubheader>Sites</ListSubheader>}>
-                    {props.permission.origins?.map((x) => (
-                        <ListItem key={x}>
-                            <ListItemText primary={x}></ListItemText>
-                        </ListItem>
-                    ))}
-                </List>
+                {origins?.length ? (
+                    <List dense subheader={<ListSubheader>Sites</ListSubheader>}>
+                        {origins?.map((x) => (
+                            <ListItem key={x}>
+                                <ListItemText primary={x}></ListItemText>
+                            </ListItem>
+                        ))}
+                    </List>
+                ) : null}
+                {permissions?.length ? (
+                    <List dense subheader={<ListSubheader>Permissions</ListSubheader>}>
+                        {permissions?.map((x) => (
+                            <ListItem key={x}>
+                                <ListItemText primary={x}></ListItemText>
+                            </ListItem>
+                        ))}
+                    </List>
+                ) : null}
             </DialogContent>
             <DialogActions>
                 <Button onClick={props.onCancel} variant="text">
@@ -45,20 +56,5 @@ export function RequestPermission(props: RequestPermissionProps) {
                 </Button>
             </DialogActions>
         </Card>
-    )
-}
-
-export function RequestPermissionPage() {
-    const param = useLocation()
-    const _ = new URLSearchParams(param.search)
-    const origins = _.getAll('origin')
-    return (
-        <div style={{ width: 'fit-content', maxWidth: 600, margin: 'auto' }}>
-            <RequestPermission
-                onCancel={() => window.close()}
-                onRequestApprove={() => browser.permissions.request({ origins }).then(() => window.close())}
-                permission={{ origins }}
-            />
-        </div>
     )
 }

--- a/packages/maskbook/src/extension/popups/RequestPermission/index.tsx
+++ b/packages/maskbook/src/extension/popups/RequestPermission/index.tsx
@@ -25,7 +25,7 @@ export function RequestPermissionPage() {
     const permissions = _.getAll('permissions').filter(isAcceptablePermission)
 
     const { retry, value: hasPermission } = useAsyncRetry(
-        () => browser.permissions.request({ origins, permissions }),
+        () => browser.permissions.contains({ origins, permissions }),
         [param.search],
     )
 

--- a/packages/maskbook/src/extension/popups/RequestPermission/index.tsx
+++ b/packages/maskbook/src/extension/popups/RequestPermission/index.tsx
@@ -1,0 +1,52 @@
+import { Box } from '@material-ui/core'
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useAsyncRetry } from 'react-use'
+import { RequestPermission } from './RequestPermission'
+
+const acceptable: readonly browser.permissions.Permission[] = [
+    'alarms',
+    'clipboardRead',
+    'clipboardWrite',
+    'contextMenus',
+    'contextualIdentities',
+    'menus',
+    'notifications',
+    'webRequestBlocking',
+]
+function isAcceptablePermission(x: string): x is browser.permissions.Permission {
+    return (acceptable as string[]).includes(x)
+}
+
+export function RequestPermissionPage() {
+    const param = useLocation()
+    const _ = new URLSearchParams(param.search)
+    const origins = _.getAll('origins')
+    const permissions = _.getAll('permissions').filter(isAcceptablePermission)
+
+    const { retry, value: hasPermission } = useAsyncRetry(
+        () => browser.permissions.request({ origins, permissions }),
+        [param.search],
+    )
+
+    useEffect(() => {
+        if (hasPermission) window.close()
+    }, [hasPermission])
+    return (
+        <Box
+            sx={{
+                height: '100vh',
+                width: '100vw',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+            }}>
+            <RequestPermission
+                onCancel={() => window.close()}
+                onRequestApprove={() => browser.permissions.request({ origins, permissions }).finally(retry)}
+                origins={origins}
+                permissions={permissions}
+            />
+        </Box>
+    )
+}

--- a/packages/maskbook/src/extension/popups/RequestPermission/utils.ts
+++ b/packages/maskbook/src/extension/popups/RequestPermission/utils.ts
@@ -1,0 +1,9 @@
+import { DialogRoutes, getRouteURLWithNoParam } from '..'
+
+export function constructRequestPermissionURL(permission: browser.permissions.Permissions) {
+    const { origins = [], permissions = [] } = permission
+    const params = new URLSearchParams()
+    for (const each of origins) params.append('origins', each)
+    for (const each of permissions) params.append('permissions', each)
+    return `${getRouteURLWithNoParam(DialogRoutes.RequestPermission)}?${params.toString()}`
+}

--- a/packages/maskbook/src/extension/popups/index.tsx
+++ b/packages/maskbook/src/extension/popups/index.tsx
@@ -1,1 +1,8 @@
-export enum DialogRoutes {}
+export enum DialogRoutes {
+    RequestPermission = '/request-permission',
+}
+
+export function getRouteURLWithNoParam(kind: DialogRoutes) {
+    return browser.runtime.getURL(`/popups.html#${kind}`)
+}
+export { constructRequestPermissionURL } from './RequestPermission/utils'

--- a/packages/maskbook/src/extension/popups/render.tsx
+++ b/packages/maskbook/src/extension/popups/render.tsx
@@ -2,10 +2,12 @@
 /// <reference types="react-dom/experimental" />
 
 import { Suspense } from 'react'
-import { Switch } from 'react-router'
+import { Route, Switch } from 'react-router'
 import { HashRouter } from 'react-router-dom'
 import ReactDOM from 'react-dom'
 import { MaskUIRoot } from '../../UIRoot'
+import { DialogRoutes } from '.'
+import { RequestPermissionPage } from './RequestPermission'
 
 const root = document.createElement('div')
 document.body.insertBefore(root, document.body.children[0] || null)
@@ -15,7 +17,11 @@ function Dialogs() {
     return MaskUIRoot(
         <Suspense fallback="">
             <HashRouter>
-                <Switch></Switch>
+                <Switch>
+                    <Route path={DialogRoutes.RequestPermission}>
+                        <RequestPermissionPage />
+                    </Route>
+                </Switch>
             </HashRouter>
         </Suspense>,
     )


### PR DESCRIPTION
related #3131 (cc @manishoo)

This PR adds a new service method `Services.Helper.requestBrowserPermission` has the same function as `browser.permission.request` but works in content script.

In Chrome, it is OK to call `browser.permission.request` directly in the background.
In Firefox, it will create a new popup window that can request permission in that context.

UI is reused from the unused GitCoin plugin.

![image](https://user-images.githubusercontent.com/5390719/118627333-32652e00-b7fe-11eb-9050-c268123feeef.png)
