### PR TITLE
fix: file service label

### DIFF
--- a/packages/maskbook/src/plugins/FileService/SNSAdaptor/index.tsx
+++ b/packages/maskbook/src/plugins/FileService/SNSAdaptor/index.tsx
@@ -21,7 +21,7 @@ const definition: Plugin.SNSAdaptor.Definition = {
         [META_KEY_2, onAttachedFile],
     ]),
     CompositionDialogEntry: {
-        label: FileServiceDialog,
+        label: '📃 File Service',
         dialog({ open, onClose }) {
             return <FileServiceDialog open={open} onConfirm={onClose} onDecline={onClose} />
         },


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #

before:
<img width="539" alt="CleanShot 2021-06-29 at 19 21 19@2x" src="https://user-images.githubusercontent.com/3842474/123788948-31e8a880-d90f-11eb-912e-5d6e7760f0f2.png">

after:
<img width="511" alt="CleanShot 2021-06-29 at 19 22 23@2x" src="https://user-images.githubusercontent.com/3842474/123789078-5775b200-d90f-11eb-9d89-7a6e879b87b3.png">
