### PR TITLE
fix: dialog close button position

### DIFF
--- a/packages/theme/src/Components/Dialogs/DialogTitle.tsx
+++ b/packages/theme/src/Components/Dialogs/DialogTitle.tsx
@@ -7,7 +7,6 @@ const Title = styled(DialogTitle)(({ theme }) => ({
     alignItems: 'center',
     padding: `${theme.spacing(1)} ${theme.spacing(3)}`,
     // gap: theme.spacing(1), // ? Safari doesn't support it
-    '& > *:first-of-type': { marginRight: theme.spacing(1) },
 }))
 export interface MaskDialogTitleProps {
     children: string
@@ -17,7 +16,7 @@ export interface MaskDialogTitleProps {
 export const MaskDialogTitle = memo((props: MaskDialogTitleProps) => {
     const { children, onBack, onClose } = props
     const backButton = onBack ? (
-        <IconButton onClick={onBack} edge="start" color="inherit">
+        <IconButton onClick={onBack} edge="start" color="inherit" sx={{ marginRight: '8px' }}>
             <ArrowBack />
         </IconButton>
     ) : null


### PR DESCRIPTION
`:first-of-type` let close button get the margin when there is no back button, `:first-child` would get server side rending unsafe error tip, so just add the margin to back button.