### PR TITLE
refactor: send request with second-time confirmation

### DIFF
--- a/packages/maskbook/src/extension/background-script/EthereumServices/request.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/request.ts
@@ -11,7 +11,15 @@ import { openPopupsWindow } from '../HelperService'
 
 let id = 0
 
-const unconfirmedCallbackMap = new Map<number, (error: Error | null, response?: JsonRpcResponse) => void>()
+const UNCONFIRMED_CALLBACK_MAP = new Map<number, (error: Error | null, response?: JsonRpcResponse) => void>()
+const RISK_METHOD_LIST = [
+    EthereumMethodType.ETH_SIGN,
+    EthereumMethodType.PERSONAL_SIGN,
+    EthereumMethodType.ETH_SIGN_TYPED_DATA,
+    EthereumMethodType.ETH_DECRYPT,
+    EthereumMethodType.ETH_GET_ENCRYPTION_PUBLIC_KEY,
+    EthereumMethodType.ETH_SEND_TRANSACTION,
+]
 
 function getSendMethod() {
     if (hasNativeAPI && nativeAPI) return INTERNAL_nativeSend
@@ -22,15 +30,8 @@ function getPayloadId(payload: JsonRpcPayload) {
     return typeof payload.id === 'string' ? Number.parseInt(payload.id, 10) : payload.id
 }
 
-function isRpcNeedToBeConfirmed(method: EthereumMethodType) {
-    return [
-        EthereumMethodType.ETH_SIGN,
-        EthereumMethodType.PERSONAL_SIGN,
-        EthereumMethodType.ETH_SIGN_TYPED_DATA,
-        EthereumMethodType.ETH_DECRYPT,
-        EthereumMethodType.ETH_GET_ENCRYPTION_PUBLIC_KEY,
-        EthereumMethodType.ETH_SEND_TRANSACTION,
-    ].includes(method)
+function isRiskMethod(method: EthereumMethodType) {
+    return RISK_METHOD_LIST.includes(method)
 }
 
 export async function request<T extends unknown>(requestArguments: RequestArguments, overrides?: SendOverrides) {
@@ -64,7 +65,7 @@ export async function requestSend(
     }
     if (
         Flags.v2_enabled &&
-        isRpcNeedToBeConfirmed(payload_.method as EthereumMethodType) &&
+        isRiskMethod(payload_.method as EthereumMethodType) &&
         providerType === ProviderType.Maskbook
     ) {
         try {
@@ -73,7 +74,7 @@ export async function requestSend(
             callback(error instanceof Error ? error : new Error('Failed to add request.'))
             return
         }
-        unconfirmedCallbackMap.set(payload_.id, callback)
+        UNCONFIRMED_CALLBACK_MAP.set(payload_.id, callback)
         return
     }
     getSendMethod()(payload_, callback, overrides)
@@ -91,14 +92,14 @@ export async function requestSendWithConfirmation(
 export async function confirmRequest(payload: JsonRpcPayload) {
     const pid = getPayloadId(payload)
     if (!pid) return
-    getSendMethod()(payload, unconfirmedCallbackMap.get(pid) ?? noop)
+    getSendMethod()(payload, UNCONFIRMED_CALLBACK_MAP.get(pid) ?? noop)
     await WalletRPC.deleteUnconfirmedRequest(payload)
-    unconfirmedCallbackMap.delete(pid)
+    UNCONFIRMED_CALLBACK_MAP.delete(pid)
 }
 
 export async function rejectRequest(payload: JsonRpcPayload) {
     const pid = getPayloadId(payload)
     if (!pid) return
     await WalletRPC.deleteUnconfirmedRequest(payload)
-    unconfirmedCallbackMap.delete(pid)
+    UNCONFIRMED_CALLBACK_MAP.delete(pid)
 }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/request.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/request.ts
@@ -1,13 +1,41 @@
+import { noop } from 'lodash-es'
 import type { RequestArguments } from 'web3-core'
 import type { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
-import { INTERNAL_send, SendOverrides } from './send'
+import { INTERNAL_nativeSend, INTERNAL_send, SendOverrides } from './send'
+import { hasNativeAPI, nativeAPI } from '../../../utils/native-rpc'
+import { EthereumMethodType, ProviderType } from '@masknet/web3-shared'
+import { currentProviderSettings } from '../../../plugins/Wallet/settings'
+import { Flags } from '../../../utils'
+import { WalletRPC } from '../../../plugins/Wallet/messages'
+import { openPopupsWindow } from '../HelperService'
 
 let id = 0
 
+const unconfirmedCallbackMap = new Map<number, (error: Error | null, response?: JsonRpcResponse) => void>()
+
+function getSendMethod() {
+    if (hasNativeAPI && nativeAPI) return INTERNAL_nativeSend
+    return INTERNAL_send
+}
+
+function getPayloadId(payload: JsonRpcPayload) {
+    return typeof payload.id === 'string' ? Number.parseInt(payload.id, 10) : payload.id
+}
+
+function isRpcNeedToBeConfirmed(method: EthereumMethodType) {
+    return [
+        EthereumMethodType.ETH_SIGN,
+        EthereumMethodType.PERSONAL_SIGN,
+        EthereumMethodType.ETH_SIGN_TYPED_DATA,
+        EthereumMethodType.ETH_DECRYPT,
+        EthereumMethodType.ETH_GET_ENCRYPTION_PUBLIC_KEY,
+        EthereumMethodType.ETH_SEND_TRANSACTION,
+    ].includes(method)
+}
+
 export async function request<T extends unknown>(requestArguments: RequestArguments, overrides?: SendOverrides) {
-    return new Promise<T>((resolve, reject) => {
-        id += 1
-        INTERNAL_send(
+    return new Promise<T>(async (resolve, reject) => {
+        requestSend(
             {
                 jsonrpc: '2.0',
                 id,
@@ -26,13 +54,51 @@ export async function request<T extends unknown>(requestArguments: RequestArgume
 export async function requestSend(
     payload: JsonRpcPayload,
     callback: (error: Error | null, response?: JsonRpcResponse) => void,
+    overrides?: SendOverrides,
 ) {
     id += 1
-    await INTERNAL_send(
-        {
-            ...payload,
-            id,
-        },
-        callback,
-    )
+    const { providerType = currentProviderSettings.value } = overrides ?? {}
+    const payload_ = {
+        ...payload,
+        id,
+    }
+    if (
+        Flags.v2_enabled &&
+        isRpcNeedToBeConfirmed(payload_.method as EthereumMethodType) &&
+        providerType === ProviderType.Maskbook
+    ) {
+        try {
+            await WalletRPC.pushUnconfirmedRequest(payload_)
+        } catch (error) {
+            callback(error instanceof Error ? error : new Error('Failed to add request.'))
+            return
+        }
+        unconfirmedCallbackMap.set(payload_.id, callback)
+        return
+    }
+    getSendMethod()(payload_, callback, overrides)
+}
+
+export async function requestSendWithConfirmation(
+    payload: JsonRpcPayload,
+    callback: (error: Error | null, response?: JsonRpcResponse) => void,
+    overrides?: SendOverrides,
+) {
+    requestSend(payload, callback, overrides)
+    openPopupsWindow()
+}
+
+export async function confirmRequest(payload: JsonRpcPayload) {
+    const pid = getPayloadId(payload)
+    if (!pid) return
+    getSendMethod()(payload, unconfirmedCallbackMap.get(pid) ?? noop)
+    await WalletRPC.deleteUnconfirmedRequest(payload)
+    unconfirmedCallbackMap.delete(pid)
+}
+
+export async function rejectRequest(payload: JsonRpcPayload) {
+    const pid = getPayloadId(payload)
+    if (!pid) return
+    await WalletRPC.deleteUnconfirmedRequest(payload)
+    unconfirmedCallbackMap.delete(pid)
 }

--- a/packages/maskbook/src/extension/background-script/EthereumServices/send.ts
+++ b/packages/maskbook/src/extension/background-script/EthereumServices/send.ts
@@ -250,5 +250,6 @@ export async function INTERNAL_nativeSend(
             callback(error, undefined)
             handleNonce(account, error, undefined)
         }
+        console.error('internal native send error', error)
     }
 }

--- a/packages/maskbook/src/extension/popups/pages/Wallet/GasSetting/index.tsx
+++ b/packages/maskbook/src/extension/popups/pages/Wallet/GasSetting/index.tsx
@@ -191,10 +191,7 @@ const GasSetting = memo(() => {
                           gasPrice: currentGasPrice ? options[currentGasPrice].gasPrice : initConfig.gasPrice,
                       }
                 await WalletRPC.deleteUnconfirmedRequest(value.payload)
-                await Services.Ethereum.request(
-                    { ...value.payload, params: [config, ...value.payload.params] },
-                    { skipConfirmation: true },
-                )
+                await Services.Ethereum.request({ ...value.payload, params: [config, ...value.payload.params] })
             }
         },
         [value, currentGasPrice, options],

--- a/packages/maskbook/src/extension/popups/pages/Wallet/SignRequest/index.tsx
+++ b/packages/maskbook/src/extension/popups/pages/Wallet/SignRequest/index.tsx
@@ -81,7 +81,7 @@ const SignRequest = memo(() => {
     const [{ loading }, handleConfirm] = useAsyncFn(async () => {
         if (value) {
             await WalletRPC.deleteUnconfirmedRequest(value.payload)
-            await Services.Ethereum.request(value.payload, { skipConfirmation: true })
+            await Services.Ethereum.request(value.payload)
         }
     }, [value])
 

--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/hooks/useBlockNumberOfChain.ts
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/hooks/useBlockNumberOfChain.ts
@@ -1,18 +1,14 @@
-import { ChainId, getRPCConstants, EthereumMethodType } from '@masknet/web3-shared'
-import { first } from 'lodash-es'
-import Services from '../../../../extension/service'
 import { useAsync } from 'react-use'
+import { ChainId, EthereumMethodType } from '@masknet/web3-shared'
+import Services from '../../../../extension/service'
 
 /**
  * Get the current block number of specified chain
  */
 export function useBlockNumberOfChain(chainId: ChainId) {
-    const { RPC } = getRPCConstants(chainId)
-    const provderURL = first(RPC)
-    if (!provderURL) throw new Error('Unknown chain id.')
     const { value } = useAsync(
-        () => Services.Ethereum.request<string>({ method: EthereumMethodType.ETH_BLOCK_NUMBER }, { rpc: provderURL }),
-        [provderURL],
+        () => Services.Ethereum.request<string>({ method: EthereumMethodType.ETH_BLOCK_NUMBER }, { chainId }),
+        [chainId],
     )
     return value ? Number.parseInt(value, 10) : 0
 }

--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/hooks/useClaimablePoolsByWeb3.ts
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/hooks/useClaimablePoolsByWeb3.ts
@@ -1,5 +1,5 @@
 import { useAsyncRetry } from 'react-use'
-import { flatten, first } from 'lodash-es'
+import { flatten } from 'lodash-es'
 import { sha3 } from 'web3-utils'
 import type { PastLogsOptions, Log } from 'web3-core'
 import {
@@ -10,7 +10,6 @@ import {
     EthereumTokenType,
     useGetPastLogsParams,
     ChainId,
-    getRPCConstants,
 } from '@masknet/web3-shared'
 import type { ClaimablePool } from '../../types'
 import { useBlockNumberOfChain } from './useBlockNumberOfChain'
@@ -40,9 +39,6 @@ export function useClaimablePoolsByWeb3(chainId: ChainId) {
         topics: [SWAP_SUCCESS_TOPIC],
     })
 
-    const { RPC } = getRPCConstants(chainId)
-    const provderURL = first(RPC)
-    if (!provderURL) throw new Error('Unknown chain id.')
     return useAsyncRetry(async () => {
         if (!currentBlock) return []
         const logs = flatten<Log>(
@@ -50,7 +46,6 @@ export function useClaimablePoolsByWeb3(chainId: ChainId) {
                 queryParams.map((queryParam: PastLogsOptions) =>
                     Services.Ethereum.getPastLogs(queryParam, {
                         chainId,
-                        rpc: provderURL,
                     }),
                 ),
             ),
@@ -69,5 +64,5 @@ export function useClaimablePoolsByWeb3(chainId: ChainId) {
             }
             return acc
         }, [])
-    }, [account, address, chainId, JSON.stringify(queryParams), currentBlock, provderURL])
+    }, [account, address, chainId, JSON.stringify(queryParams), currentBlock])
 }

--- a/packages/maskbook/src/plugins/Wallet/services/rpc.ts
+++ b/packages/maskbook/src/plugins/Wallet/services/rpc.ts
@@ -4,7 +4,7 @@ import type { JsonRpcPayload } from 'web3-core-helpers'
 import { createTransaction } from '../../../database/helpers/openDB'
 import { createWalletDBAccess } from '../database/Wallet.db'
 
-const MAX_UNCONFIRMED_REQUESTS_SIZE = 5
+const MAX_UNCONFIRMED_REQUESTS_SIZE = 1
 const MAIN_RECORD_ID = '0'
 
 function requestSorter(a: JsonRpcPayload, z: JsonRpcPayload) {


### PR DESCRIPTION
+ Use `chainId` to replace the `rpc` in overrides;
+ Need to confirm or reject each request by second time;


<!-- Please refer to the related issue number -->
closes #
