### PR TITLE
chore: ito tx hash disable button

### DIFF
--- a/packages/maskbook/src/_locales/en/messages.json
+++ b/packages/maskbook/src/_locales/en/messages.json
@@ -472,6 +472,7 @@
     "plugin_ito_begin_time": "Start Time {{zone}}",
     "plugin_ito_wait_unlock_time": "Claim in {{unlockTime}}",
     "plugin_ito_claim": "Claim",
+    "plugin_ito_claiming": "Claiming",
     "plugin_ito_claim_all": "Claim All",
     "plugin_ito_claimed": "Claimed",
     "plugin_ito_qualification_start_time": "Qualification Start Time:",

--- a/packages/maskbook/src/_locales/ja/messages.json
+++ b/packages/maskbook/src/_locales/ja/messages.json
@@ -472,6 +472,7 @@
     "plugin_ito_begin_time": "開始時刻 {{zone}}",
     "plugin_ito_wait_unlock_time": "",
     "plugin_ito_claim": "",
+    "plugin_ito_claiming": "",
     "plugin_ito_claim_all": "",
     "plugin_ito_claimed": "",
     "plugin_ito_qualification_start_time": "",

--- a/packages/maskbook/src/_locales/ko/messages.json
+++ b/packages/maskbook/src/_locales/ko/messages.json
@@ -472,6 +472,7 @@
     "plugin_ito_begin_time": "",
     "plugin_ito_wait_unlock_time": "",
     "plugin_ito_claim": "",
+    "plugin_ito_claiming": "",
     "plugin_ito_claim_all": "",
     "plugin_ito_claimed": "",
     "plugin_ito_qualification_start_time": "",

--- a/packages/maskbook/src/_locales/zh/messages.json
+++ b/packages/maskbook/src/_locales/zh/messages.json
@@ -472,6 +472,7 @@
     "plugin_ito_begin_time": "",
     "plugin_ito_wait_unlock_time": "",
     "plugin_ito_claim": "",
+    "plugin_ito_claiming": "",
     "plugin_ito_claim_all": "",
     "plugin_ito_claimed": "",
     "plugin_ito_qualification_start_time": "",

--- a/packages/maskbook/src/plugins/ITO/UI/ITO.tsx
+++ b/packages/maskbook/src/plugins/ITO/UI/ITO.tsx
@@ -609,8 +609,11 @@ export function ITO(props: ITO_Props) {
                                             onClick={onClaimButtonClick}
                                             variant="contained"
                                             size="large"
+                                            disabled={claimState.type === TransactionStateType.HASH}
                                             className={classes.actionButton}>
-                                            {t('plugin_ito_claim')}
+                                            {claimState.type === TransactionStateType.HASH
+                                                ? t('plugin_ito_claiming')
+                                                : t('plugin_ito_claim')}
                                         </ActionButton>
                                     ) : (
                                         <ActionButton


### PR DESCRIPTION
Disable the claim button after receive its relative tx hash and before network update.