### PR TITLE
fix: open status dialog instead of select dialog

### DIFF
--- a/packages/maskbook/src/components/InjectedComponents/ToolboxHint.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/ToolboxHint.tsx
@@ -6,6 +6,7 @@ import {
     resolveChainColor,
     useChainDetailed,
     useChainIdValid,
+    useWallet,
     formatEthereumAddress,
 } from '@masknet/web3-shared'
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
@@ -121,6 +122,7 @@ export function ToolboxHint(props: ToolboxHintProps) {
     const classes = useStylesExtends(useStyles(), props)
     const account = useAccount()
     const chainId = useChainId()
+    const selectedWallet = useWallet()
     const chainIdValid = useChainIdValid()
     const chainDetailed = useChainDetailed()
 
@@ -132,6 +134,9 @@ export function ToolboxHint(props: ToolboxHintProps) {
     //#endregion
 
     //#region Wallet
+    const { openDialog: openWalletStatusDialog } = useRemoteControlledDialog(
+        WalletMessages.events.walletStatusDialogUpdated,
+    )
     const { openDialog: openSelectWalletDialog } = useRemoteControlledDialog(
         WalletMessages.events.selectProviderDialogUpdated,
     )
@@ -238,6 +243,8 @@ export function ToolboxHint(props: ToolboxHintProps) {
         },
     )
 
+    const isWalletValid = !!account && selectedWallet && chainIdValid
+
     return (
         <>
             <div className={classes.wrapper} onClick={openMenu}>
@@ -248,13 +255,9 @@ export function ToolboxHint(props: ToolboxHintProps) {
             </div>
             {menu}
 
-            <div className={classes.wrapper} onClick={openSelectWalletDialog}>
+            <div className={classes.wrapper} onClick={isWalletValid ? openWalletStatusDialog : openSelectWalletDialog}>
                 <div className={classes.button}>
-                    {account && chainIdValid ? (
-                        <WalletIcon />
-                    ) : (
-                        <WalletSharp classes={{ root: classes.icon }} size={24} />
-                    )}
+                    {isWalletValid ? <WalletIcon /> : <WalletSharp classes={{ root: classes.icon }} size={24} />}
 
                     <Typography className={classes.title}>
                         {account

--- a/packages/maskbook/src/plugins/Wallet/SNSAdaptor/WalletStatusDialog/index.tsx
+++ b/packages/maskbook/src/plugins/Wallet/SNSAdaptor/WalletStatusDialog/index.tsx
@@ -1,18 +1,22 @@
-import { useCallback } from 'react'
-import { Copy, ExternalLink, Edit3 } from 'react-feather'
-import { useCopyToClipboard } from 'react-use'
-import classNames from 'classnames'
-import ErrorIcon from '@material-ui/icons/Error'
-import { FormattedAddress, useValueRef } from '@masknet/shared'
-import { ProviderType, resolveAddressLinkOnExplorer, useChainId, useChainIdValid } from '@masknet/web3-shared'
+import { FormattedAddress, useRemoteControlledDialog, useValueRef } from '@masknet/shared'
+import {
+    ProviderType,
+    resolveAddressLinkOnExplorer,
+    useChainId,
+    useChainIdValid,
+    useWallet,
+} from '@masknet/web3-shared'
 import { Button, DialogActions, DialogContent, Link, makeStyles, Typography } from '@material-ui/core'
+import ErrorIcon from '@material-ui/icons/Error'
+import classNames from 'classnames'
+import { useCallback } from 'react'
+import { Copy, Edit3, ExternalLink } from 'react-feather'
+import { useCopyToClipboard } from 'react-use'
 import { InjectedDialog } from '../../../../components/shared/InjectedDialog'
 import { WalletIcon } from '../../../../components/shared/WalletIcon'
 import { useSnackbarCallback } from '../../../../extension/options-page/DashboardDialogs/Base'
 import Services from '../../../../extension/service'
 import { useI18N } from '../../../../utils'
-import { useRemoteControlledDialog } from '@masknet/shared'
-import { useWallet } from '../../hooks/useWallet'
 import { WalletMessages } from '../../messages'
 import { currentProviderSettings } from '../../settings'
 import { RecentTransactionList } from './RecentTransactionList'

--- a/packages/maskbook/src/web3/UI/EthereumAccountButton.tsx
+++ b/packages/maskbook/src/web3/UI/EthereumAccountButton.tsx
@@ -8,6 +8,7 @@ import {
     useChainDetailed,
     useChainId,
     useChainIdValid,
+    useWallet,
     useNativeTokenBalance,
 } from '@masknet/web3-shared'
 import { Button, ButtonProps, makeStyles, Typography } from '@material-ui/core'
@@ -16,7 +17,6 @@ import AccountBalanceWalletIcon from '@material-ui/icons/AccountBalanceWallet'
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
 import { useStylesExtends } from '../../components/custom-ui-helper'
 import { WalletIcon } from '../../components/shared/WalletIcon'
-import { useWallet } from '../../plugins/Wallet/hooks/useWallet'
 import { WalletMessages } from '../../plugins/Wallet/messages'
 import { Flags, useI18N } from '../../utils'
 import { useRemoteControlledDialog } from '@masknet/shared'
@@ -73,7 +73,7 @@ export function EthereumAccountButton(props: EthereumAccountButtonProps) {
         WalletMessages.events.selectProviderDialogUpdated,
     )
     const onOpen = useCallback(() => {
-        if (account) openSelectWalletDialog()
+        if (account && selectedWallet) openSelectWalletDialog()
         else openSelectProviderDialog()
     }, [account, openSelectWalletDialog, openSelectProviderDialog])
 


### PR DESCRIPTION
if the wallet is a valid one, clicking on status button should open
status dialog.

<!-- Please refer to the related issue number -->
closes #3602 

@wenluomask Please take a look.

I found another issue during testing: I have two wallets (one connects to MetaMask which is currently activate, another is Maskbook wallet), when I delete the first one, the account becomes Maskbook wallet, but the selected wallet is unset. We might discuss the behave details further.
