### PR TITLE
fix: return UTC time string instead of `Date` for `public-api`s

### DIFF
--- a/packages/maskbook/src/utils/native-rpc/Web.ts
+++ b/packages/maskbook/src/utils/native-rpc/Web.ts
@@ -21,8 +21,8 @@ const personaFomatter = (p: Persona) => {
         nickname: p.nickname,
         linkedProfiles: profiles,
         hasPrivateKey: p.hasPrivateKey,
-        createdAt: p.createdAt,
-        updatedAt: p.updatedAt,
+        createdAt: p.createdAt.toUTCString(),
+        updatedAt: p.updatedAt.toUTCString(),
     }
 }
 
@@ -31,8 +31,8 @@ const profileFormatter = (p: Profile) => {
         identifier: p.identifier.toText(),
         nickname: p.nickname,
         linkedPersona: !!p.linkedPersona,
-        createdAt: p.createdAt,
-        updatedAt: p.updatedAt,
+        createdAt: p.createdAt.toUTCString(),
+        updatedAt: p.updatedAt.toUTCString(),
     }
 }
 

--- a/packages/public-api/src/web.ts
+++ b/packages/public-api/src/web.ts
@@ -55,8 +55,8 @@ export interface Profile {
     identifier: string
     nickname?: string
     linkedPersona: boolean
-    createdAt: Date
-    updatedAt: Date
+    createdAt: string // in UTC
+    updatedAt: string // in UTC
 }
 
 export interface ProfileState {
@@ -68,8 +68,8 @@ export interface Persona {
     nickname?: string
     linkedProfiles: ProfileState
     hasPrivateKey: boolean
-    createdAt: Date
-    updatedAt: Date
+    createdAt: string // in UTC
+    updatedAt: string // in UTC
 }
 
 export interface BackupOptions {


### PR DESCRIPTION
Raw `Date` type inside a JSON is difficult for mobile apps to resolve