### PR TITLE
ci: speedup ci by share build caches between build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,18 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: "**/dist/"
-          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
-          # Do not use restore-keys!
+          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
       - uses: actions/cache@v2
         with:
           path: ./packages/maskbook/node_modules/.cache/webpack/
-          key: ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}
-          # Do not use restore-keys! Cache should be drop once dependencies has changed.
+          key: ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
+          # Not fallback to different dependencies. Webpack seems like have bug.
+          # An example caused by the webpack cache bug: https://github.com/facebook/react/issues/21587
+          restore-keys: |
+            ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npx pnpm install
       - run: npx build-ci
       - name: Upload `Maskbook.base.zip`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,16 @@ jobs:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-node-
+      - uses: actions/cache@v2
+        with:
+          path: "**/dist/"
+          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
+          # Do not use restore-keys!
+      - uses: actions/cache@v2
+        with:
+          path: ./packages/maskbook/node_modules/.cache/webpack/
+          key: ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}
+          # Do not use restore-keys! Cache should be drop once dependencies has changed.
       - run: npx pnpm install
       - run: npx build-ci
       - name: Upload `Maskbook.base.zip`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
+      - name: Get cache date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,11 @@ jobs:
       #       npm -v
 
       # @v2 requires too much configurations
+      - name: Get cache date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
       - uses: actions/checkout@v1
 
       - uses: actions/cache@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,11 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - uses: actions/cache@v2
+        with:
+          path: "**/dist/"
+          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
+          # Do not use restore-keys
       - run: sudo npm i -g pnpm
       - run: npm run ci
       # Install puppeteer requires download a browser when installing which is noisy. Let's move it to CI only

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,8 +46,16 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: "**/dist/"
-          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
-          # Do not use restore-keys
+          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
+      - uses: actions/cache@v2
+        with:
+          path: ./packages/maskbook/node_modules/.cache/webpack/
+          key: ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: sudo npm i -g pnpm
       - run: npm run ci
       # Install puppeteer requires download a browser when installing which is noisy. Let's move it to CI only

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -41,6 +41,11 @@ jobs:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-node-
+      - uses: actions/cache@v2
+        with:
+          path: "**/dist/"
+          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
+          # Do not use restore-keys! tsc build should not be shared once tsc config has changed. But IMO it's safe to share if dependencies has changed.
       - run: npx pnpm install
       - run: npx build -- echo "Check tsc"
   eslint:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -43,25 +43,9 @@ jobs:
           restore-keys: ${{ runner.os }}-node-
       - run: npx pnpm install
       - run: npx build -- echo "Check tsc"
-  type-coverage:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v2-beta
-      - uses: actions/cache@v2
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-node-
-      - run: npx pnpm install
-      # typecoverage computes different coverage rate on the developer's machine and CI and fails on CI. disabled for now
-      # - run: npm run lint:typecoverage
-      #   working-directory: packages/maskbook
   eslint:
     runs-on: ubuntu-20.04
-    needs: [prettier, locale-kit, type-check, type-coverage]
+    needs: [prettier, locale-kit, type-check]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -32,6 +32,11 @@ jobs:
   type-check:
     runs-on: ubuntu-20.04
     steps:
+      - name: Get cache date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -44,8 +49,14 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: "**/dist/"
-          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
-          # Do not use restore-keys! tsc build should not be shared once tsc config has changed. But IMO it's safe to share if dependencies has changed.
+          # actions/cache will not upload changes in cache if primary key hits
+          # by adding date to the primary key, we can ensure the cache updates on the first build of the day
+          key: ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
+          # Allow fallback to cache of different dependencies but not allowing fallback to different tsconfig
+          # because that might indicates a structural/flags changes in tsc emit.
+          restore-keys: |
+            ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+            ${{ runner.os }}-tsc-${{ hashFiles('**/tsconfig.json') }}
       - run: npx pnpm install
       - run: npx build -- echo "Check tsc"
   eslint:

--- a/packages/dashboard/src/API.tsx
+++ b/packages/dashboard/src/API.tsx
@@ -2,17 +2,17 @@
 // In isolated mode, set up at ./initialization/isolated_bridge
 // In intergrated mode, set up at /packages/maskbook/src/extension/dashboard/index
 
-import type { Services as ServiceType } from '../../maskbook/dist/src/extension/service'
-import type { MaskMessage } from '../../maskbook/dist/src/utils/messages'
+import type { Services as ServiceType } from '../../maskbook/dist/extension/service'
+import type { MaskMessage } from '../../maskbook/dist/utils/messages'
 export let Services: typeof ServiceType = null!
 export let Messages: typeof MaskMessage = null!
 export let PluginServices: PluginServices = null!
 export let PluginMessages: PluginMessages = null!
 export interface PluginServices {
-    Wallet: typeof import('../../maskbook/dist/src/plugins/Wallet/messages').WalletRPC
+    Wallet: typeof import('../../maskbook/dist/plugins/Wallet/messages').WalletRPC
 }
 export interface PluginMessages {
-    Wallet: typeof import('../../maskbook/dist/src/plugins/Wallet/messages').WalletMessages
+    Wallet: typeof import('../../maskbook/dist/plugins/Wallet/messages').WalletMessages
 }
 export function setService(x: typeof ServiceType) {
     Services = x

--- a/packages/maskbook/src/database/migrate/fix.qr.private.key.bug.ts
+++ b/packages/maskbook/src/database/migrate/fix.qr.private.key.bug.ts
@@ -14,7 +14,6 @@ export default async function () {
     for (const id of ids) {
         const key = id.privateKey
         if (!key.d) {
-            console.log('Key is broken')
             deletePersona(id.identifier, 'delete even with private').catch(() => {})
             hasBug = true
         }

--- a/packages/maskbook/src/database/migrate/fix.qr.private.key.bug.ts
+++ b/packages/maskbook/src/database/migrate/fix.qr.private.key.bug.ts
@@ -14,6 +14,7 @@ export default async function () {
     for (const id of ids) {
         const key = id.privateKey
         if (!key.d) {
+            console.log('Key is broken')
             deletePersona(id.identifier, 'delete even with private').catch(() => {})
             hasBug = true
         }

--- a/packages/maskbook/src/database/tasks/clean-avatar-profile.ts
+++ b/packages/maskbook/src/database/tasks/clean-avatar-profile.ts
@@ -16,7 +16,6 @@ async function cleanAvatarDB(anotherList: IdentifierMap<ProfileIdentifier | Grou
 export async function cleanProfileWithNoLinkedPersona() {
     setTimeout(cleanProfileWithNoLinkedPersona, 1000 * 60 * 60 * 24 * 7 /** days */)
 
-    console.log('Run cleanProfileWithNoLinkedPersona...')
     const cleanedList = new IdentifierMap<ProfileIdentifier | GroupIdentifier, undefined>(
         new Map(),
         ProfileIdentifier,

--- a/packages/maskbook/src/database/tasks/clean-avatar-profile.ts
+++ b/packages/maskbook/src/database/tasks/clean-avatar-profile.ts
@@ -16,6 +16,7 @@ async function cleanAvatarDB(anotherList: IdentifierMap<ProfileIdentifier | Grou
 export async function cleanProfileWithNoLinkedPersona() {
     setTimeout(cleanProfileWithNoLinkedPersona, 1000 * 60 * 60 * 24 * 7 /** days */)
 
+    console.log('Run cleanProfileWithNoLinkedPersona...')
     const cleanedList = new IdentifierMap<ProfileIdentifier | GroupIdentifier, undefined>(
         new Map(),
         ProfileIdentifier,

--- a/packages/maskbook/tsconfig.json
+++ b/packages/maskbook/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDirs": ["./src/", "./abis/"],
-    "outDir": "./dist/"
+    "rootDir": "./src/",
+    "outDir": "./dist/",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": ["./src/**/*.tsx", "./src/**/*.ts", "./src/**/*.json", "./abis/*.json"],
+  "include": ["./src/**/*.tsx", "./src/**/*.ts", "./src/**/*.json"],
   // ! Note: maskbook/ depends dashboard/ on source-code level
   // !       but dashboard/ depends maskbook/ on type level
   // !       do not add dashboard/ as a reference otherwise there is a circular dependency on the type level.

--- a/packages/plugin-infra/tsconfig.json
+++ b/packages/plugin-infra/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src/",
     "outDir": "./dist/",
     "stripInternal": true,
-    "rootDir": "./src/"
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["./src/**/*"],
   "references": [{ "path": "../shared/" }, { "path": "../theme/" }, { "path": "../web3-shared" }],

--- a/packages/plugins/example/src/Components.tsx
+++ b/packages/plugins/example/src/Components.tsx
@@ -8,7 +8,6 @@ export function GlobalComponent() {
 }
 export function PluginDialog(props: { open: boolean; onClose: () => void }) {
     if (!props.open) return null
-    console.log('Dialog opened!')
     // TODO: the ShadowRoot related items are in the maskbook-shared package
     // TODO: but plugins should only rely on the plugin-infra package
     // TODO: so it's not possible to display a proper dialog in an isolated package

--- a/packages/plugins/example/src/Components.tsx
+++ b/packages/plugins/example/src/Components.tsx
@@ -8,6 +8,7 @@ export function GlobalComponent() {
 }
 export function PluginDialog(props: { open: boolean; onClose: () => void }) {
     if (!props.open) return null
+    console.log('Dialog opened!')
     // TODO: the ShadowRoot related items are in the maskbook-shared package
     // TODO: but plugins should only rely on the plugin-infra package
     // TODO: so it's not possible to display a proper dialog in an isolated package

--- a/packages/plugins/example/tsconfig.json
+++ b/packages/plugins/example/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src/",
     "outDir": "./dist/",
     "stripInternal": true,
-    "rootDir": "./src/"
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["./src/**/*"],
   "references": [{ "path": "../../plugin-infra" }],

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "./src/",
     "outDir": "./dist/",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["./src/"],
   "ts-node": {

--- a/packages/web3-shared/tsconfig.json
+++ b/packages/web3-shared/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src/",
-    "outDir": "./dist/"
+    "outDir": "./dist/",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx", "./src/**/*.json"],
   "ts-node": {


### PR DESCRIPTION
Before (on commit c40cc5e8f62ccc30c74d58b673d9176174fb0cc3 which does not have a dependency changes):

- Type check spent 1m35s (2m52s in total) to run
- Webpack spent 5m52s (7m1s in total) to run

After (when cache hits):

- Type check spent 14s (3m23s in total) to run
- Webpack spent 2m22s (6m31s in total) to run

Note: I only optimized for Github Actions. Not for CircleCI or Netlify (maybe future)