### PR TITLE
fix(Firefox): collectibles detail tab can't scrolll

### DIFF
--- a/packages/maskbook/src/plugins/Collectible/SNSAdaptor/CollectibleTab.tsx
+++ b/packages/maskbook/src/plugins/Collectible/SNSAdaptor/CollectibleTab.tsx
@@ -7,6 +7,7 @@ const useStyles = makeStyles()({
         width: '100%',
         height: '100%',
         borderRadius: 0,
+        overflow: 'scroll',
     },
 })
 


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #4255
