### PR TITLE
chore: add watchTwitterUserSettings

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -219,7 +219,8 @@
         "counterparty",
         "jailbroken",
         "misoperation",
-        "majeure"
+        "majeure",
+        "localforage"
     ],
     "ignoreWords": [
         "BSCT",
@@ -283,7 +284,11 @@
         "vitalik",
         "unlockprotocol",
         "unlocklock",
-        "chainid"
+        "chainid",
+        "keyvaluepairs",
+        "rweb",
+        "Checkin",
+        "settingschange"
     ],
     "ignoreRegExpList": ["/@servie/"],
     "ignorePaths": [

--- a/packages/injected-script/main/index.ts
+++ b/packages/injected-script/main/index.ts
@@ -1,5 +1,6 @@
 import './EventListenerPatch/index'
 import './locationChange'
+import './settingsChange'
 import './user-agent'
 
 if (document.currentScript) document.currentScript.remove()

--- a/packages/injected-script/main/intrinsic.ts
+++ b/packages/injected-script/main/intrinsic.ts
@@ -27,7 +27,7 @@ export function xray_Map() {
 //#endregion
 export const {
     Proxy: no_xray_Proxy,
-    Event: no_xray_Event,
+    CustomEvent: no_xray_Event,
     dispatchEvent,
     DataTransfer: no_xray_DataTransfer,
     ClipboardEvent: no_xray_ClipboardEvent,

--- a/packages/injected-script/main/settingsChange.ts
+++ b/packages/injected-script/main/settingsChange.ts
@@ -1,0 +1,86 @@
+import { apply, dispatchEvent, no_xray_Event } from './intrinsic'
+
+namespace TwitterSettings {
+    export interface TwitterUserSettingsLocal {
+        autoPollNewTweets: boolean
+        highContrastEnabled: boolean
+        loginPromptLastShown: number
+        nextPushCheckin: number
+        preciseLocationEnabled: boolean
+        reducedMotionEnabled: boolean
+        scale: 'xSmall' | 'small' | 'normal' | 'large' | 'xLarge'
+        shouldAutoPlayGif: boolean
+        showTweetMediaDetailDrawer: boolean
+        themeBackground: 'light' | 'dark' | 'darker'
+    }
+
+    export interface TwitterUserSettings {
+        local: TwitterUserSettingsLocal
+        _lastPersisted: number
+    }
+
+    const TWITTER_LOCALFORAGE_DB_VERSION = 2
+
+    export async function getTwitterUserSettings() {
+        return new Promise<TwitterUserSettings>((resolve, reject) => {
+            const open = indexedDB.open('localforage', TWITTER_LOCALFORAGE_DB_VERSION)
+
+            open.onsuccess = function () {
+                const db = open.result
+                const tx = db.transaction('keyvaluepairs', 'readwrite')
+                const store = tx.objectStore('keyvaluepairs')
+                const getSettings = store.get('device:rweb.settings')
+
+                getSettings.onsuccess = () => {
+                    resolve(getSettings.result)
+                }
+
+                getSettings.onerror = (error) => {
+                    reject(error)
+                }
+
+                tx.oncomplete = () => {
+                    db.close()
+                }
+            }
+            open.onerror = (error) => {
+                reject(error)
+            }
+        })
+    }
+
+    export function watchTwitterUserSettings() {
+        // the count of running tasks
+        let tasks = 0
+        const dispatchUserSettings = async () => {
+            tasks += 1
+            // a task is already emitted
+            if (tasks > 1) return
+            try {
+                const userSettings = await getTwitterUserSettings()
+                apply(dispatchEvent, window, [
+                    new no_xray_Event<TwitterUserSettings>('settingschange', {
+                        detail: userSettings,
+                    }),
+                ])
+            } catch {
+                // do nothing
+            } finally {
+                if (tasks > 1) return
+                tasks = 1
+                dispatchUserSettings()
+            }
+        }
+        dispatchUserSettings()
+        window.addEventListener('load', dispatchUserSettings)
+        window.addEventListener('locationchange', dispatchUserSettings)
+    }
+}
+
+function main() {
+    if (location.host.includes('twitter.com')) TwitterSettings.watchTwitterUserSettings()
+}
+
+main()
+
+export {}


### PR DESCRIPTION
## Background

I found that Twitter UI settings were stored in IndexedDB.

<img width="1089" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/52657989/132934981-ff9a695e-b891-4a1e-b220-fcf3770b496c.png">

## What's Next?

+ [x] To found out what kind of color schemas were used in various theme settings by Twitter.
+ [ ] Add a bunch of hooks for tracking theme colors derived from the theme settings.
+ [ ] Merge theme colors into MUI theme settings.

## Notes

+ [Twitter Color Schema](https://guanbinrui.github.io/twitter-color-schema/index.html)
+ [color_schema.json](https://github.com/guanbinrui/twitter-color-schema/blob/master/data/color_schema.json)
+ You can format [Main.js](https://abs.twimg.com/responsive-web/client-web-legacy/main.0d6a0415.js) to get more theme info from it.

Part of  #4320
