### PR TITLE
chore: lock snapshot.js version

### DIFF
--- a/packages/maskbook/package.json
+++ b/packages/maskbook/package.json
@@ -32,7 +32,7 @@
     "@openzeppelin/contracts": "^3.2.0",
     "@popperjs/core": "*",
     "@servie/events": "^3.0.0",
-    "@snapshot-labs/snapshot.js": "github:snapshot-labs/snapshot.js#master",
+    "@snapshot-labs/snapshot.js": "github:snapshot-labs/snapshot.js#f32bf0f5b4a27a23b0db3c6fdaced1abab25f55a",
     "@types/bn.js": "^4.11.6",
     "@types/d3": "5.16.4",
     "@types/elliptic": "^6.4.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,7 +259,7 @@ importers:
       '@popperjs/core': '*'
       '@servie/events': ^3.0.0
       '@sinonjs/text-encoding': ^0.7.1
-      '@snapshot-labs/snapshot.js': github:snapshot-labs/snapshot.js#master
+      '@snapshot-labs/snapshot.js': github:snapshot-labs/snapshot.js#f32bf0f5b4a27a23b0db3c6fdaced1abab25f55a
       '@testing-library/react-hooks': ^7.0.0
       '@types/bn.js': ^4.11.6
       '@types/d3': 5.16.4


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #
