### PR TITLE
fix: connect gas now breaks iOS from loading

### DIFF
--- a/packages/maskbook/src/plugins/Wallet/settings.ts
+++ b/packages/maskbook/src/plugins/Wallet/settings.ts
@@ -120,4 +120,8 @@ export const currentGasNowSettings = createGlobalSettings<GasNow | null>(
     (a: GasNow | null, b: GasNow | null) => isEqual(a, b),
 )
 
-connectGasNow()
+try {
+    connectGasNow()
+} catch {
+    // fails on iOS
+}


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #
