### PR TITLE
refactor: let usePostInfoDetails support reference

### DIFF
--- a/packages/maskbook/src/components/DataSource/usePostInfo.ts
+++ b/packages/maskbook/src/components/DataSource/usePostInfo.ts
@@ -9,13 +9,13 @@ export {
     usePostInfoSharedPublic,
 } from '@dimensiondev/mask-plugin-infra'
 export function usePostLink() {
-    const postID = usePostInfoDetails('postID')
-    const postIdentifier = usePostInfoDetails('postIdentifier')
+    const postID = usePostInfoDetails.postID()
+    const postIdentifier = usePostInfoDetails.postIdentifier()
     if (!postID || !postIdentifier) return ''
     return activatedSocialNetworkUI.utils.getPostURL?.(postIdentifier) ?? ''
 }
 export function usePostClaimedAuthor(): ProfileIdentifier | undefined {
-    const info = usePostInfoDetails('postPayload')
+    const info = usePostInfoDetails.postPayload()
     if (info.err) return undefined
     const payload = info.val
     if (payload.version !== -38) return undefined

--- a/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptedPost.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptedPost.tsx
@@ -63,13 +63,13 @@ export interface DecryptPostProps {
 }
 export function DecryptPost(props: DecryptPostProps) {
     const { whoAmI, profiles, alreadySelectedPreviously, onDecrypted } = props
-    const deconstructedPayload = usePostInfoDetails('postPayload')
+    const deconstructedPayload = usePostInfoDetails.postPayload()
     const authorInPayload = usePostClaimedAuthor()
     const current = usePostInfo()
-    const currentPostBy = usePostInfoDetails('postBy')
-    const decryptedPayloadForImage = usePostInfoDetails('decryptedPayloadForImage')
+    const currentPostBy = usePostInfoDetails.postBy()
+    const decryptedPayloadForImage = usePostInfoDetails.decryptedPayloadForImage()
     const postBy = or(authorInPayload, currentPostBy)
-    const postMetadataImages = usePostInfoDetails('postMetadataImages')
+    const postMetadataImages = usePostInfoDetails.postMetadataImages()
     const Success = props.successComponent || DecryptPostSuccess
     const Awaiting = props.waitingComponent || DecryptPostAwaiting
     const Failed = props.failedComponent || DecryptPostFailed

--- a/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptedPostDebug.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptedPostDebug.tsx
@@ -18,8 +18,8 @@ interface DebugDisplayProps {
     decryptedResult: SuccessDecryption | FailureDecryption | null
 }
 export function DecryptedPostDebug(props: Partial<DebugDisplayProps>) {
-    const postBy = usePostInfoDetails('postBy')
-    const postContent = usePostInfoDetails('postContent')
+    const postBy = usePostInfoDetails.postBy()
+    const postContent = usePostInfoDetails.postContent()
     const payloadResult = useMemo(() => deconstructPayload(postContent), [postContent])
     const setting = useValueRef(debugModeSetting)
     const isDebugging = isEnvironment(Environment.ManifestOptions) ? true : setting

--- a/packages/maskbook/src/components/InjectedComponents/PostComments.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/PostComments.tsx
@@ -46,9 +46,9 @@ export interface PostCommentProps {
 export function PostComment(props: PostCommentProps) {
     const { failedComponent: Fail, waitingComponent: Wait, needZip } = props
     const comment = useValueRef(props.comment)
-    const postContent = usePostInfoDetails('transformedPostContent')
-    const postPayload = usePostInfoDetails('postPayload')
-    const iv = usePostInfoDetails('iv')
+    const postContent = usePostInfoDetails.transformedPostContent()
+    const postPayload = usePostInfoDetails.postPayload()
+    const iv = usePostInfoDetails.iv()
     const postIV = postPayload.map((x) => x.iv).unwrapOr(iv)
 
     const dec = useAsync(async () => {

--- a/packages/maskbook/src/components/InjectedComponents/PostInspector.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/PostInspector.tsx
@@ -31,12 +31,12 @@ export interface PostInspectorProps {
     slotPosition?: 'before' | 'after'
 }
 export function PostInspector(props: PostInspectorProps) {
-    const postBy = usePostInfoDetails('postBy')
-    const postContent = usePostInfoDetails('postContent')
-    const encryptedPost = usePostInfoDetails('postPayload')
-    const postId = usePostInfoDetails('postIdentifier')
-    const decryptedPayloadForImage = usePostInfoDetails('decryptedPayloadForImage')
-    const postImages = usePostInfoDetails('postMetadataImages')
+    const postBy = usePostInfoDetails.postBy()
+    const postContent = usePostInfoDetails.postContent()
+    const encryptedPost = usePostInfoDetails.postPayload()
+    const postId = usePostInfoDetails.postIdentifier()
+    const decryptedPayloadForImage = usePostInfoDetails.decryptedPayloadForImage()
+    const postImages = usePostInfoDetails.postMetadataImages()
     const isDebugging = useValueRef(debugModeSetting)
     const whoAmI = useCurrentIdentity()
     const friends = useFriendsList()
@@ -63,7 +63,7 @@ export function PostInspector(props: PostInspectorProps) {
                 ['My fingerprint', whoAmI?.linkedPersona?.fingerprint ?? 'Unknown'],
                 ['Post ID', postId?.toText() || 'Unknown'],
                 ['Post Content', postContent],
-                ['Post Attachment Links', JSON.stringify(postImages.values())],
+                ['Post Attachment Links', JSON.stringify(postImages)],
             ]}
         />
     ) : null

--- a/packages/maskbook/src/components/InjectedComponents/PostReplacer.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/PostReplacer.tsx
@@ -21,8 +21,8 @@ export interface PostReplacerProps {
 
 export function PostReplacer(props: PostReplacerProps) {
     const classes = useStlyes()
-    const postMessage = usePostInfoDetails('postMessage')
-    const postPayload = usePostInfoDetails('postPayload')
+    const postMessage = usePostInfoDetails.postMessage()
+    const postPayload = usePostInfoDetails.postPayload()
     const allPostReplacement = useValueRef(allPostReplacementSettings)
 
     const plugins = [...PluginUI.values()]

--- a/packages/maskbook/src/plugins/Collectible/define.tsx
+++ b/packages/maskbook/src/plugins/Collectible/define.tsx
@@ -23,7 +23,7 @@ export const CollectiblesPluginDefine: PluginConfig = {
     },
     postInspector: function Component() {
         const link = uniq(
-            usePostInfoDetails('postMetadataMentionedLinks').concat(usePostInfoDetails('postMentionedLinks')),
+            usePostInfoDetails.postMetadataMentionedLinks().concat(usePostInfoDetails.postMentionedLinks()),
         ).find(checkUrl)
         const asset = getAssetInfoFromURL(link)
 

--- a/packages/maskbook/src/plugins/Gitcoin/define.tsx
+++ b/packages/maskbook/src/plugins/Gitcoin/define.tsx
@@ -27,8 +27,9 @@ export const GitcoinPluginDefine: PluginConfig = {
         return <Renderer url={link} />
     },
     postInspector: function Component(): JSX.Element | null {
-        const link = usePostInfoDetails('postMetadataMentionedLinks')
-            .concat(usePostInfoDetails('postMentionedLinks'))
+        const link = usePostInfoDetails
+            .postMetadataMentionedLinks()
+            .concat(usePostInfoDetails.postMentionedLinks())
             .find(isGitcoin)
         if (!link) return null
         return <Renderer url={link} />

--- a/packages/maskbook/src/plugins/NFT/define.tsx
+++ b/packages/maskbook/src/plugins/NFT/define.tsx
@@ -19,8 +19,9 @@ export const NFT_PluginsDefine: PluginConfig = {
         return nftUrl ? <NFTInPost nftUrl={nftUrl} /> : null
     },
     postInspector: function Component(): JSX.Element | null {
-        const nftUrl = usePostInfoDetails('postMetadataMentionedLinks')
-            .concat(usePostInfoDetails('postMentionedLinks'))
+        const nftUrl = usePostInfoDetails
+            .postMetadataMentionedLinks()
+            .concat(usePostInfoDetails.postMentionedLinks())
             .map(getRelevantUrl)
             .find((url) => Boolean(url))
 

--- a/packages/maskbook/src/plugins/RedPacket/UI/RedPacketInPost.tsx
+++ b/packages/maskbook/src/plugins/RedPacket/UI/RedPacketInPost.tsx
@@ -13,7 +13,7 @@ export function RedPacketInPost(props: RedPacketInPostProps) {
     const { payload } = props
 
     //#region discover red packet
-    const postIdentifier = usePostInfoDetails('postIdentifier')
+    const postIdentifier = usePostInfoDetails.postIdentifier()
     const fromUrl =
         postIdentifier && !postIdentifier.isUnknown
             ? activatedSocialNetworkUI.utils.getPostURL?.(postIdentifier)?.toString()

--- a/packages/maskbook/src/plugins/Snapshot/define.tsx
+++ b/packages/maskbook/src/plugins/Snapshot/define.tsx
@@ -38,8 +38,9 @@ export const SnapShotPluginDefine: PluginConfig = {
         return <Renderer url={link} />
     },
     postInspector: function Component(): JSX.Element | null {
-        const link = usePostInfoDetails('postMetadataMentionedLinks')
-            .concat(usePostInfoDetails('postMentionedLinks'))
+        const link = usePostInfoDetails
+            .postMetadataMentionedLinks()
+            .concat(usePostInfoDetails.postMentionedLinks())
             .find(isSnaphotURL)
         if (!link) return null
         return <Renderer url={link} />

--- a/packages/maskbook/src/plugins/VCent/define.tsx
+++ b/packages/maskbook/src/plugins/VCent/define.tsx
@@ -13,7 +13,7 @@ export const VCentPluginDefine: PluginConfig = {
     scope: PluginScope.Internal,
 
     postInspector: function Component(): JSX.Element | null {
-        const tweetAddress = usePostInfoDetails('postID')
+        const tweetAddress = usePostInfoDetails.postID()
         if (!tweetAddress) return null
         return <VCentDialog tweetAddress={tweetAddress} />
     },

--- a/packages/maskbook/src/plugins/dHEDGE/define.tsx
+++ b/packages/maskbook/src/plugins/dHEDGE/define.tsx
@@ -29,8 +29,9 @@ export const DHedgePluginDefine: PluginConfig = {
     },
     postInspector: function Component(): JSX.Element | null {
         const isPoolUrl = useIsPoolUrl()
-        const link = usePostInfoDetails('postMetadataMentionedLinks')
-            .concat(usePostInfoDetails('postMentionedLinks'))
+        const link = usePostInfoDetails
+            .postMetadataMentionedLinks()
+            .concat(usePostInfoDetails.postMentionedLinks())
             .find(isPoolUrl)
         if (!link) return null
         return <Renderer url={link} />

--- a/packages/maskbook/src/social-network/defaults/inject/CommentBox.tsx
+++ b/packages/maskbook/src/social-network/defaults/inject/CommentBox.tsx
@@ -28,10 +28,10 @@ export const injectCommentBoxDefaultFactory = function <T extends string>(
 ) {
     const CommentBoxUI = memo(function CommentBoxUI({ dom }: { dom: HTMLElement | null }) {
         const info = usePostInfo()
-        const payload = usePostInfoDetails('postPayload')
-        const postContent = usePostInfoDetails('transformedPostContent')
+        const payload = usePostInfoDetails.postPayload()
+        const postContent = usePostInfoDetails.transformedPostContent()
         const styles = useCustomStyles()
-        const iv = usePostInfoDetails('iv')
+        const iv = usePostInfoDetails.iv()
         const props = additionPropsToCommentBox(styles)
         const onCallback = useCallback(
             async (content) => {


### PR DESCRIPTION
This PR allows items on `PostInfo` can be reference-discoverable.