### PR TITLE
chore: close poll plugin by default close #4400

### DIFF
--- a/packages/maskbook/src/plugins/Polls/base.ts
+++ b/packages/maskbook/src/plugins/Polls/base.ts
@@ -10,7 +10,7 @@ export const base: Plugin.Shared.Definition = {
     enableRequirement: {
         architecture: { app: true, web: true },
         networks: { type: 'opt-out', networks: {} },
-        target: 'stable',
+        target: 'insider',
     },
     experimentalMark: true,
 }


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #
