### PR TITLE
fix: unlimit thegraph query amount

### DIFF
--- a/packages/maskbook/src/plugins/ITO/apis/index.ts
+++ b/packages/maskbook/src/plugins/ITO/apis/index.ts
@@ -56,7 +56,7 @@ export async function getTradeInfo(pid: string, trader: string) {
         body: stringify({
             query: `
             {
-                buyInfos (where: { pool: "${pid.toLowerCase()}", buyer: "${trader.toLowerCase()}" }) {
+                buyInfos (where: { pool: "${pid.toLowerCase()}", buyer: "${trader.toLowerCase()}" } first: 10000) {
                     buyer {
                         ${TRADER_FIELDS}
                     }
@@ -67,13 +67,13 @@ export async function getTradeInfo(pid: string, trader: string) {
                     amount_sold
                     amount_bought
                 }
-                sellInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" }) {
+                sellInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" } first: 10000) {
                     seller {
                         address
                     }
                     amount
                 }
-                destructInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" }) {
+                destructInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" } first: 10000) {
                     seller {
                         address
                     }
@@ -153,7 +153,7 @@ export async function getAllPoolsAsSeller(address: string) {
         body: stringify({
             query: `
             {
-                sellInfos (where: { seller: "${address.toLowerCase()}" }) {
+                sellInfos (where: { seller: "${address.toLowerCase()}" } first: 10000) {
                     pool {
                         ${POOL_FIELDS}
                         exchange_in_volumes
@@ -191,7 +191,7 @@ export async function getAllPoolsAsBuyer(address: string) {
         body: stringify({
             query: `
             {
-                buyInfos (where: { buyer: "${address.toLowerCase()}" }) {
+                buyInfos (where: { buyer: "${address.toLowerCase()}" } first: 10000) {
                     pool {
                         ${POOL_FIELDS}
                         exchange_in_volumes

--- a/packages/maskbook/src/plugins/ITO/apis/index.ts
+++ b/packages/maskbook/src/plugins/ITO/apis/index.ts
@@ -56,7 +56,7 @@ export async function getTradeInfo(pid: string, trader: string) {
         body: stringify({
             query: `
             {
-                buyInfos (where: { pool: "${pid.toLowerCase()}", buyer: "${trader.toLowerCase()}" } first: 10000) {
+                buyInfos (where: { pool: "${pid.toLowerCase()}", buyer: "${trader.toLowerCase()}" } first: 1000) {
                     buyer {
                         ${TRADER_FIELDS}
                     }
@@ -67,13 +67,13 @@ export async function getTradeInfo(pid: string, trader: string) {
                     amount_sold
                     amount_bought
                 }
-                sellInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" } first: 10000) {
+                sellInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" } first: 1000) {
                     seller {
                         address
                     }
                     amount
                 }
-                destructInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" } first: 10000) {
+                destructInfos (where: { pool: "${pid.toLowerCase()}", seller: "${trader.toLowerCase()}" } first: 1000) {
                     seller {
                         address
                     }
@@ -153,7 +153,7 @@ export async function getAllPoolsAsSeller(address: string) {
         body: stringify({
             query: `
             {
-                sellInfos (where: { seller: "${address.toLowerCase()}" } first: 10000) {
+                sellInfos (where: { seller: "${address.toLowerCase()}" } first: 1000) {
                     pool {
                         ${POOL_FIELDS}
                         exchange_in_volumes
@@ -191,7 +191,7 @@ export async function getAllPoolsAsBuyer(address: string) {
         body: stringify({
             query: `
             {
-                buyInfos (where: { buyer: "${address.toLowerCase()}" } first: 10000) {
+                buyInfos (where: { buyer: "${address.toLowerCase()}" } first: 1000) {
                     pool {
                         ${POOL_FIELDS}
                         exchange_in_volumes

--- a/packages/maskbook/src/plugins/RedPacket/apis/index.ts
+++ b/packages/maskbook/src/plugins/RedPacket/apis/index.ts
@@ -78,7 +78,7 @@ export async function getRedPacketTxid(rpid: string) {
         body: JSON.stringify({
             query: `
             {
-                redPackets (where: { rpid: "${rpid.toLowerCase()}" }) {
+                redPackets (where: { rpid: "${rpid.toLowerCase()}" } first: 10000) {
                     ${RED_PACKET_FIELDS}
                 }
             }
@@ -100,7 +100,7 @@ export async function getRedPacketHistory(address: string, chainId: ChainId) {
         body: JSON.stringify({
             query: `
             {
-                redPackets (where: { creator: "${address.toLowerCase()}" }) {
+                redPackets (where: { creator: "${address.toLowerCase()}" } first: 10000) {
                     ${RED_PACKET_FIELDS}
                 }
             }

--- a/packages/maskbook/src/plugins/RedPacket/apis/index.ts
+++ b/packages/maskbook/src/plugins/RedPacket/apis/index.ts
@@ -78,7 +78,7 @@ export async function getRedPacketTxid(rpid: string) {
         body: JSON.stringify({
             query: `
             {
-                redPackets (where: { rpid: "${rpid.toLowerCase()}" } first: 10000) {
+                redPackets (where: { rpid: "${rpid.toLowerCase()}" } first: 1000) {
                     ${RED_PACKET_FIELDS}
                 }
             }
@@ -100,7 +100,7 @@ export async function getRedPacketHistory(address: string, chainId: ChainId) {
         body: JSON.stringify({
             query: `
             {
-                redPackets (where: { creator: "${address.toLowerCase()}" } first: 10000) {
+                redPackets (where: { creator: "${address.toLowerCase()}" } first: 1000) {
                     ${RED_PACKET_FIELDS}
                 }
             }

--- a/packages/maskbook/src/plugins/Trader/apis/uniswap-v2-subgraph/index.ts
+++ b/packages/maskbook/src/plugins/Trader/apis/uniswap-v2-subgraph/index.ts
@@ -202,7 +202,7 @@ export async function fetchTokenDayData(address: string, date: Date) {
         }
     }>(`
         {
-            tokenDayDatas(first: 1000, orderBy: date, date: ${utcTimestamp}, where: { token: ${address} }) {
+            tokenDayDatas(first: 10000, orderBy: date, date: ${utcTimestamp}, where: { token: ${address} }) {
                 id
                 date
                 priceUSD

--- a/packages/maskbook/src/plugins/Trader/apis/uniswap-v2-subgraph/index.ts
+++ b/packages/maskbook/src/plugins/Trader/apis/uniswap-v2-subgraph/index.ts
@@ -202,7 +202,7 @@ export async function fetchTokenDayData(address: string, date: Date) {
         }
     }>(`
         {
-            tokenDayDatas(first: 10000, orderBy: date, date: ${utcTimestamp}, where: { token: ${address} }) {
+            tokenDayDatas(first: 1000, orderBy: date, date: ${utcTimestamp}, where: { token: ${address} }) {
                 id
                 date
                 priceUSD


### PR DESCRIPTION
This is an urgent and quick fix.

thegraph api only returns default first 100 entities when `first` attribute is absent, which cause that the user can't retrieve his 101th red packets from history.

I will open another issue to discuss tech solution of List lazy loading later.