### PR TITLE
chore: ito qual error msg

### DIFF
--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
@@ -43,6 +43,7 @@ import { ITO_Status, JSON_PayloadInMask } from '../types'
 import { StyledLinearProgress } from './StyledLinearProgress'
 import { SwapGuide, SwapStatus } from './SwapGuide'
 import urlcat from 'urlcat'
+import { startCase } from 'lodash-es'
 
 export interface IconProps {
     size?: number
@@ -683,7 +684,7 @@ export function ITO(props: ITO_Props) {
                             : !ifQualified
                             ? t('plugin_ito_qualification_failed')
                             : !(ifQualified as Qual_V2).qualified
-                            ? (ifQualified as Qual_V2).errorMsg
+                            ? startCase((ifQualified as Qual_V2).errorMsg)
                             : null}
                     </ActionButton>
                 ) : listOfStatus.includes(ITO_Status.expired) ? (

--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
@@ -259,6 +259,7 @@ export function ITO(props: ITO_Props) {
         !isRegionRestrict || !currentRegion || (!loadingRegion && allowRegions.includes(currentRegion.code))
 
     //#region if qualified
+    type Qual_V2 = { qualified: boolean; errorMsg: string }
     const {
         value: ifQualified = false,
         loading: loadingIfQualified,
@@ -670,14 +671,20 @@ export function ITO(props: ITO_Props) {
                             </ActionButton>
                         </Grid>
                     </Grid>
-                ) : !ifQualified ? (
+                ) : !ifQualified || !(ifQualified as Qual_V2).qualified ? (
                     <ActionButton
                         onClick={retryIfQualified}
                         loading={loadingIfQualified}
                         variant="contained"
                         size="large"
                         className={classes.actionButton}>
-                        {t(loadingIfQualified ? 'plugin_ito_qualification_loading' : 'plugin_ito_qualification_failed')}
+                        {loadingIfQualified
+                            ? t('plugin_ito_qualification_loading')
+                            : !ifQualified
+                            ? t('plugin_ito_qualification_failed')
+                            : !(ifQualified as Qual_V2).qualified
+                            ? (ifQualified as Qual_V2).errorMsg
+                            : null}
                     </ActionButton>
                 ) : listOfStatus.includes(ITO_Status.expired) ? (
                     <ActionButton


### PR DESCRIPTION
Support ITO qualification `ifQualified()` which returns an error msg, and display it.

<img src="https://user-images.githubusercontent.com/63733714/130754109-49768da1-fb7b-4907-9eec-25a8a123ec3d.png" width=500 />

(This is a testing qualification, 'not started' is pure text)

