### PR TITLE
fix: show nft airdrop

### DIFF
--- a/packages/maskbook/src/plugins/ITO/SNSAdaptor/ClaimAllDialog.tsx
+++ b/packages/maskbook/src/plugins/ITO/SNSAdaptor/ClaimAllDialog.tsx
@@ -372,9 +372,7 @@ export function ClaimAllDialog(props: ClaimAllDialogProps) {
                         <AbstractTab {...tabProps} />
                     </div>
                     <div className={classes.contentWrapper} ref={DialogRef}>
-                        {(showNftAirdrop || loadingAirdrop) &&
-                        currentChainId === ChainId.Matic &&
-                        chainId === ChainId.Matic ? (
+                        {(showNftAirdrop || loadingAirdrop) && chainId === ChainId.Matic ? (
                             <NftAirdropCard
                                 campaignInfos={campaignInfos!}
                                 loading={loadingAirdrop}


### PR DESCRIPTION
Show nft airdrop card on all networks, the Claim button is disabled when not on Matic.