### PR TITLE
chore: add date-fns usage limit

### DIFF
--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -12,7 +12,13 @@
         "import/no-deprecated": "warn",
         "no-restricted-imports": [
             "error",
-            { "paths": [{ "name": "lodash", "message": "Please use lodash-es instead." }] }
+            {
+                "paths": [
+                    { "name": "lodash", "message": "Please use lodash-es instead." },
+                    { "name": "date-fns", "message": "Please use date-fns/{submodule} instead." },
+                    { "name": "date-fns/esm", "message": "Please use date-fns/{submodule} instead." }
+                ]
+            }
         ],
         "react-hooks/exhaustive-deps": "off",
         "react-hooks/rules-of-hooks": "error",


### PR DESCRIPTION
<img width="283" alt="CleanShot 2021-07-27 at 17 58 39@2x" src="https://user-images.githubusercontent.com/3842474/127135309-05ce6787-8060-426f-bf2b-92a23c42062e.png">

```
➜  Maskbook git:(septs/date-fns-limit) npm run lint

> maskbook@1.34.1 lint
> eslint -c packages/.eslintrc.json packages --ext .ts,.tsx,.js --cache --fix


/Volumes/Projects/DimensionDev/Maskbook/packages/maskbook/test.ts
  1:1  error  'date-fns' import is restricted from being used. Please use date-fns/{submodule} instead      no-restricted-imports
  2:1  error  'date-fns/esm' import is restricted from being used. Please use date-fns/{submodule} instead  no-restricted-imports

✖ 2 problems (2 errors, 0 warnings)

```