### PR TITLE
fix: hot reload for plugins

### DIFF
--- a/packages/maskbook/src/plugins/Airdrop/index.ts
+++ b/packages/maskbook/src/plugins/Airdrop/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/Collectible/index.ts
+++ b/packages/maskbook/src/plugins/Collectible/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/External/index.ts
+++ b/packages/maskbook/src/plugins/External/index.ts
@@ -6,6 +6,6 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
 })

--- a/packages/maskbook/src/plugins/FileService/Worker/rpc.ts
+++ b/packages/maskbook/src/plugins/FileService/Worker/rpc.ts
@@ -1,7 +1,7 @@
 import { createPluginMessage, createPluginRPC, createPluginRPCGenerator } from '@masknet/plugin-infra'
 import { FileServicePluginID } from '../constants'
 
-import.meta.webpackHot?.accept()
+import.meta.webpackHot && import.meta.webpackHot.accept()
 
 const PluginFileServiceMessage = createPluginMessage<{ _: unknown; _2: unknown }>(FileServicePluginID)
 

--- a/packages/maskbook/src/plugins/FileService/index.ts
+++ b/packages/maskbook/src/plugins/FileService/index.ts
@@ -6,13 +6,13 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) => {
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor')))
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor')))
         },
     },
     Worker: {
         load: () => import('./Worker'),
         hotModuleReload: (hot) => {
-            import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker')))
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker')))
         },
     },
 })

--- a/packages/maskbook/src/plugins/Gitcoin/index.ts
+++ b/packages/maskbook/src/plugins/Gitcoin/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/GoodGhosting/index.ts
+++ b/packages/maskbook/src/plugins/GoodGhosting/index.ts
@@ -6,6 +6,6 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
 })

--- a/packages/maskbook/src/plugins/ITO/index.ts
+++ b/packages/maskbook/src/plugins/ITO/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/NFT/index.ts
+++ b/packages/maskbook/src/plugins/NFT/index.ts
@@ -6,6 +6,6 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
 })

--- a/packages/maskbook/src/plugins/Polls/index.ts
+++ b/packages/maskbook/src/plugins/Polls/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/PoolTogether/index.ts
+++ b/packages/maskbook/src/plugins/PoolTogether/index.ts
@@ -6,14 +6,16 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Dashboard: {
         load: () => import('./Dashboard'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Dashboard/index', () => hot(import('./Dashboard'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Dashboard', () => hot(import('./Dashboard'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/PoolTogether/messages.ts
+++ b/packages/maskbook/src/plugins/PoolTogether/messages.ts
@@ -18,7 +18,7 @@ interface PoolTogetherMessages {
 
     rpc: unknown
 }
-import.meta.webpackHot?.accept()
+import.meta.webpackHot && import.meta.webpackHot.accept()
 export const PluginPoolTogetherMessages: PluginMessageEmitter<PoolTogetherMessages> =
     createPluginMessage(POOLTOGETHER_PLUGIN_ID)
 

--- a/packages/maskbook/src/plugins/RedPacket/index.ts
+++ b/packages/maskbook/src/plugins/RedPacket/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/Snapshot/index.ts
+++ b/packages/maskbook/src/plugins/Snapshot/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/Trader/index.ts
+++ b/packages/maskbook/src/plugins/Trader/index.ts
@@ -6,14 +6,16 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Dashboard: {
         load: () => import('./Dashboard'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Dashboard/index', () => hot(import('./Dashboard'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Dashboard', () => hot(import('./Dashboard'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/Transak/index.ts
+++ b/packages/maskbook/src/plugins/Transak/index.ts
@@ -6,10 +6,11 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Dashboard: {
         load: () => import('./Dashboard'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Dashboard/index', () => hot(import('./Dashboard'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Dashboard', () => hot(import('./Dashboard'))),
     },
 })

--- a/packages/maskbook/src/plugins/VCent/index.ts
+++ b/packages/maskbook/src/plugins/VCent/index.ts
@@ -6,6 +6,6 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
 })

--- a/packages/maskbook/src/plugins/Wallet/index.ts
+++ b/packages/maskbook/src/plugins/Wallet/index.ts
@@ -6,14 +6,16 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Dashboard: {
         load: () => import('./Dashboard'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Dashboard/index', () => hot(import('./Dashboard'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Dashboard', () => hot(import('./Dashboard'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/maskbook/src/plugins/dHEDGE/index.ts
+++ b/packages/maskbook/src/plugins/dHEDGE/index.ts
@@ -6,14 +6,16 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Dashboard: {
         load: () => import('./Dashboard'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Dashboard/index', () => hot(import('./Dashboard'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Dashboard', () => hot(import('./Dashboard'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })

--- a/packages/plugin-infra/src/types.ts
+++ b/packages/plugin-infra/src/types.ts
@@ -13,7 +13,7 @@ export namespace Plugin {
      * ```ts
      * const loader = {
      *     load: () => import('./code'),
-     *     hotModuleReload: hot => import.meta.webpackHot?.accept('./code', () => hot(import('./code')))
+     *     hotModuleReload: hot => import.meta.webpackHot && import.meta.webpackHot.accept('./code', () => hot(import('./code')))
      * }
      * ```
      *
@@ -32,7 +32,7 @@ export namespace Plugin {
         /**
          * This provides the functionality for hot module reload on the plugin.
          * When the callback is called, the old instance of the plugin will be unloaded, then the new instance will be init.
-         * @example hotModuleReload: hot => import.meta.webpackHot?.accept('./path', () => hot(import('./path')))
+         * @example hotModuleReload: hot => import.meta.webpackHot && import.meta.webpackHot.accept('./path', () => hot(import('./path')))
          */
         hotModuleReload(onHot: (hot: Promise<{ default: DeferredModule }>) => void): void
     }

--- a/packages/plugins/example/src/index.ts
+++ b/packages/plugins/example/src/index.ts
@@ -6,14 +6,16 @@ registerPlugin({
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>
-            import.meta.webpackHot?.accept('./SNSAdaptor/index', () => hot(import('./SNSAdaptor'))),
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
     },
     Dashboard: {
         load: () => import('./Dashboard'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Dashboard/index', () => hot(import('./Dashboard'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Dashboard', () => hot(import('./Dashboard'))),
     },
     Worker: {
         load: () => import('./Worker'),
-        hotModuleReload: (hot) => import.meta.webpackHot?.accept('./Worker/index', () => hot(import('./Worker'))),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./Worker', () => hot(import('./Worker'))),
     },
 })


### PR DESCRIPTION
This is a regression introduced in #3471 which @guanbinrui converts all `import.meta.webpackHot && import.meta.webpackHot.accept` into `import.meta.webpackHot?.accept`. I was raised concern about if HMR still works and get the answer of yes but it proved it's not the case.

We can go back to `?.` once we get #3750 back (that depends on webpack/webpack#12960).