### PR TITLE
feat: update connectProfile to directly use `ProfileIdentifier` as param

### DIFF
--- a/packages/maskbook/src/utils/native-rpc/Web.ts
+++ b/packages/maskbook/src/utils/native-rpc/Web.ts
@@ -141,9 +141,11 @@ export const MaskNetworkAPI: MaskNetworkAPIs = {
 
         if (!result) throw new Error('invalid base64')
     },
-    persona_connectProfile: async ({ network, profileUsername, personaIdentifier }) => {
+    persona_connectProfile: async ({ profileIdentifier, personaIdentifier }) => {
+        const profileId = ProfileIdentifier.fromString(profileIdentifier)
+        if (!(profileId instanceof ProfileIdentifier)) throw new Error('invalid identifier')
         const identifier = stringToIdentifier(personaIdentifier)
-        await Services.Identity.attachProfile(new ProfileIdentifier(network, profileUsername), identifier, {
+        await Services.Identity.attachProfile(profileId, identifier, {
             connectionConfirmState: 'confirmed',
         })
 
@@ -206,7 +208,7 @@ export const MaskNetworkAPI: MaskNetworkAPIs = {
         await WalletRPC.updateAccount({
             account,
         })
-        await WalletMessages.events.walletsUpdated.sendToAll()
+        WalletMessages.events.walletsUpdated.sendToAll()
     },
     wallet_updateEthereumChainId: async ({ chainId }) => {
         await WalletRPC.updateAccount({

--- a/packages/public-api/src/web.ts
+++ b/packages/public-api/src/web.ts
@@ -46,8 +46,7 @@ export interface MaskNetworkAPIs {
     persona_restoreFromJson(params: { backup: string }): Promise<void>
     persona_restoreFromBase64(params: { backup: string }): Promise<void>
     persona_connectProfile(params: {
-        network: string
-        profileUsername: string
+        profileIdentifier: ProfileIdentifier_string
         personaIdentifier: PersonaIdentifier_string
     }): Promise<void>
     persona_disconnectProfile(params: { identifier: ProfileIdentifier_string }): Promise<void>


### PR DESCRIPTION
Since `SNSAdaptor_getCurrentDetectedProfile` returns `ProfileIdentifier` as the result, the `persona_connectProfile` should also accept `ProfileIdentifier` as the input param