### PR TITLE
fix: the Past tabl of the Red Packet composition dialog

### DIFF
--- a/packages/maskbook/src/components/shared/AbstractTab.tsx
+++ b/packages/maskbook/src/components/shared/AbstractTab.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface TabPanelProps extends BoxProps {
     id?: string
     label: string
+    disabled?: boolean
 }
 
 export interface AbstractTabProps {
@@ -43,6 +44,7 @@ export default function AbstractTab({ tabs, state, height = 200 }: AbstractTabPr
                             label={tab.label}
                             key={tab.label}
                             data-testid={`${tab.id?.toLowerCase()}_tab`}
+                            disabled={tab.disabled ?? false}
                         />
                     ))}
                 </Tabs>

--- a/packages/maskbook/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
+++ b/packages/maskbook/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
@@ -70,6 +70,7 @@ export default function RedPacketDialog(props: RedPacketDialogProps) {
                 label: t('plugin_red_packet_select_existing'),
                 children: <RedPacketHistoryList onSelect={onCreateOrSelect} onClose={onClose} />,
                 sx: { p: 0 },
+                disabled: !account,
             },
         ],
         state,


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #3325
