### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,34 +14,35 @@ jobs:
     steps:
       - name: Get cache date
         id: get-date
-        run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - uses: actions/setup-node@v2-beta
-      - uses: actions/cache@v2
+      - uses: actions/setup-node@v2
+      - name: pnpm cache
+        uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-node-
-      - uses: actions/cache@v2
+      - name: compiled dist cache
+        uses: actions/cache@v2
         with:
-          path: "packages/**/dist/"
+          path: packages/**/dist
           key: ${{ runner.os }}-tsc-${{ hashFiles('packages/**/tsconfig.json') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
           restore-keys: |
             ${{ runner.os }}-tsc-${{ hashFiles('packages/**/tsconfig.json') }}-${{ hashFiles('pnpm-lock.yaml') }}
             ${{ runner.os }}-tsc-${{ hashFiles('packages/**/tsconfig.json') }}
-      - uses: actions/cache@v2
+      - name: maskbook webpack cache
+        uses: actions/cache@v2
         with:
-          path: ./packages/maskbook/node_modules/.cache/webpack/
+          path: packages/maskbook/node_modules/.cache/webpack
           key: ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
           # Not fallback to different dependencies. Webpack seems like have bug.
           # An example caused by the webpack cache bug: https://github.com/facebook/react/issues/21587
-          restore-keys: |
-            ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-webpack-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npx pnpm install
       - run: npx gulp build-ci
       - name: Upload `Maskbook.base.zip`

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
       - run: npx prettier --list-different .
   locale-kit:
     runs-on: ubuntu-20.04
@@ -21,8 +21,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v2-beta
-      - uses: actions/cache@v2
+      - uses: actions/setup-node@v2
+      - name: pnpm cache
+        uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -34,21 +35,22 @@ jobs:
     steps:
       - name: Get cache date
         id: get-date
-        run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v2-beta
-      - uses: actions/cache@v2
+      - uses: actions/setup-node@v2
+      - name: pnpm cache
+        uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-node-
-      - uses: actions/cache@v2
+      - name: compiled dist cache
+        uses: actions/cache@v2
         with:
-          path: "packages/**/dist/"
+          path: packages/**/dist
           # actions/cache will not upload changes in cache if primary key hits
           # by adding date to the primary key, we can ensure the cache updates on the first build of the day
           key: ${{ runner.os }}-tsc-${{ hashFiles('packages/**/tsconfig.json') }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ steps.get-date.outputs.date }}
@@ -61,20 +63,20 @@ jobs:
       - run: npx gulp codegen
   eslint:
     runs-on: ubuntu-20.04
-    needs: [prettier, locale-kit, type-check]
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v2-beta
-      - uses: actions/cache@v2
+      - uses: actions/setup-node@v2
+      - name: pnpm cache
+        uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-node-
       - run: npx pnpm install
       - run: npm run lint:ci -- --max-warnings=0
-      - run: npm run lint:ci -- --format junit -o reports/junit/eslint-results.xml
+      - run: npm run lint:ci -- --format=junit --output-file=reports/junit/eslint-results.xml
       - name: Upload eslint report
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #

<img width="627" alt="CleanShot 2021-08-04 at 14 27 32@2x" src="https://user-images.githubusercontent.com/3842474/128132432-03c16cf9-1ad1-4ea8-a23a-740caddaa48f.png">

1. vscode thinks `build.yml` belong hammerkit's build file format
    therefore rename `build.yml` -> `compile.yaml`
2. add cache action name
3. switch `actions/setup-node@v2-beta` to `actions/setup-node@v2`