### PR TITLE
fix: ui regression introduced by 4060

### DIFF
--- a/packages/maskbook/src/components/shared/InjectedDialog.tsx
+++ b/packages/maskbook/src/components/shared/InjectedDialog.tsx
@@ -105,6 +105,9 @@ export function InjectedDialog(props: InjectedDialogProps) {
                         </Typography>
                     </DialogTitle>
                 ) : null}
+                {/* There is a .MuiDialogTitle+.MuiDialogContent selector that provides paddingTop: 0 */}
+                {/* Add an empty span here to revert this effect. */}
+                <span />
                 {content}
                 {actions}
             </ErrorBoundary>


### PR DESCRIPTION
- Revert "fix: dialog padding top in injected script"
- fix: dialog padding top again
bring in #4060
<!-- Please refer to the related issue number -->
closes #4113