### PR TITLE
fix: unlock metamask

### DIFF
--- a/packages/maskbook/src/_locales/en-US/messages.json
+++ b/packages/maskbook/src/_locales/en-US/messages.json
@@ -404,7 +404,7 @@
     "plugin_red_packet_amount_total": "Amount Total",
     "plugin_red_packet_next": "Next",
     "plugin_red_packet_back": "Back",
-    "plugin_red_packet_hint": "You can withdraw the remaining balance 24 hours after the red packet is sent",
+    "plugin_red_packet_hint": "You can withdraw the remaining balance 24 hours after the red packet is sent.",
     "plugin_red_packet_token": "Token",
     "plugin_red_packet_create_with_token": "Creating red packet with {{symbol}}",
     "plugin_red_packet_history_duration": "Time: {{startTime}} ~ {{endTime}} (UTC+8)",

--- a/packages/maskbook/src/_locales/en-US/messages.json
+++ b/packages/maskbook/src/_locales/en-US/messages.json
@@ -315,7 +315,6 @@
     "plugin_wallet_select_a_token": "Select a Token",
     "plugin_wallet_connect_a_wallet": "Connect a Wallet",
     "plugin_wallet_confirm_risk_warning": "Confirm Risk Warning",
-    "plugin_wallet_unlock_metamask": "Unlock MetaMask",
     "plugin_wallet_no_gas_fee": "No Gas Fee",
     "plugin_wallet_update_gas_fee": "Updating Gas Fee…",
     "plugin_wallet_invalid_network": "Invalid Network",

--- a/packages/maskbook/src/_locales/ja-JP/messages.json
+++ b/packages/maskbook/src/_locales/ja-JP/messages.json
@@ -276,7 +276,6 @@
     "relative_time_years_ago": "{{years}}年前",
     "plugin_wallet_select_a_token": "トークンを選択",
     "plugin_wallet_connect_a_wallet": "ウォレットと接続",
-    "plugin_wallet_unlock_metamask": "MetaMask をアンロック",
     "plugin_wallet_no_gas_fee": "ガス代が不足しています",
     "plugin_wallet_update_gas_fee": "ガス代を更新中…",
     "plugin_wallet_invalid_network": "無効のネットワーク",

--- a/packages/maskbook/src/_locales/ko-KR/messages.json
+++ b/packages/maskbook/src/_locales/ko-KR/messages.json
@@ -276,7 +276,6 @@
     "plugin_powered_by": "기술 지원",
     "plugin_wallet_select_a_token": "토큰을 선택하기",
     "plugin_wallet_connect_a_wallet": "월렛을 연결하기",
-    "plugin_wallet_unlock_metamask": "MetaMask를 열기",
     "plugin_wallet_no_gas_fee": "가스비가 없습니다",
     "plugin_wallet_update_gas_fee": "가스비 업데이트 중...",
     "plugin_wallet_invalid_network": "잘못된 네트워크",

--- a/packages/maskbook/src/_locales/zh-TW/messages.json
+++ b/packages/maskbook/src/_locales/zh-TW/messages.json
@@ -282,7 +282,6 @@
     "plugin_powered_by": "提供者為 ",
     "plugin_wallet_select_a_token": "選擇一個代幣",
     "plugin_wallet_connect_a_wallet": "連接到錢包",
-    "plugin_wallet_unlock_metamask": "解鎖 MetaMask",
     "plugin_wallet_no_gas_fee": "沒有 Gas 費用",
     "plugin_wallet_update_gas_fee": "正在更新 Gas 費用…",
     "plugin_wallet_invalid_network": "錯誤的網路",

--- a/packages/maskbook/src/components/InjectedComponents/PostDialog.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/PostDialog.tsx
@@ -463,9 +463,12 @@ function PluginRenderer() {
     const pluginField = usePluginI18NField()
     const operatingSupportedChainMapping = useActivatedPluginSNSAdaptorWithOperatingChainSupportedMet()
     const result = useActivatedPluginsSNSAdaptor()
-        .sort((plugin) => {
-            if (plugin.ID === redpacketBase.ID || plugin.ID === ITOBase.ID) return -1
-            return 1
+        .sort((pluginA, pluginB) => {
+            if (pluginA.ID === redpacketBase.ID && pluginB.ID === ITOBase.ID) return -1
+            if (pluginB.ID === redpacketBase.ID && pluginA.ID === ITOBase.ID) return 1
+            if ([redpacketBase.ID, ITOBase.ID].includes(pluginA.ID)) return -1
+            if ([redpacketBase.ID, ITOBase.ID].includes(pluginB.ID)) return 1
+            return 0
         })
         .map((plugin) =>
             Result.wrap(() => {

--- a/packages/maskbook/src/extension/background-script/EthereumServices/provider.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/provider.ts
@@ -30,7 +30,7 @@ export async function connectWalletConnect() {
 
 export async function connectMetaMask() {
     const { accounts, chainId } = await MetaMask.requestAccounts()
-    await MetaMask.updateIsMetaMaskLockedSettings()
+    await MetaMask.updateIsMetaMaskLockedSettings(accounts)
     return {
         account: first(accounts),
         chainId,

--- a/packages/maskbook/src/extension/background-script/EthereumServices/provider.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/provider.ts
@@ -30,7 +30,6 @@ export async function connectWalletConnect() {
 
 export async function connectMetaMask() {
     const { accounts, chainId } = await MetaMask.requestAccounts()
-    await MetaMask.updateIsMetaMaskLockedSettings(accounts)
     return {
         account: first(accounts),
         chainId,

--- a/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
@@ -14,7 +14,7 @@ let provider: MetaMaskInpageProvider | null = null
 let web3: Web3 | null = null
 
 async function onAccountsChanged(accounts: string[]) {
-    await updateIsMetaMaskLockedSettings()
+    await updateIsMetaMaskLockedSettings(accounts)
     if (currentProviderSettings.value !== ProviderType.MetaMask) return
 
     await updateAccount({
@@ -46,9 +46,10 @@ async function onError(error: string) {
     })
 }
 
-export async function updateIsMetaMaskLockedSettings() {
+export async function updateIsMetaMaskLockedSettings(accounts: string[] = []) {
     try {
-        currentIsMetaMaskLockedSettings.value = !(await provider?._metamask?.isUnlocked())
+        const unlocked = accounts.length > 0 || await provider?._metamask?.isUnlocked()
+        currentIsMetaMaskLockedSettings.value = !unlocked
     } catch {
         currentIsMetaMaskLockedSettings.value = false
     }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/providers/MetaMask.ts
@@ -4,19 +4,13 @@ import { first } from 'lodash-es'
 import createMetaMaskProvider, { MetaMaskInpageProvider } from '@dimensiondev/metamask-extension-provider'
 import { ChainId, ProviderType } from '@masknet/web3-shared'
 import { resetAccount, updateAccount } from '../../../../plugins/Wallet/services'
-import {
-    currentChainIdSettings,
-    currentIsMetaMaskLockedSettings,
-    currentProviderSettings,
-} from '../../../../plugins/Wallet/settings'
+import { currentChainIdSettings, currentProviderSettings } from '../../../../plugins/Wallet/settings'
 
 let provider: MetaMaskInpageProvider | null = null
 let web3: Web3 | null = null
 
 async function onAccountsChanged(accounts: string[]) {
-    await updateIsMetaMaskLockedSettings(accounts)
     if (currentProviderSettings.value !== ProviderType.MetaMask) return
-
     await updateAccount({
         account: first(accounts),
         providerType: ProviderType.MetaMask,
@@ -26,7 +20,6 @@ async function onAccountsChanged(accounts: string[]) {
 }
 
 async function onChainIdChanged(id: string) {
-    await updateIsMetaMaskLockedSettings()
     if (currentProviderSettings.value !== ProviderType.MetaMask) return
 
     // learn more: https://docs.metamask.io/guide/ethereum-provider.html#chain-ids and https://chainid.network/
@@ -44,15 +37,6 @@ async function onError(error: string) {
     await resetAccount({
         providerType: ProviderType.MetaMask,
     })
-}
-
-export async function updateIsMetaMaskLockedSettings(accounts: string[] = []) {
-    try {
-        const unlocked = accounts.length > 0 || await provider?._metamask?.isUnlocked()
-        currentIsMetaMaskLockedSettings.value = !unlocked
-    } catch {
-        currentIsMetaMaskLockedSettings.value = false
-    }
 }
 
 export function createProvider() {
@@ -81,5 +65,30 @@ export async function requestAccounts() {
     return {
         chainId,
         accounts,
+    }
+}
+
+export async function ensureConnectedAndUnlocked() {
+    const web3 = createWeb3()
+    try {
+        const accounts = await web3.eth.requestAccounts()
+        throw accounts
+    } catch (error: string[] | any) {
+        const accounts = error
+        if (Array.isArray(accounts)) {
+            if (accounts.length === 0) throw new Error('MetaMask is locked or it has not connected any accounts.')
+            else if (accounts.length > 0) return // valid
+        }
+        // Any other error means failed to connect MetaMask
+        throw new Error('Failed to connect MetaMask.')
+    }
+}
+
+export async function isUnlocked() {
+    try {
+        // it's an experimental API. we should not depend on.
+        return provider?._metamask?.isUnlocked() ?? false
+    } catch {
+        return false
     }
 }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/send.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/send.ts
@@ -4,6 +4,7 @@ import type { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
 import { addGasMargin, ChainId, EthereumMethodType, ProviderType } from '@masknet/web3-shared'
 import type { IJsonRpcRequest } from '@walletconnect/types'
 import { safeUnreachable } from '@dimensiondev/kit'
+import * as MetaMask from './providers/MetaMask'
 import { createWeb3 } from './web3'
 import * as WalletConnect from './providers/WalletConnect'
 import { addRecentTransaction, getWallet } from '../../../plugins/Wallet/services'
@@ -75,6 +76,12 @@ export async function INTERNAL_send(
                 })
                 break
             case ProviderType.MetaMask:
+                try {
+                    await MetaMask.ensureConnectedAndUnlocked()
+                } catch (error: any) {
+                    callback(error)
+                    break
+                }
                 provider?.send(
                     {
                         ...payload,
@@ -132,6 +139,12 @@ export async function INTERNAL_send(
                 )
                 break
             case ProviderType.MetaMask:
+                try {
+                    await MetaMask.ensureConnectedAndUnlocked()
+                } catch (error: any) {
+                    callback(error)
+                    break
+                }
                 provider?.send(payload, (error, response) => {
                     callback(error, response)
                     handleRecentTransaction(account, response)

--- a/packages/maskbook/src/plugins/Wallet/settings.ts
+++ b/packages/maskbook/src/plugins/Wallet/settings.ts
@@ -41,17 +41,6 @@ export const currentProviderSettings = createGlobalSettings<ProviderType>(
 )
 
 /**
- * Is Metamask Locked
- */
-export const currentIsMetaMaskLockedSettings = createGlobalSettings<boolean>(
-    `${PLUGIN_IDENTIFIER}+isMetaMaskLocked`,
-    true,
-    {
-        primary: () => 'DO NOT DISPLAY IT IN UI',
-    },
-)
-
-/**
  * The default portfolio data provider
  */
 export const currentPortfolioDataProviderSettings = createGlobalSettings<PortfolioProvider>(

--- a/packages/maskbook/src/web3/UI/EthereumWalletConnectedBoundary.tsx
+++ b/packages/maskbook/src/web3/UI/EthereumWalletConnectedBoundary.tsx
@@ -1,13 +1,10 @@
 import { Grid, makeStyles } from '@material-ui/core'
 import classNames from 'classnames'
-import { useCallback } from 'react'
-import { useValueRef, useRemoteControlledDialog, useStylesExtends } from '@masknet/shared'
+import { useRemoteControlledDialog, useStylesExtends } from '@masknet/shared'
 import ActionButton from '../../extension/options-page/DashboardComponents/ActionButton'
-import Services from '../../extension/service'
 import { WalletMessages } from '../../plugins/Wallet/messages'
-import { currentIsMetaMaskLockedSettings, currentProviderSettings } from '../../plugins/Wallet/settings'
 import { useI18N } from '../../utils'
-import { isZero, ProviderType, useAccount, useChainIdValid, useNativeTokenBalance } from '@masknet/web3-shared'
+import { isZero, useAccount, useChainIdValid, useNativeTokenBalance } from '@masknet/web3-shared'
 import { useWalletRiskWarningDialog } from '../../plugins/Wallet/hooks/useWalletRiskWarningDialog'
 
 const useStyles = makeStyles((theme) => ({
@@ -41,14 +38,6 @@ export function EthereumWalletConnectedBoundary(props: EthereumWalletConnectedBo
     )
     //#endregion
 
-    //#region metamask
-    const providerType = useValueRef(currentProviderSettings)
-    const currentIsMetamaskLocked = useValueRef(currentIsMetaMaskLockedSettings)
-    const onConnectMetaMask = useCallback(async () => {
-        await Services.Ethereum.connectMetaMask()
-    }, [])
-    //#endregion
-
     if (!account)
         return (
             <Grid container>
@@ -73,20 +62,6 @@ export function EthereumWalletConnectedBoundary(props: EthereumWalletConnectedBo
                     size="large"
                     onClick={openRiskWarningDialog}>
                     {t('plugin_wallet_confirm_risk_warning')}
-                </ActionButton>
-            </Grid>
-        )
-
-    if (providerType === ProviderType.MetaMask && currentIsMetamaskLocked)
-        return (
-            <Grid container>
-                <ActionButton
-                    className={classNames(classes.button, classes.unlockMetaMask)}
-                    fullWidth
-                    variant="contained"
-                    size="large"
-                    onClick={onConnectMetaMask}>
-                    {t('plugin_wallet_unlock_metamask')}
                 </ActionButton>
             </Grid>
         )


### PR DESCRIPTION
This PR removed `currentIsMetaMaskLockedSettings` and related UI interface. For each transaction that needs to be signed. We will emit a preflight request to make sure MetaMask has connected an account and unlocked it. 

closes #
