### PR TITLE
ci: lock prettier version at prettier job

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v2
-      - run: npx prettier --list-different .
+      - run: npx prettier@2.3.2 --list-different .
   locale-kit:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
prettier@latest or prettier@2.4.0 fails CI (see https://github.com/DimensionDev/Maskbook/pull/4288/checks?check_run_id=3554560830)