### PR TITLE
refactor: move to rpc apis

### DIFF
--- a/packages/maskbook/src/plugins/VCent/SNSAdaptor/TweetDialog.tsx
+++ b/packages/maskbook/src/plugins/VCent/SNSAdaptor/TweetDialog.tsx
@@ -1,11 +1,12 @@
+import { first } from 'lodash-es'
 import { Button } from '@material-ui/core'
 import { makeStyles } from '@masknet/theme'
 import { isDarkTheme } from '../../../utils/theme-tools'
-import * as TweetAPI from '../apis/index'
 import { ETHIcon } from '../icons/ETH'
 import { VCentIconLight, VCentIconDark } from '../icons/VCent'
 import { VALUABLES_VCENT_URL } from '../constants'
 import { useAsync } from 'react-use'
+import { PluginVCentRPC } from '../messages'
 
 const useStyle = makeStyles()((theme) => ({
     root: {
@@ -73,8 +74,8 @@ const useStyle = makeStyles()((theme) => ({
 
 export default function VCentDialog({ tweetAddress }: { tweetAddress: string }) {
     const { classes } = useStyle()
-    const tweet: TweetAPI.TweetData | undefined = useAsync(() => TweetAPI.getTweetData(tweetAddress), [tweetAddress])
-        .value?.[0]
+    const { value: tweets } = useAsync(() => PluginVCentRPC.getTweetData(tweetAddress), [tweetAddress])
+    const tweet = first(tweets)
 
     // only offer tweets
     if (tweet?.type !== 'Offer') return null
@@ -88,7 +89,7 @@ export default function VCentDialog({ tweetAddress }: { tweetAddress: string }) 
                 style={isDarkTheme() ? { backgroundColor: '#1a2735' } : { backgroundColor: '#f3f3f3' }}>
                 <div className={classes.VCent}>{isDarkTheme() ? <VCentIconDark /> : <VCentIconLight />}</div>
                 <div className={classes.bidInfo}>
-                    <div className={classes.text}> LATEST OFFER at</div>
+                    <div className={classes.text}>LATEST OFFER at</div>
                     <div className={classes.textUSD}> ${tweet.amount_usd}</div>
                     <div className={classes.textETH}>
                         (<ETHIcon />

--- a/packages/maskbook/src/plugins/VCent/SNSAdaptor/index.tsx
+++ b/packages/maskbook/src/plugins/VCent/SNSAdaptor/index.tsx
@@ -6,7 +6,6 @@ import { base } from '../base'
 const sns: Plugin.SNSAdaptor.Definition = {
     ...base,
     init(signal) {},
-    DecryptedInspector: Component,
     PostInspector: Component,
 }
 
@@ -14,8 +13,10 @@ export default sns
 
 function Component() {
     const tweetAddress = usePostInfoDetails.postID()
+
     if (!tweetAddress) return null
-    // only for detailed page
-    if (!/\/status\/\d+$/.test(location.pathname)) return null
+    // only for the primary tweet on the detailed page
+    if (!location.pathname.includes(`/status/${tweetAddress}`)) return null
+
     return <VCentDialog tweetAddress={tweetAddress} />
 }

--- a/packages/maskbook/src/plugins/VCent/Worker/index.ts
+++ b/packages/maskbook/src/plugins/VCent/Worker/index.ts
@@ -1,0 +1,9 @@
+import type { Plugin } from '@masknet/plugin-infra'
+import { base } from '../base'
+import '../messages'
+
+const worker: Plugin.Worker.Definition = {
+    ...base,
+    init(signal) {},
+}
+export default worker

--- a/packages/maskbook/src/plugins/VCent/index.ts
+++ b/packages/maskbook/src/plugins/VCent/index.ts
@@ -3,6 +3,11 @@ import { base } from './base'
 
 registerPlugin({
     ...base,
+    Worker: {
+        load: () => import('./Worker'),
+        hotModuleReload: (hot) =>
+            import.meta.webpackHot && import.meta.webpackHot.accept('./SNSAdaptor', () => hot(import('./SNSAdaptor'))),
+    },
     SNSAdaptor: {
         load: () => import('./SNSAdaptor'),
         hotModuleReload: (hot) =>

--- a/packages/maskbook/src/plugins/VCent/messages.ts
+++ b/packages/maskbook/src/plugins/VCent/messages.ts
@@ -1,0 +1,9 @@
+import { createPluginMessage, PluginMessageEmitter, createPluginRPC } from '@masknet/plugin-infra'
+import { PLUGIN_IDENTIFIER } from './constants'
+
+interface VCentMessages {
+    rpc: unknown
+}
+
+export const PluginVCentMessages: PluginMessageEmitter<VCentMessages> = createPluginMessage(PLUGIN_IDENTIFIER)
+export const PluginVCentRPC = createPluginRPC(PLUGIN_IDENTIFIER, () => import('./services'), PluginVCentMessages.rpc)

--- a/packages/maskbook/src/plugins/VCent/services.ts
+++ b/packages/maskbook/src/plugins/VCent/services.ts
@@ -1,0 +1,1 @@
+export * from './apis'


### PR DESCRIPTION
+ [x] Only fetch data of the primary tweet on the detailed page.
+ [x] Move requests to the background.
+ [x] Reduce duplicate requests.

closes #4420
