### PR TITLE
fix: getERC20TokenDetailed invalid address, closes #3674

### DIFF
--- a/packages/web3-shared/src/hooks/useERC20TokenDetailed.ts
+++ b/packages/web3-shared/src/hooks/useERC20TokenDetailed.ts
@@ -56,7 +56,7 @@ async function getERC20TokenDetailed(
     erc20TokenBytes32Contract: ERC20Bytes32 | null,
     token?: Partial<ERC20TokenDetailed>,
 ) {
-    const address = token?.address ?? ''
+    const address = token?.address ?? erc20TokenContract?.options.address ?? ''
     const results = await Promise.allSettled([
         token?.name ?? (await (erc20TokenContract?.methods.name().call() ?? '')),
         token?.name ? '' : await (erc20TokenBytes32Contract?.methods.name().call() ?? ''),


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #3674

Using ERC20 contract address as a fallback option.
