### PR TITLE
feat: record post history

### DIFF
--- a/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptedPost.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptedPost.tsx
@@ -96,7 +96,7 @@ export function DecryptPost(props: DecryptPostProps) {
     // pass 1:
     // decrypt post content and image attachments
     const decryptedPayloadForImageAlpha38 = decryptedPayloadForImage?.version === -38 ? decryptedPayloadForImage : null
-    const sharedPublic = usePostInfoSharedPublic() || decryptedPayloadForImageAlpha38?.sharedPublic
+    const sharedPublic = usePostInfoSharedPublic() || decryptedPayloadForImageAlpha38?.sharedPublic || false
 
     useEffect(() => {
         const signal = new AbortController()
@@ -139,6 +139,7 @@ export function DecryptPost(props: DecryptPostProps) {
             }
         }
 
+        const postURL = current.url.getCurrentValue()?.toString()
         if (deconstructedPayload.ok)
             makeProgress(
                 'post text',
@@ -148,11 +149,15 @@ export function DecryptPost(props: DecryptPostProps) {
                     whoAmI.network,
                     whoAmI,
                     sharedPublic,
+                    postURL,
                 ),
             )
         postMetadataImages.forEach((url) => {
             if (signal.signal.aborted) return
-            makeProgress(url, ServicesWithProgress.decryptFromImageUrl(url, postBy, whoAmI.network, whoAmI, undefined))
+            makeProgress(
+                url,
+                ServicesWithProgress.decryptFromImageUrl(url, postBy, whoAmI.network, whoAmI, false, postURL),
+            )
         })
         return () => signal.abort()
     }, [

--- a/packages/maskbook/src/database/post.ts
+++ b/packages/maskbook/src/database/post.ts
@@ -6,6 +6,7 @@ import { IdentifierMap } from './IdentifierMap'
 import { createDBAccessWithAsyncUpgrade, createTransaction } from './helpers/openDB'
 import type { AESJsonWebKey } from '../modules/CryptoAlgorithm/interfaces/utils'
 import { CryptoKeyToJsonWebKey } from '../utils/type-transform/CryptoKey-JsonWebKey'
+import { ECKeyIdentifier, PersonaIdentifier } from '@masknet/shared-base'
 
 type UpgradeKnowledge = { version: 4; data: Map<string, AESJsonWebKey> } | undefined
 const db = createDBAccessWithAsyncUpgrade<PostDB, UpgradeKnowledge>(
@@ -34,6 +35,10 @@ const db = createDBAccessWithAsyncUpgrade<PostDB, UpgradeKnowledge>(
                 }
                 type Version5PostRecord = Omit<Version4PostRecord, 'postCryptoKey'> & {
                     postCryptoKey?: AESJsonWebKey
+                    encryptBy?: PrototypeLess<PersonaIdentifier>
+                    url?: string
+                    summary?: string
+                    interestedMeta?: ReadonlyMap<string, unknown>
                 }
                 /**
                  * A type assert that make sure a and b are the same type
@@ -237,7 +242,7 @@ export async function deletePostCryptoKeyDB(record: PostIVIdentifier, t?: PostTr
 
 //#region db in and out
 function postOutDB(db: PostDBRecord): PostRecord {
-    const { identifier, foundAt, postBy, recipients, postCryptoKey } = db
+    const { identifier, foundAt, postBy, recipients, postCryptoKey, encryptBy, interestedMeta, summary, url } = db
     for (const detail of recipients.values()) {
         detail.reason.forEach((x) => x.type === 'group' && restorePrototype(x.group, GroupIdentifier.prototype))
     }
@@ -247,6 +252,10 @@ function postOutDB(db: PostDBRecord): PostRecord {
         recipients: new IdentifierMap(recipients, ProfileIdentifier),
         foundAt: foundAt,
         postCryptoKey: postCryptoKey,
+        encryptBy: restorePrototype(encryptBy, ECKeyIdentifier.prototype),
+        interestedMeta,
+        summary,
+        url,
     }
 }
 function postToDB(out: PostRecord): PostDBRecord {
@@ -297,6 +306,7 @@ export interface PostRecord {
      * For others post, it is when you see it first time.
      */
     foundAt: Date
+    encryptBy?: PersonaIdentifier
     /** The URL of this post */
     url?: string
     /** Summary of this post (maybe front 20 chars). */
@@ -305,10 +315,11 @@ export interface PostRecord {
     interestedMeta?: ReadonlyMap<string, unknown>
 }
 
-interface PostDBRecord extends Omit<PostRecord, 'postBy' | 'identifier' | 'recipients'> {
+interface PostDBRecord extends Omit<PostRecord, 'postBy' | 'identifier' | 'recipients' | 'encryptBy'> {
     postBy: PrototypeLess<ProfileIdentifier>
     identifier: string
     recipients: Map<string, RecipientDetail>
+    encryptBy?: PrototypeLess<PersonaIdentifier>
 }
 
 interface PostDB extends DBSchema {

--- a/packages/maskbook/src/database/post.ts
+++ b/packages/maskbook/src/database/post.ts
@@ -297,6 +297,12 @@ export interface PostRecord {
      * For others post, it is when you see it first time.
      */
     foundAt: Date
+    /** The URL of this post */
+    url?: string
+    /** Summary of this post (maybe front 20 chars). */
+    summary?: string
+    /** Interested metadata contained in this post. */
+    interestedMeta?: ReadonlyMap<string, unknown>
 }
 
 interface PostDBRecord extends Omit<PostRecord, 'postBy' | 'identifier' | 'recipients'> {

--- a/packages/maskbook/src/extension/background-script/CryptoServices/decryptFrom.ts
+++ b/packages/maskbook/src/extension/background-script/CryptoServices/decryptFrom.ts
@@ -6,7 +6,7 @@ import { deconstructPayload, Payload } from '../../../utils/type-transform/Paylo
 import { i18n } from '../../../utils/i18n-next'
 import { queryPersonaRecord, queryLocalKey } from '../../../database'
 import { ProfileIdentifier, PostIVIdentifier } from '../../../database/type'
-import { queryPostDB, updatePostDB } from '../../../database/post'
+import { PostRecord, queryPostDB, updatePostDB } from '../../../database/post'
 import { getNetworkWorker, getNetworkWorkerUninitialized } from '../../../social-network/worker'
 import { cryptoProviderTable } from './cryptoProviderTable'
 import type { PersonaRecord } from '../../../database/Persona/Persona.db'
@@ -15,7 +15,7 @@ import { publicSharedAESKey } from '../../../crypto/crypto-alpha-38'
 import { DecryptFailedReason } from '../../../utils/constants'
 import { asyncIteratorWithResult, memorizeAsyncGenerator } from '../../../utils/type-transform/asyncIteratorHelpers'
 import { delay } from '../../../utils/utils'
-import type { EC_Public_JsonWebKey, AESJsonWebKey } from '../../../modules/CryptoAlgorithm/interfaces/utils'
+import type { AESJsonWebKey } from '../../../modules/CryptoAlgorithm/interfaces/utils'
 import { decodeImageUrl } from '../SteganographyService'
 import type { TypedMessage } from '../../../protocols/typed-message'
 import stringify from 'json-stable-stringify'
@@ -128,7 +128,8 @@ async function* decryptFromPayloadWithProgress_raw(
     author: ProfileIdentifier,
     authorNetworkHint: string,
     whoAmI: ProfileIdentifier,
-    publicShared: undefined | boolean,
+    publicShared: boolean,
+    discoverURL: string | undefined,
 ): ReturnOfDecryptPostContentWithProgress {
     const cacheKey = stringify(post)
     if (successDecryptionCache.has(cacheKey)) return successDecryptionCache.get(cacheKey)!
@@ -152,7 +153,7 @@ async function* decryptFromPayloadWithProgress_raw(
         yield { type: 'progress', progress: 'payload_decrypted', decryptedPayloadForImage: data, internal: true }
         yield { type: 'progress', progress: 'iv_decrypted', iv: iv, internal: true }
         // ? Early emit the cache.
-        const [cachedPostResult, setPostCache] = await decryptFromCache(data, author)
+        const [cachedPostResult, setPostCache] = await decryptFromCache(data, author, discoverURL)
         if (cachedPostResult) {
             yield makeProgress(makeSuccessResult(cachedPostResult, ['post_key_cached']))
         }
@@ -201,8 +202,8 @@ async function* decryptFromPayloadWithProgress_raw(
          * ? then try to go through a normal decrypt process
          */
         try {
-            const a = decryptAsAuthor(author, minePublic)
-            const b = decryptAsAuthor(whoAmI, minePublic)
+            const a = decryptAsAuthor(author)
+            const b = decryptAsAuthor(whoAmI)
             // ! Don't remove the await
             return await a.catch(() => b)
         } catch (error) {
@@ -288,7 +289,7 @@ async function* decryptFromPayloadWithProgress_raw(
             return makeSuccessResult(content, ['normal_decrypted'])
         }
 
-        async function decryptAsAuthor(authorIdentifier: ProfileIdentifier, authorPublic: EC_Public_JsonWebKey) {
+        async function decryptAsAuthor(authorIdentifier: ProfileIdentifier) {
             const localKey = sharePublic ? publicSharedAESKey : await queryLocalKey(authorIdentifier)
             if (!localKey) throw new Error(`Local key for identity ${authorIdentifier.toText()} not found`)
             const [contentArrayBuffer, postAESKey] = await cryptoProvider.decryptMessage1ToNByMyself({
@@ -312,7 +313,8 @@ async function* decryptFromImageUrlWithProgress_raw(
     author: ProfileIdentifier,
     authorNetworkHint: string,
     whoAmI: ProfileIdentifier,
-    publicShared?: boolean,
+    publicShared: boolean,
+    discoverURL: string | undefined,
 ): ReturnOfDecryptPostContentWithProgress {
     if (successDecryptionCache.has(url)) return successDecryptionCache.get(url)!
     yield makeProgress('decode_post', true)
@@ -325,20 +327,19 @@ async function* decryptFromImageUrlWithProgress_raw(
     if (worker.err) return makeError(worker.val as Error)
     const payload = deconstructPayload(post, await decodeTextPayloadWorker(author))
     if (payload.err) return makeError(payload.val)
-    return yield* decryptFromText(payload.val, author, authorNetworkHint, whoAmI, publicShared)
+    return yield* decryptFromText(payload.val, author, authorNetworkHint, whoAmI, publicShared, discoverURL)
 }
 
 export const decryptFromText = memorizeAsyncGenerator(
     decryptFromPayloadWithProgress_raw,
-    (encrypted, author, authorNetworkHint, whoAmI, publicShared = undefined) =>
-        JSON.stringify([encrypted, author.toText(), authorNetworkHint, whoAmI.toText(), publicShared]),
+    (encrypted, author, _, whoAmI) =>
+        JSON.stringify([encrypted.iv, encrypted.encryptedText, author.toText(), whoAmI.toText()]),
     1000 * 30,
 )
 
 export const decryptFromImageUrl = memorizeAsyncGenerator(
     decryptFromImageUrlWithProgress_raw,
-    (url, author, authorNetworkHint, whoAmI, publicShared = undefined) =>
-        JSON.stringify([url, author.toText(), authorNetworkHint, whoAmI.toText(), publicShared]),
+    (url, author, _, whoAmI) => JSON.stringify([url, author.toText(), whoAmI.toText()]),
     1000 * 30,
 )
 
@@ -389,21 +390,23 @@ async function* findAuthorPublicKey(
     return 'out of chance'
 }
 
-async function decryptFromCache(postPayload: Payload, by: ProfileIdentifier) {
+async function decryptFromCache(postPayload: Payload, by: ProfileIdentifier, discoverURL: string | undefined) {
     const { encryptedText, iv, version } = postPayload
     const cryptoProvider = version === -40 ? Alpha40 : Alpha39
 
     const postIdentifier = new PostIVIdentifier(by.network, iv)
     const cachedKey = await queryPostDB(postIdentifier)
+    if (cachedKey && !cachedKey.url && discoverURL) {
+        await updatePostDB({ identifier: postIdentifier, url: discoverURL }, 'append')
+    }
     const setCache = (postAESKey: AESJsonWebKey) => {
-        updatePostDB(
-            {
-                identifier: postIdentifier,
-                postCryptoKey: postAESKey,
-                postBy: by,
-            },
-            'append',
-        )
+        const postUpdate: Partial<PostRecord> & Pick<PostRecord, 'identifier'> = {
+            identifier: postIdentifier,
+            postCryptoKey: postAESKey,
+            postBy: by,
+        }
+        if (discoverURL) postUpdate.url = discoverURL
+        updatePostDB(postUpdate, 'append')
     }
     if (cachedKey?.postCryptoKey) {
         try {

--- a/packages/maskbook/src/extension/background-script/CryptoServices/encryptTo.ts
+++ b/packages/maskbook/src/extension/background-script/CryptoServices/encryptTo.ts
@@ -2,7 +2,7 @@ import * as Alpha38 from '../../../crypto/crypto-alpha-38'
 import { GunAPI as Gun2 } from '../../../network/gun'
 import { encodeArrayBuffer } from '../../../utils/type-transform/String-ArrayBuffer'
 import { constructAlpha38, PayloadLatest } from '../../../utils/type-transform/Payload'
-import { queryPrivateKey, queryLocalKey } from '../../../database'
+import { queryPrivateKey, queryLocalKey, queryProfile } from '../../../database'
 import { ProfileIdentifier, PostIVIdentifier } from '../../../database/type'
 import { prepareRecipientDetail } from './prepareRecipientDetail'
 import { getNetworkWorker } from '../../../social-network/worker'
@@ -42,6 +42,7 @@ export async function encryptTo(
     if (publicShared) to = []
     const [recipients, toKey] = await prepareRecipientDetail(to)
 
+    const usingPersona = await queryProfile(whoAmI)
     const minePrivateKey = await queryPrivateKey(whoAmI)
     if (!minePrivateKey) throw new TypeError('Not inited yet')
     const stringifiedContent = Alpha38.typedMessageStringify(content)
@@ -85,6 +86,7 @@ export async function encryptTo(
         postCryptoKey: postAESKey,
         recipients: recipients,
         foundAt: new Date(),
+        encryptBy: usingPersona.linkedPersona?.identifier,
     }
     if (Flags.v2_enabled) {
         if (isTypedMessageText(content)) {

--- a/packages/maskbook/src/extension/background-script/CryptoServices/encryptTo.ts
+++ b/packages/maskbook/src/extension/background-script/CryptoServices/encryptTo.ts
@@ -6,12 +6,13 @@ import { queryPrivateKey, queryLocalKey } from '../../../database'
 import { ProfileIdentifier, PostIVIdentifier } from '../../../database/type'
 import { prepareRecipientDetail } from './prepareRecipientDetail'
 import { getNetworkWorker } from '../../../social-network/worker'
-import { createPostDB } from '../../../database/post'
+import { createPostDB, PostRecord } from '../../../database/post'
 import { queryPersonaByProfileDB } from '../../../database/Persona/Persona.db'
 import { compressSecp256k1Key } from '../../../utils/type-transform/SECP256k1-Compression'
 import { i18n } from '../../../utils/i18n-next'
-import type { TypedMessage } from '../../../protocols/typed-message'
+import { isTypedMessageText, TypedMessage, TypedMessageText } from '../../../protocols/typed-message'
 import { encodeTextPayloadWorker } from '../../../social-network/utils/text-payload-worker'
+import { Flags } from '../../../utils'
 
 type EncryptedText = string
 type OthersAESKeyEncryptedToken = string
@@ -78,13 +79,20 @@ export async function encryptTo(
 
     payload.signature = '_'
 
-    await createPostDB({
+    const newPostRecord: PostRecord = {
         identifier: new PostIVIdentifier(whoAmI.network, payload.iv),
         postBy: whoAmI,
         postCryptoKey: postAESKey,
         recipients: recipients,
         foundAt: new Date(),
-    })
+    }
+    if (Flags.v2_enabled) {
+        if (isTypedMessageText(content)) {
+            newPostRecord.summary = getSummary(content)
+            newPostRecord.interestedMeta = content.meta
+        }
+    }
+    await createPostDB(newPostRecord)
 
     const postAESKeyToken = encodeArrayBuffer(iv)
     const worker = await getNetworkWorker(whoAmI)!
@@ -103,4 +111,19 @@ export async function publishPostAESKey(iv: string) {
     if (!info[1].length) return
     // Use the latest payload version here since we do not accept new post for older version.
     return Gun2.publishPostAESKeyOnGun2(-38, iv, ...info)
+}
+function getSummary(content: TypedMessageText) {
+    let result = ''
+    // UTF-8 aware summary
+    if (Intl.Segmenter) {
+        // it seems like using "en" can also split the word correctly.
+        const seg = new Intl.Segmenter('en')
+        for (const word of seg.segment(content.content)) {
+            if (result.length >= 20) break
+            result += word.segment
+        }
+    } else {
+        result = result.slice(0, 20)
+    }
+    return result
 }

--- a/packages/maskbook/src/polyfill/global.d.ts
+++ b/packages/maskbook/src/polyfill/global.d.ts
@@ -9,4 +9,11 @@ declare namespace Intl {
         constructor(locales?: string, options?: Partial<ListFormatOptions>)
         format(str: string[]): string
     }
+    export interface SegmenterOptions {
+        granularity?: 'grapheme' | 'word' | 'sentence'
+    }
+    export class Segmenter {
+        constructor(lang: string, options?: SegmenterOptions)
+        segment(word: string): Iterable<{ segment: string; index: number; input: string; isWordLike: boolean }>
+    }
 }

--- a/packages/maskbook/src/social-network-adaptor/facebook.com/shared.ts
+++ b/packages/maskbook/src/social-network-adaptor/facebook.com/shared.ts
@@ -5,6 +5,11 @@ import { PostIdentifier, ProfileIdentifier } from '@masknet/shared'
 import { deconstructPayload } from '../../utils'
 import { createSNSAdaptorSpecializedPostContext } from '../../social-network/utils/create-post-context'
 
+const getPostURL = (post: PostIdentifier): URL | null => {
+    if (post.identifier instanceof ProfileIdentifier)
+        return new URL(getPostUrlAtFacebook(post as PostIdentifier<ProfileIdentifier>))
+    return null
+}
 export const facebookShared: SocialNetwork.Shared & SocialNetwork.Base = {
     ...facebookBase,
     utils: {
@@ -12,11 +17,7 @@ export const facebookShared: SocialNetwork.Shared & SocialNetwork.Base = {
         isValidUsername: (v) => !!isValidFacebookUsername(v),
         publicKeyEncoding: undefined,
         textPayloadPostProcessor: undefined,
-        getPostURL(post) {
-            if (post.identifier instanceof ProfileIdentifier)
-                return new URL(getPostUrlAtFacebook(post as PostIdentifier<ProfileIdentifier>))
-            return null
-        },
+        getPostURL,
         getShareLinkURL(message) {
             const url = new URL('https://www.facebook.com/sharer/sharer.php')
             url.searchParams.set('quote', message)
@@ -25,6 +26,7 @@ export const facebookShared: SocialNetwork.Shared & SocialNetwork.Base = {
         },
         createPostContext: createSNSAdaptorSpecializedPostContext({
             payloadParser: deconstructPayload,
+            getURLFromPostIdentifier: getPostURL,
         }),
     },
 }

--- a/packages/maskbook/src/social-network-adaptor/minds.com/shared.ts
+++ b/packages/maskbook/src/social-network-adaptor/minds.com/shared.ts
@@ -1,9 +1,13 @@
+import type { PostIdentifier } from '@masknet/shared'
 import type { SocialNetwork } from '../../social-network/types'
 import { createSNSAdaptorSpecializedPostContext } from '../../social-network/utils/create-post-context'
 import { deconstructPayload } from '../../utils'
 import { mindsBase } from './base'
 import { usernameValidator } from './utils/user'
 
+const getPostURL = (post: PostIdentifier): URL => {
+    return new URL(`https://minds.com/newsfeed/${post.postId}`)
+}
 export const mindsShared: SocialNetwork.Shared & SocialNetwork.Base = {
     ...mindsBase,
     utils: {
@@ -11,14 +15,13 @@ export const mindsShared: SocialNetwork.Shared & SocialNetwork.Base = {
         isValidUsername: usernameValidator,
         publicKeyEncoding: undefined,
         textPayloadPostProcessor: undefined,
-        getPostURL(post) {
-            return new URL(`https://minds.com/newsfeed/${post.postId}`)
-        },
+        getPostURL,
         getShareLinkURL(message) {
             return new URL(`https://www.minds.com/newsfeed/subscriptions?intentUrl=${encodeURIComponent(message)}`)
         },
         createPostContext: createSNSAdaptorSpecializedPostContext({
             payloadParser: deconstructPayload,
+            getURLFromPostIdentifier: getPostURL,
         }),
     },
 }

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/shared.ts
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/shared.ts
@@ -1,4 +1,4 @@
-import { ProfileIdentifier } from '@masknet/shared'
+import { PostIdentifier, ProfileIdentifier } from '@masknet/shared'
 import type { SocialNetwork } from '../../social-network/types'
 import { createSNSAdaptorSpecializedPostContext } from '../../social-network/utils/create-post-context'
 import { deconstructPayload } from '../../utils'
@@ -6,6 +6,10 @@ import { twitterBase } from './base'
 import { twitterEncoding } from './encoding'
 import { usernameValidator } from './utils/user'
 
+const getPostURL = (post: PostIdentifier): URL | null => {
+    if (!(post.identifier instanceof ProfileIdentifier)) return null
+    return new URL(`https://twitter.com/${post.identifier.userId}/status/${post.postId}`)
+}
 export const twitterShared: SocialNetwork.Shared & SocialNetwork.Base = {
     ...twitterBase,
     utils: {
@@ -27,16 +31,14 @@ export const twitterShared: SocialNetwork.Shared & SocialNetwork.Base = {
                 return twitterEncoding.payloadDecoder(text)
             },
         },
-        getPostURL(post) {
-            if (!(post.identifier instanceof ProfileIdentifier)) return null
-            return new URL(`https://twitter.com/${post.identifier.userId}/status/${post.postId}`)
-        },
+        getPostURL,
         getShareLinkURL(message) {
             return new URL(`https://twitter.com/intent/tweet?text=${encodeURIComponent(message)}`)
         },
         createPostContext: createSNSAdaptorSpecializedPostContext({
             payloadParser: deconstructPayload,
             payloadDecoder: twitterEncoding.payloadDecoder,
+            getURLFromPostIdentifier: getPostURL,
         }),
     },
 }

--- a/packages/maskbook/src/utils/type-transform/BackupFormat/JSON/version-2.ts
+++ b/packages/maskbook/src/utils/type-transform/BackupFormat/JSON/version-2.ts
@@ -63,6 +63,10 @@ export interface BackupJSONFileVersion2 {
         /** @deprecated */
         recipientGroups: never[] // Array<GroupIdentifier.toText()>
         foundAt: number // Unix timestamp
+        encryptBy?: string // PersonaIdentifier.toText()
+        url?: string
+        summary?: string
+        interestedMeta?: string // encoded by MessagePack
     }>
     wallets: Array<{
         address: string

--- a/packages/plugin-infra/src/PostContext.ts
+++ b/packages/plugin-infra/src/PostContext.ts
@@ -20,6 +20,7 @@ export interface PostContextSNSActions {
      * @returns a list of candidates of payload string.
      */
     payloadDecoder?(postContent: string): string[]
+    getURLFromPostIdentifier?(post: PostIdentifier): URL | null
 }
 export interface PostContextAuthor {
     readonly nickname: Subscription<string | null>
@@ -29,7 +30,6 @@ export interface PostContextAuthor {
     readonly postBy: Subscription<ProfileIdentifier>
     // TODO: rename to id
     readonly postID: Subscription<string | null>
-    readonly url: Subscription<URL | null>
 }
 export interface PostContextComment {
     readonly commentsSelector: LiveSelector<HTMLElement, false>
@@ -72,6 +72,7 @@ export interface PostContext extends PostContextAuthor {
     /** Auto computed */
     // TODO: rename to identifier
     readonly postIdentifier: Subscription<null | PostIdentifier<ProfileIdentifier>>
+    readonly url: Subscription<URL | null>
     // Meta
     // TODO: rename to mentionedLinks
     readonly postMentionedLinks: Subscription<string[]>


### PR DESCRIPTION
Record the following information of a post:

- URL
- `encryptedBy`: `PersonaIdentifier`
- `summary`: string (a char that has a length around 20, can overflow to keep the completeness of Unicode code-point cluster)
- `interestedMeta`: The interested metadata that this post contains.

Notice: Only URL is recorded on the decryption process. All other extra information ARE ONLY recorded at the composition (encryption) time!

Since the dashboard is ONLY using the post _I_ sent, so I will not record other one's posts to save space.

close #3374 
close MASK-58