### PR TITLE
fix: setTimeout overflow

### DIFF
--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/ITO.tsx
@@ -383,7 +383,7 @@ export function ITO(props: ITO_Props) {
     useEffect(() => {
         const timeToExpired = endTime - Date.now()
 
-        // https://stackoverflow.com/questions/3468607/why-does-settimeout-break-for-large-millisecond-delay-values
+        // https://stackoverflow.com/q/3468607
         // SetTimeout using a 32 bit int to store the delay so the max value allowed would be 2147483647.
         // Meanwhile, no need to refresh ITO card when expired time is a large value (more than one day).
         if (timeToExpired < 0 || listOfStatus.includes(ITO_Status.expired) || timeToExpired > 1000 * 60 * 60 * 24)


### PR DESCRIPTION
https://stackoverflow.com/questions/3468607/why-does-settimeout-break-for-large-millisecond-delay-values

![image](https://user-images.githubusercontent.com/63733714/130901986-246080a1-ade4-48fb-bcb6-933125e646ac.png)

Meanwhile, no need to refresh ITO card when expired time is a large value (more than one day)

