### PR TITLE
feat: ito use tokens detail

### DIFF
--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
@@ -14,8 +14,6 @@ import {
     useChainId,
     useChainIdValid,
     useTokenConstants,
-    useTokenDetailed,
-    EthereumTokenType,
     ZERO,
 } from '@masknet/web3-shared'
 import { Box, Card, Grid, Link, makeStyles, Theme, Typography } from '@material-ui/core'
@@ -543,11 +541,17 @@ export function ITO(props: ITO_Props) {
                         .sort(sortTokens)
                         .map((exchangeToken, i) => (
                             <div className={classes.rationWrap} key={i}>
-                                <ExchangeToken
-                                    i={i}
-                                    exchange_token={exchangeToken}
-                                    exchange_amounts={exchange_amounts}
+                                <TokenItem
+                                    price={formatBalance(
+                                        new BigNumber(exchange_amounts[i * 2])
+                                            .dividedBy(exchange_amounts[i * 2 + 1])
+                                            .multipliedBy(pow10(token.decimals - exchangeToken.decimals))
+                                            .multipliedBy(pow10(exchangeToken.decimals))
+                                            .integerValue(),
+                                        exchangeToken.decimals,
+                                    )}
                                     token={token}
+                                    exchangeToken={exchangeToken}
                                 />
                             </div>
                         ))}
@@ -764,34 +768,4 @@ export function ITO_Error({ retryPoolPayload }: { retryPoolPayload: () => void }
             </ActionButton>
         </Card>
     )
-}
-interface ExchangeTokenProps {
-    i: number
-    exchange_amounts: string[]
-    exchange_token: FungibleTokenDetailed
-    token: FungibleTokenDetailed
-}
-function ExchangeToken({ i, exchange_amounts, exchange_token, token }: ExchangeTokenProps) {
-    const classes = useStyles({})
-    const { NATIVE_TOKEN_ADDRESS } = useTokenConstants()
-    const { value: exchangeToken } = useTokenDetailed(
-        isSameAddress(NATIVE_TOKEN_ADDRESS, exchange_token.address)
-            ? EthereumTokenType.Native
-            : EthereumTokenType.ERC20,
-        exchange_token.address,
-    )
-    return exchangeToken ? (
-        <TokenItem
-            price={formatBalance(
-                new BigNumber(exchange_amounts[i * 2])
-                    .dividedBy(exchange_amounts[i * 2 + 1])
-                    .multipliedBy(pow10(token.decimals - exchangeToken.decimals))
-                    .multipliedBy(pow10(exchangeToken.decimals))
-                    .integerValue(),
-                exchangeToken.decimals,
-            )}
-            token={token}
-            exchangeToken={exchangeToken}
-        />
-    ) : null
 }

--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/PostInspector.tsx
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/PostInspector.tsx
@@ -1,10 +1,19 @@
-import { useChainId, useTokenDetailed, EthereumTokenType, FungibleTokenDetailed } from '@masknet/web3-shared'
+import {
+    useChainId,
+    useTokenDetailed,
+    EthereumTokenType,
+    FungibleTokenDetailed,
+    FungibleToken,
+    useFungibleTokensDetailed,
+    isSameAddress,
+    useTokenConstants,
+} from '@masknet/web3-shared'
 import { EthereumChainBoundary } from '../../../web3/UI/EthereumChainBoundary'
 import { isCompactPayload } from './helpers'
 import { usePoolPayload } from './hooks/usePoolPayload'
 import type { JSON_PayloadInMask } from '../types'
 import { ITO, ITO_Error, ITO_Loading } from './ITO'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 export interface PostInspectorProps {
     payload: JSON_PayloadInMask
@@ -13,6 +22,7 @@ export interface PostInspectorProps {
 export function PostInspector(props: PostInspectorProps) {
     const { chain_id, pid } = props.payload
     const isCompactPayload_ = isCompactPayload(props.payload)
+    const { NATIVE_TOKEN_ADDRESS } = useTokenConstants()
 
     const chainId = useChainId()
     const {
@@ -28,17 +38,40 @@ export function PostInspector(props: PostInspectorProps) {
     const token = _payload.token as unknown as string | FungibleTokenDetailed
     const {
         value: tokenDetailed,
-        loading: loadingToken,
+        loading: _loadingToken,
         retry: retryToken,
     } = useTokenDetailed(
         EthereumTokenType.ERC20,
         typeof token === 'string' ? (token as string) : (token as FungibleTokenDetailed).address,
     )
 
+    const exchangeFungibleTokens = useMemo(
+        () =>
+            _payload.exchange_tokens.map(
+                (t) =>
+                    ({
+                        address: t.address,
+                        type: isSameAddress(t.address, NATIVE_TOKEN_ADDRESS)
+                            ? EthereumTokenType.Native
+                            : EthereumTokenType.ERC20,
+                    } as Pick<FungibleToken, 'address' | 'type'>),
+            ),
+        [JSON.stringify(_payload.exchange_tokens)],
+    )
+
+    const {
+        value: exchangeTokensDetailed,
+        loading: loadingExchangeTokensDetailed,
+        retry: retryExchangeTokensDetailed,
+    } = useFungibleTokensDetailed(exchangeFungibleTokens)
+
     const retry = useCallback(() => {
         retryPayload()
         retryToken()
-    }, [retryPayload, retryToken])
+        retryExchangeTokensDetailed()
+    }, [retryPayload, retryToken, retryExchangeTokensDetailed])
+
+    const loadingToken = _loadingToken || loadingExchangeTokensDetailed
 
     const renderITO = () => {
         if (isCompactPayload_) {
@@ -48,7 +81,16 @@ export function PostInspector(props: PostInspectorProps) {
         if ((loadingToken && typeof token === 'string') || tokenDetailed?.symbol?.toUpperCase() === 'UNKNOWN')
             return <ITO_Loading />
         if (!tokenDetailed && typeof token === 'string') return <ITO_Error retryPoolPayload={retry} />
-        return <ITO pid={pid} payload={typeof token === 'string' ? { ..._payload, token: tokenDetailed! } : _payload} />
+        return (
+            <ITO
+                pid={pid}
+                payload={
+                    typeof token === 'string'
+                        ? { ..._payload, token: tokenDetailed!, exchange_tokens: exchangeTokensDetailed! }
+                        : _payload
+                }
+            />
+        )
     }
     return <EthereumChainBoundary chainId={chain_id}>{renderITO()}</EthereumChainBoundary>
 }

--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/index.tsx
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/index.tsx
@@ -5,7 +5,7 @@ import { formatEthereumAddress, formatBalance, useTokenDetailed, EthereumTokenTy
 import { PostInspector } from './PostInspector'
 import { base } from '../base'
 import { ITO_MetaKey_1, ITO_MetaKey_2, MSG_DELIMITER } from '../constants'
-import type { JSON_PayloadOutMask } from '../types'
+import type { JSON_PayloadComposeMask } from '../types'
 import { ITO_MetadataReader, payloadIntoMask } from './helpers'
 import MaskbookPluginWrapper from '../../MaskbookPluginWrapper'
 import { CompositionDialog } from './CompositionDialog'
@@ -45,18 +45,15 @@ const sns: Plugin.SNSAdaptor.Definition = {
     },
 }
 
-function onAttached_ITO(payload: JSON_PayloadOutMask) {
+function onAttached_ITO(payload: JSON_PayloadComposeMask) {
     return { text: <Badge payload={payload} /> }
 }
 interface BadgeProps {
-    payload: JSON_PayloadOutMask
+    payload: JSON_PayloadComposeMask
 }
 function Badge({ payload }: BadgeProps) {
     const classes = useStyles()
-    const { value: tokenDetailed, loading: loadingToken } = useTokenDetailed(
-        EthereumTokenType.ERC20,
-        payload.token as string,
-    )
+    const { value: tokenDetailed, loading: loadingToken } = useTokenDetailed(EthereumTokenType.ERC20, payload.token)
     const balance = formatBalance(payload.total, tokenDetailed?.decimals)
     const symbol = tokenDetailed?.symbol ?? tokenDetailed?.name ?? 'Token'
     const sellerName = payload.seller.name

--- a/packages/maskbook/src/plugins/ITO/types.ts
+++ b/packages/maskbook/src/plugins/ITO/types.ts
@@ -49,6 +49,11 @@ export interface JSON_PayloadOutMask extends Omit<JSON_PayloadInMask, 'token' | 
     exchange_tokens: TokenOutMask[]
 }
 
+export interface JSON_PayloadComposeMask extends Omit<JSON_PayloadInMask, 'token' | 'exchange_tokens'> {
+    token: string
+    exchange_tokens: { address: string }[]
+}
+
 export enum ITO_Status {
     waited = 'waited',
     started = 'started',

--- a/packages/web3-shared/src/hooks/useERC20TokenDetailed.ts
+++ b/packages/web3-shared/src/hooks/useERC20TokenDetailed.ts
@@ -1,11 +1,12 @@
 import { useAsyncRetry } from 'react-use'
-import type { ERC20TokenDetailed, ERC20Token, ChainId } from '../types'
+import { ERC20TokenDetailed, FungibleToken, ChainId, EthereumTokenType, FungibleTokenDetailed } from '../types'
 import { useChainId } from './useChainId'
 import type { ERC20 } from '@masknet/web3-contracts/types/ERC20'
 import type { ERC20Bytes32 } from '@masknet/web3-contracts/types/ERC20Bytes32'
 import { useERC20TokenContract, useERC20TokenContracts } from '../contracts/useERC20TokenContract'
 import { useERC20TokenBytes32Contract, useERC20TokenBytes32Contracts } from '../contracts/useERC20TokenBytes32Contract'
-import { parseStringOrBytes32, createERC20Token } from '../utils'
+import { parseStringOrBytes32, createERC20Token, createNativeToken } from '../utils'
+import { useMemo } from 'react'
 
 export function useERC20TokenDetailed(address: string, token?: Partial<ERC20TokenDetailed>) {
     const chainId = useChainId()
@@ -18,22 +19,34 @@ export function useERC20TokenDetailed(address: string, token?: Partial<ERC20Toke
     )
 }
 
-export function useERC20TokensDetailed(listOfToken: Pick<ERC20Token, 'type' | 'address'>[]) {
+export function useFungibleTokensDetailed(listOfToken: Pick<FungibleToken, 'address' | 'type'>[]) {
     const chainId = useChainId()
-    const listOfAddress = listOfToken.map((t) => t.address)
+    const listOfAddress = useMemo(() => listOfToken.map((t) => t.address), [JSON.stringify(listOfToken)])
     const erc20TokenContracts = useERC20TokenContracts(listOfAddress)
     const erc20TokenBytes32Contracts = useERC20TokenBytes32Contracts(listOfAddress)
 
-    return useAsyncRetry(
+    return useAsyncRetry<FungibleTokenDetailed[]>(
         async () =>
             Promise.all(
                 listOfToken.map(async (token, i) => {
+                    if (token.type === EthereumTokenType.Native) return createNativeToken(chainId)
+
                     const erc20TokenContract = erc20TokenContracts[i]
                     const erc20TokenBytes32Contract = erc20TokenBytes32Contracts[i]
-                    return getERC20TokenDetailed(chainId, erc20TokenContract, erc20TokenBytes32Contract, token)
+                    return getERC20TokenDetailed(
+                        chainId,
+                        erc20TokenContract,
+                        erc20TokenBytes32Contract,
+                        token as Partial<ERC20TokenDetailed>,
+                    )
                 }),
             ),
-        [chainId, listOfToken, erc20TokenContracts, erc20TokenBytes32Contracts],
+        [
+            chainId,
+            JSON.stringify(listOfToken),
+            JSON.stringify(erc20TokenContracts),
+            JSON.stringify(erc20TokenBytes32Contracts),
+        ],
     )
 }
 


### PR DESCRIPTION
Since we reduce the size of ITO compose payload to support image payload. `exchange_tokens` only retains `address` property, then the ITO postInspector will fetch the detail of tokens by `useFungibleTokensDetailed()`