### PR TITLE
refactor: merge contexts into one

### DIFF
--- a/packages/dashboard/src/API.tsx
+++ b/packages/dashboard/src/API.tsx
@@ -4,11 +4,11 @@
 
 import type { DashboardPluginMessages, DashboardPluginServices } from '@masknet/shared'
 import type { Services as ServiceType } from '../../maskbook/dist/extension/service'
-import type { MaskMessage } from '../../maskbook/dist/utils/messages'
+import type { MaskMessages } from '../../maskbook/dist/utils/messages'
 import type { WalletMessages } from '@masknet/plugin-wallet'
 
 export let Services: typeof ServiceType = null!
-export let Messages: typeof MaskMessage = null!
+export let Messages: typeof MaskMessages = null!
 export let PluginServices: PluginServices = null!
 export let PluginMessages: PluginMessages = null!
 export interface PluginServices extends DashboardPluginServices {

--- a/packages/dashboard/src/web3/context.ts
+++ b/packages/dashboard/src/web3/context.ts
@@ -1,74 +1,14 @@
-import { omit, noop } from 'lodash-es'
-import type { Subscription } from 'use-subscription'
-import { ChainId, PortfolioProvider, ProviderType } from '@masknet/web3-shared'
-import { ERC20TokenDetailed, EthereumTokenType, NetworkType, Web3ProviderType } from '@masknet/web3-shared'
+import { createWeb3Context } from '@masknet/web3-shared'
 import { Messages, PluginMessages, PluginServices, Services } from '../API'
 
-const Web3Provider = createExternalProvider()
+export const Web3Provider = createExternalProvider()
 
-export const Web3Context: Web3ProviderType = {
-    provider: {
-        getCurrentValue: () => Web3Provider,
-        subscribe: () => noop,
-    },
-    allowTestnet: createSubscriptionFromAsync(Services.Settings.getWalletAllowTestChain, false, () => {
-        return () => {}
-    }),
-    account: createSubscriptionFromAsync(
-        Services.Settings.getSelectedWalletAddress,
-        '',
-        Messages.events.currentAccountSettings.on,
-    ),
-    tokenPrices: createSubscriptionFromAsync(
-        Services.Settings.getTokenPrices,
-        {},
-        Messages.events.currentTokenPricesSettings.on,
-    ),
-    balance: createSubscriptionFromAsync(Services.Settings.getBalance, '0', Messages.events.currentBalanceSettings.on),
-    blockNumber: createSubscriptionFromAsync(
-        Services.Settings.getBlockNumber,
-        0,
-        Messages.events.currentBlockNumberSettings.on,
-    ),
-    chainId: createSubscriptionFromAsync(
-        Services.Settings.getChainId,
-        ChainId.Mainnet,
-        Messages.events.currentChainIdSettings.on,
-    ),
-    providerType: createSubscriptionFromAsync(
-        Services.Settings.getCurrentSelectedWalletProvider,
-        ProviderType.MaskWallet,
-        Messages.events.currentProviderSettings.on,
-    ),
-    networkType: createSubscriptionFromAsync(
-        Services.Settings.getCurrentSelectedWalletNetwork,
-        NetworkType.Ethereum,
-        Messages.events.currentNetworkSettings.on,
-    ),
-    walletPrimary: createSubscriptionFromAsync(getWalletPrimary, null, PluginMessages.Wallet.events.walletsUpdated.on),
-    wallets: createSubscriptionFromAsync(getWallets, [], PluginMessages.Wallet.events.walletsUpdated.on),
-    erc20Tokens: createSubscriptionFromAsync(getERC20Tokens, [], PluginMessages.Wallet.events.erc20TokensUpdated.on),
-    addERC20Token: PluginServices.Wallet.addERC20Token,
-    trustERC20Token: PluginServices.Wallet.trustERC20Token,
-    erc20TokensCount: createSubscriptionFromAsync(
-        PluginServices.Wallet.getERC20TokensCount,
-        0,
-        PluginMessages.Wallet.events.erc20TokensUpdated.on,
-    ),
-    getERC20TokensPaged,
-    portfolioProvider: createSubscriptionFromAsync(
-        Services.Settings.getCurrentPortfolioDataProvider,
-        PortfolioProvider.DEBANK,
-        Messages.events.currentPortfolioDataProviderSettings.on,
-    ),
-    getAssetsList: PluginServices.Wallet.getAssetsList,
-    getAssetsListNFT: PluginServices.Wallet.getAssetsListNFT,
-    getAddressNamesList: PluginServices.Wallet.getAddressNames,
-    getERC721TokensPaged,
-    getTransactionList: PluginServices.Wallet.getTransactionList,
-    fetchERC20TokensFromTokenLists: Services.Ethereum.fetchERC20TokensFromTokenLists,
-    createMnemonicWords: PluginServices.Wallet.createMnemonicWords,
-}
+export const Web3Context = createWeb3Context(Web3Provider, {
+    MaskMessages: Messages,
+    MaskServices: Services,
+    PluginMessages,
+    PluginServices,
+})
 
 export function createExternalProvider() {
     return {
@@ -80,96 +20,4 @@ export function createExternalProvider() {
         send: Services.Ethereum.requestSend,
         sendAsync: Services.Ethereum.requestSend,
     }
-}
-
-async function getWallets() {
-    const wallets = await PluginServices.Wallet.getWallets()
-    return wallets.map((x) => ({
-        ...omit(x, 'derivationPath', 'storedKeyInfo'),
-        hasStoredKeyInfo: !!x.storedKeyInfo,
-        hasDerivationPath: !!x.derivationPath,
-    }))
-}
-
-export async function getWalletPrimary() {
-    const wallet = await PluginServices.Wallet.getWalletPrimary()
-    if (!wallet) return null
-    return {
-        ...omit(wallet, 'derivationPath', 'storedKeyInfo'),
-        hasStoredKeyInfo: !!wallet.storedKeyInfo,
-        hasDerivationPath: !!wallet.derivationPath,
-    }
-}
-
-async function getERC20Tokens() {
-    const raw = await PluginServices.Wallet.getERC20Tokens()
-    return raw.map<ERC20TokenDetailed>((x) => ({
-        type: EthereumTokenType.ERC20,
-        ...x,
-    }))
-}
-
-async function getERC20TokensPaged(index: number, count: number, query?: string) {
-    const raw = await PluginServices.Wallet.getERC20TokensPaged(index, count, query)
-    return raw.map<ERC20TokenDetailed>((x) => ({
-        type: EthereumTokenType.ERC20,
-        ...x,
-    }))
-}
-
-async function getERC721TokensPaged(index: number, count: number, query?: string) {
-    return PluginServices.Wallet.getERC721TokensPaged(index, count, query)
-}
-
-// double check
-function createSubscriptionFromAsync<T>(
-    f: () => Promise<T>,
-    defaultValue: T,
-    onChange: (callback: () => void) => () => void,
-): Subscription<T> {
-    // 0 - idle, 1 - updating state, > 1 - waiting state
-    let beats = 0
-    let state = defaultValue
-    const { subscribe, trigger } = getEventTarget()
-    f()
-        .then((v) => (state = v))
-        .finally(trigger)
-    const flush = async () => {
-        state = await f()
-        beats -= 1
-        if (beats > 0) {
-            beats = 1
-            setTimeout(flush, 0)
-        } else if (beats < 0) {
-            beats = 0
-        }
-        trigger()
-    }
-    return {
-        getCurrentValue: () => state,
-        subscribe: (sub) => {
-            const a = subscribe(sub)
-            const b = onChange(async () => {
-                beats += 1
-                if (beats === 1) flush()
-            })
-            return () => void [a(), b()]
-        },
-    }
-}
-
-function getEventTarget() {
-    const event = new EventTarget()
-    const EVENT = 'event'
-    let timer: NodeJS.Timeout
-    function trigger() {
-        clearTimeout(timer)
-        // delay to update state to ensure that all settings to be synced globally
-        timer = setTimeout(() => event.dispatchEvent(new Event(EVENT)), 600)
-    }
-    function subscribe(f: () => void) {
-        event.addEventListener(EVENT, f)
-        return () => event.removeEventListener(EVENT, f)
-    }
-    return { trigger, subscribe }
 }

--- a/packages/dashboard/src/web3/context.ts
+++ b/packages/dashboard/src/web3/context.ts
@@ -68,7 +68,6 @@ export const Web3Context: Web3ProviderType = {
     getTransactionList: PluginServices.Wallet.getTransactionList,
     fetchERC20TokensFromTokenLists: Services.Ethereum.fetchERC20TokensFromTokenLists,
     createMnemonicWords: PluginServices.Wallet.createMnemonicWords,
-    getNonce: Services.Ethereum.getNonce,
 }
 
 export function createExternalProvider() {

--- a/packages/maskbook/src/components/CompositionDialog/Composition.tsx
+++ b/packages/maskbook/src/components/CompositionDialog/Composition.tsx
@@ -2,7 +2,7 @@ import { DialogContent } from '@material-ui/core'
 import { useRef } from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { activatedSocialNetworkUI, globalUIState } from '../../social-network'
-import { MaskMessage, useI18N } from '../../utils'
+import { MaskMessages, useI18N } from '../../utils'
 import { useFriendsList as useRecipientsList } from '../DataSource/useActivatedUI'
 import { InjectedDialog } from '../shared/InjectedDialog'
 import { CompositionDialogUI, CompositionRef } from './CompositionUI'
@@ -24,7 +24,7 @@ export function Composition({ type = 'timeline', requireClipboardPermission }: P
         UI.current?.reset()
     }, [])
     useEffect(() => {
-        return MaskMessage.events.requestComposition.on(({ reason, open, content, options }) => {
+        return MaskMessages.events.requestComposition.on(({ reason, open, content, options }) => {
             if (reason !== type || globalUIState.profiles.value.length <= 0) return
             setOpen(open)
             if (content) UI.current?.setMessage(content)
@@ -41,7 +41,7 @@ export function Composition({ type = 'timeline', requireClipboardPermission }: P
     }, [type])
     useEffect(() => {
         if (!open) return
-        return MaskMessage.events.replaceComposition.on((message) => {
+        return MaskMessages.events.replaceComposition.on((message) => {
             const ui = UI.current
             if (!ui) return
             UI.current.setMessage(message)

--- a/packages/maskbook/src/components/DataSource/useMyPersonas.ts
+++ b/packages/maskbook/src/components/DataSource/useMyPersonas.ts
@@ -2,7 +2,7 @@ import { ValueRef } from '@dimensiondev/holoflows-kit'
 import { useValueRef } from '@masknet/shared'
 import Services from '../../extension/service'
 import { PersonaArrayComparer } from '../../utils/comparer'
-import { MaskMessage } from '../../utils/messages'
+import { MaskMessages } from '../../utils/messages'
 import type { Persona } from '../../database'
 import { debounce } from 'lodash-es'
 
@@ -29,7 +29,7 @@ const independentRef = {
     const debounceQuery = debounce(query, 500, { trailing: true })
 
     isLoading = query()
-    MaskMessage.events.ownPersonaChanged.on(debounceQuery)
+    MaskMessages.events.ownPersonaChanged.on(debounceQuery)
 }
 
 export function useMyPersonas() {

--- a/packages/maskbook/src/components/InjectedComponents/EnhancedProfile.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/EnhancedProfile.tsx
@@ -6,7 +6,7 @@ import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined'
 import { useState, useEffect } from 'react'
 import { CollectibleListAddress } from '../../extension/options-page/DashboardComponents/CollectibleList'
 import { useEthereumAddress } from '../../social-network-adaptor/twitter.com/injection/useEthereumName'
-import { MaskMessage, useI18N } from '../../utils'
+import { MaskMessages, useI18N } from '../../utils'
 import { useLocationChange } from '../../utils/hooks/useLocationChange'
 
 const RULE_TIP = [
@@ -49,11 +49,11 @@ export function EnhancedProfilePage(props: EnhancedProfilePageProps) {
     const { t } = useI18N()
 
     useLocationChange(() => {
-        MaskMessage.events.profileNFTsTabUpdated.sendToLocal('reset')
+        MaskMessages.events.profileNFTsTabUpdated.sendToLocal('reset')
     })
 
     useEffect(() => {
-        return MaskMessage.events.profileNFTsPageUpdated.on((data) => {
+        return MaskMessages.events.profileNFTsPageUpdated.on((data) => {
             setShow(data.show)
         })
     }, [])

--- a/packages/maskbook/src/components/InjectedComponents/EnhancedProfileTab.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/EnhancedProfileTab.tsx
@@ -2,7 +2,7 @@ import { Typography } from '@material-ui/core'
 import classnames from 'classnames'
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 
-import { MaskMessage } from '../../utils'
+import { MaskMessages } from '../../utils'
 
 export interface EnhancedProfileTabProps extends withClasses<'tab' | 'button' | 'selected'> {
     clear(): void
@@ -18,16 +18,16 @@ export function EnhancedProfileTab(props: EnhancedProfileTabProps) {
 
     const onClose = () => {
         setActive(false)
-        MaskMessage.events.profileNFTsPageUpdated.sendToLocal({ show: false })
+        MaskMessages.events.profileNFTsPageUpdated.sendToLocal({ show: false })
         reset()
     }
     const onOpen = () => {
-        MaskMessage.events.profileNFTsPageUpdated.sendToLocal({ show: true })
+        MaskMessages.events.profileNFTsPageUpdated.sendToLocal({ show: true })
         setActive(true)
     }
 
     useEffect(() => {
-        return MaskMessage.events.profileNFTsTabUpdated.on(onClose)
+        return MaskMessages.events.profileNFTsTabUpdated.on(onClose)
     }, [])
 
     const onClick = useCallback(() => {

--- a/packages/maskbook/src/components/InjectedComponents/PageInspector.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/PageInspector.tsx
@@ -4,7 +4,7 @@ import Button from '@material-ui/core/Button'
 import Close from '@material-ui/icons/Close'
 import IconButton from '@material-ui/core/IconButton'
 import { createInjectHooksRenderer, useActivatedPluginsSNSAdaptor } from '@masknet/plugin-infra'
-import { useMatchXS, MaskMessage, useI18N } from '../../utils'
+import { useMatchXS, MaskMessages, useI18N } from '../../utils'
 import { useAutoPasteFailedDialog } from './AutoPasteFailedDialog'
 
 const PluginRender = createInjectHooksRenderer(useActivatedPluginsSNSAdaptor, (x) => x.GlobalInjection)
@@ -16,7 +16,7 @@ export function PageInspector(props: PageInspectorProps) {
     const xsMatched = useMatchXS()
     useEffect(
         () =>
-            MaskMessage.events.autoPasteFailed.on((data) => {
+            MaskMessages.events.autoPasteFailed.on((data) => {
                 const key = data.image ? Math.random() : data.text
                 const close = () => closeSnackbar(key)
                 const timeout = setTimeout(() => {

--- a/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/SetupGuide.tsx
@@ -23,7 +23,7 @@ import stringify from 'json-stable-stringify'
 import ActionButton, { ActionButtonPromise } from '../../extension/options-page/DashboardComponents/ActionButton'
 import { noop } from 'lodash-es'
 import { useValueRef } from '@masknet/shared'
-import { useI18N, MaskMessage, useMatchXS, extendsTheme } from '../../utils'
+import { useI18N, MaskMessages, useMatchXS, extendsTheme } from '../../utils'
 import { activatedSocialNetworkUI } from '../../social-network'
 import { currentSetupGuideStatus } from '../../settings/settings'
 import type { SetupGuideCrossContextStatus } from '../../settings/types'
@@ -611,7 +611,7 @@ function SetupGuideUI(props: SetupGuideUIProps) {
         )
         if (!persona_.hasPrivateKey) throw new Error('invalid persona')
         await Services.Identity.setupPersona(persona_.identifier)
-        MaskMessage.events.ownPersonaChanged.sendToAll(undefined)
+        MaskMessages.events.ownPersonaChanged.sendToAll(undefined)
     }
     const onCreate = async () => {
         const content = t('setup_guide_say_hello_content')

--- a/packages/maskbook/src/components/InjectedComponents/ToolboxHint.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/ToolboxHint.tsx
@@ -20,7 +20,7 @@ import { ToolIconURLs } from '../../resources/tool-icon'
 import { Image } from '../shared/Image'
 import { useMenu } from '../../utils/hooks/useMenu'
 import { forwardRef, useRef, useCallback } from 'react'
-import { MaskMessage } from '../../utils/messages'
+import { MaskMessages } from '../../utils/messages'
 import { PLUGIN_ID as TransakPluginID } from '../../plugins/Transak/constants'
 import { PLUGIN_IDENTIFIER as TraderPluginID } from '../../plugins/Trader/constants'
 import { useControlledDialog } from '../../utils/hooks/useControlledDialog'
@@ -153,7 +153,7 @@ export function ToolboxHint(props: ToolboxHintProps) {
     //#region Encrypted message
     const openEncryptedMessage = useCallback(
         (id?: string) =>
-            MaskMessage.events.requestComposition.sendToLocal({
+            MaskMessages.events.requestComposition.sendToLocal({
                 reason: 'timeline',
                 open: true,
                 options: {

--- a/packages/maskbook/src/database/Persona/Persona.db.ts
+++ b/packages/maskbook/src/database/Persona/Persona.db.ts
@@ -4,7 +4,7 @@ import { ECKeyIdentifier, Identifier, PersonaIdentifier, ProfileIdentifier } fro
 import { DBSchema, openDB } from 'idb/with-async-ittr-cjs'
 import { IdentifierMap } from '../IdentifierMap'
 import { PrototypeLess, restorePrototype } from '../../utils/type'
-import { MaskMessage } from '../../utils/messages'
+import { MaskMessages } from '../../utils/messages'
 import { createDBAccessWithAsyncUpgrade, createTransaction, IDBPSafeTransaction } from '../helpers/openDB'
 import { assertPersonaDBConsistency } from './consistency'
 import type {
@@ -136,9 +136,9 @@ export async function consistentPersonaDBWriteAccess(
     t.addEventListener('error', finish)
 
     // Pause those events when patching write access
-    const resumeProfile = MaskMessage.events.profilesChanged.pause()
-    const resumePersona = MaskMessage.events.ownPersonaChanged.pause()
-    const resumeRelation = MaskMessage.events.relationsChanged.pause()
+    const resumeProfile = MaskMessages.events.profilesChanged.pause()
+    const resumePersona = MaskMessages.events.ownPersonaChanged.pause()
+    const resumeRelation = MaskMessages.events.relationsChanged.pause()
     try {
         await action(t)
     } finally {
@@ -166,7 +166,7 @@ export async function consistentPersonaDBWriteAccess(
 /** Create a new Persona. */
 export async function createPersonaDB(record: PersonaRecord, t: PersonasTransaction<'readwrite'>): Promise<void> {
     await t.objectStore('personas').add(personaRecordToDB(record))
-    record.privateKey && MaskMessage.events.ownPersonaChanged.sendToAll(undefined)
+    record.privateKey && MaskMessages.events.ownPersonaChanged.sendToAll(undefined)
 }
 
 export async function queryPersonaByProfileDB(
@@ -268,7 +268,7 @@ export async function updatePersonaDB(
         updatedAt: nextRecord.updatedAt ?? new Date(),
     })
     await t.objectStore('personas').put(next)
-    ;(next.privateKey || old.privateKey) && MaskMessage.events.ownPersonaChanged.sendToAll(undefined)
+    ;(next.privateKey || old.privateKey) && MaskMessages.events.ownPersonaChanged.sendToAll(undefined)
 }
 
 export async function createOrUpdatePersonaDB(
@@ -302,7 +302,7 @@ export async function deletePersonaDB(
     if (confirm !== 'delete even with private' && r.privateKey)
         throw new TypeError('Cannot delete a persona with a private key')
     await t.objectStore('personas').delete(id.toText())
-    r.privateKey && MaskMessage.events.ownPersonaChanged.sendToAll()
+    r.privateKey && MaskMessages.events.ownPersonaChanged.sendToAll()
 }
 /**
  * Delete a Persona
@@ -326,7 +326,7 @@ export async function safeDeletePersonaDB(
  */
 export async function createProfileDB(record: ProfileRecord, t: ProfileTransaction<'readwrite'>): Promise<void> {
     await t.objectStore('profiles').add(profileToDB(record))
-    MaskMessage.events.profilesChanged.sendToAll([{ of: record.identifier, reason: 'update' }])
+    MaskMessages.events.profilesChanged.sendToAll([{ of: record.identifier, reason: 'update' }])
 }
 
 /**
@@ -421,7 +421,7 @@ export async function updateProfileDB(
         ...updating,
     })
     await t.objectStore('profiles').put(nextRecord)
-    MaskMessage.events.profilesChanged.sendToAll([{ reason: 'update', of: updating.identifier }])
+    MaskMessages.events.profilesChanged.sendToAll([{ reason: 'update', of: updating.identifier }])
 }
 export async function createOrUpdateProfileDB(rec: ProfileRecord, t: ProfileTransaction<'readwrite'>) {
     if (await queryProfileDB(rec.identifier, t)) return updateProfileDB(rec, t)
@@ -447,7 +447,7 @@ export async function detachProfileDB(
 
     if (persona) {
         await updatePersonaDB(persona, { linkedProfiles: 'replace', explicitUndefinedField: 'delete field' }, t)
-        if (persona.privateKey) MaskMessage.events.ownPersonaChanged.sendToAll(undefined)
+        if (persona.privateKey) MaskMessages.events.ownPersonaChanged.sendToAll(undefined)
     }
     profile.linkedPersona = undefined
     await updateProfileDB(profile, t)
@@ -480,7 +480,7 @@ export async function attachProfileDB(
     await updatePersonaDB(persona, { linkedProfiles: 'merge', explicitUndefinedField: 'ignore' }, t)
     await updateProfileDB(profile, t)
 
-    if (persona.privateKey) MaskMessage.events.ownPersonaChanged.sendToAll(undefined)
+    if (persona.privateKey) MaskMessages.events.ownPersonaChanged.sendToAll(undefined)
 }
 
 /**
@@ -488,7 +488,7 @@ export async function attachProfileDB(
  */
 export async function deleteProfileDB(id: ProfileIdentifier, t: ProfileTransaction<'readwrite'>): Promise<void> {
     await t.objectStore('profiles').delete(id.toText())
-    MaskMessage.events.profilesChanged.sendToAll([{ reason: 'delete', of: id }])
+    MaskMessages.events.profilesChanged.sendToAll([{ reason: 'delete', of: id }])
 }
 
 /**
@@ -501,7 +501,7 @@ export async function createRelationDB(
 ): Promise<void> {
     await t.objectStore('relations').add(relationRecordToDB(record))
     if (sendEvent)
-        MaskMessage.events.relationsChanged.sendToAll([{ of: record.profile, reason: 'update', favor: record.favor }])
+        MaskMessages.events.relationsChanged.sendToAll([{ of: record.profile, reason: 'update', favor: record.favor }])
 }
 
 export async function queryRelations(query: (record: RelationRecord) => boolean, t?: RelationTransaction<'readonly'>) {
@@ -584,7 +584,7 @@ export async function updateRelationDB(
     })
 
     await t.objectStore('relations').put(nextRecord)
-    MaskMessage.events.relationsChanged.sendToAll([{ of: updating.profile, favor: updating.favor, reason: 'update' }])
+    MaskMessages.events.relationsChanged.sendToAll([{ of: updating.profile, favor: updating.favor, reason: 'update' }])
 }
 
 //#endregion

--- a/packages/maskbook/src/database/helpers/avatar.ts
+++ b/packages/maskbook/src/database/helpers/avatar.ts
@@ -1,7 +1,7 @@
 import { ProfileIdentifier } from '../type'
 import { queryAvatarDB, isAvatarOutdatedDB, storeAvatarDB, IdentityWithAvatar } from '../avatar'
 import { memoizePromise } from '../../utils/memoize'
-import { MaskMessage } from '../../utils/messages'
+import { MaskMessages } from '../../utils/messages'
 import { downloadUrl } from '../../utils/utils'
 import { blobToArrayBuffer, blobToDataURL } from '@dimensiondev/kit'
 
@@ -46,7 +46,7 @@ export async function storeAvatar(
     } finally {
         queryAvatarDataURL.cache.delete(identifier.toText())
         if (identifier instanceof ProfileIdentifier) {
-            MaskMessage.events.profilesChanged.sendToAll([{ of: identifier, reason: 'update' }])
+            MaskMessages.events.profilesChanged.sendToAll([{ of: identifier, reason: 'update' }])
         }
     }
 }

--- a/packages/maskbook/src/extension/background-script/CryptoServices/decryptFrom.ts
+++ b/packages/maskbook/src/extension/background-script/CryptoServices/decryptFrom.ts
@@ -20,7 +20,7 @@ import { decodeImageUrl } from '../SteganographyService'
 import type { TypedMessage } from '../../../protocols/typed-message'
 import stringify from 'json-stable-stringify'
 import type { SharedAESKeyGun2 } from '../../../network/gun/version.2'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { GunAPI } from '../../../network/gun'
 import { Err, Ok, Result } from 'ts-results'
 import { decodeTextPayloadWorker } from '../../../social-network/utils/text-payload-worker'
@@ -368,7 +368,7 @@ async function* findAuthorPublicKey(
                     undo()
                     reject()
                 })
-                const undo = MaskMessage.events.profilesChanged.on((data) => {
+                const undo = MaskMessages.events.profilesChanged.on((data) => {
                     for (const x of data) {
                         if (x.reason === 'delete') continue
                         if (x.of.equals(by)) {

--- a/packages/maskbook/src/extension/background-script/IdentityService.ts
+++ b/packages/maskbook/src/extension/background-script/IdentityService.ts
@@ -45,7 +45,7 @@ import { decompressBackupFile } from '../../utils/type-transform/BackupFileShort
 import { assertEnvironment, Environment } from '@dimensiondev/holoflows-kit'
 import type { EC_JsonWebKey, EC_Private_JsonWebKey, PersonaInformation, ProfileInformation } from '@masknet/shared'
 import { getCurrentPersonaIdentifier } from './SettingsService'
-import { MaskMessage } from '../../utils'
+import { MaskMessages } from '../../utils'
 import type { PostIVIdentifier } from '@masknet/shared-base'
 import { split_ec_k256_keypair_into_pub_priv } from '../../modules/CryptoAlgorithm/helper'
 import { first, orderBy } from 'lodash-es'
@@ -314,7 +314,7 @@ export const updateCurrentPersonaAvatar = async (avatar: Blob) => {
 
     if (identifier) {
         await storeAvatar(identifier, await blobToArrayBuffer(avatar))
-        MaskMessage.events.ownPersonaChanged.sendToAll(undefined)
+        MaskMessages.events.ownPersonaChanged.sendToAll(undefined)
     }
 }
 

--- a/packages/maskbook/src/extension/background-script/IdentityServices/sign.ts
+++ b/packages/maskbook/src/extension/background-script/IdentityServices/sign.ts
@@ -8,7 +8,7 @@ import {
     publicToAddress,
     ECDSASignature,
 } from 'ethereumjs-util'
-import { MaskMessage } from '../../../utils'
+import { MaskMessages } from '../../../utils'
 import { Convert } from 'pvtsutils'
 import { stringToBuffer } from 'arweave/web/lib/utils'
 import { constructSignRequestURL } from '../../popups'
@@ -49,7 +49,7 @@ export async function signWithPersona({ message, method }: SignRequest): Promise
         browser.tabs.onRemoved.addListener(listener)
         // reject this request after 3 mins
         delay(1000 * 60 * 3).then(() => reject(new Error('Timeout')))
-        const removeListener = MaskMessage.events.signRequestApproved.on((approval) => {
+        const removeListener = MaskMessages.events.signRequestApproved.on((approval) => {
             if (approval.requestID !== requestID) return
             resolve(approval.selectedPersona)
         })

--- a/packages/maskbook/src/extension/background-script/Jobs/InjectContentScripts.ts
+++ b/packages/maskbook/src/extension/background-script/Jobs/InjectContentScripts.ts
@@ -1,5 +1,5 @@
 import { noop } from 'lodash-es'
-import { MaskMessage } from '../../../utils'
+import { MaskMessages } from '../../../utils'
 import { Flags } from '../../../utils/flags'
 
 type Args = browser.webNavigation.TransitionNavListener extends browser.webNavigation.NavListener<infer U> ? U : never
@@ -52,7 +52,7 @@ export default function (signal: AbortSignal) {
     if (process.env.NODE_ENV === 'development' && Flags.mask_SDK_ready) {
         signal.addEventListener(
             'abort',
-            MaskMessage.events.maskSDKHotModuleReload.on(async () => {
+            MaskMessages.events.maskSDKHotModuleReload.on(async () => {
                 const code = (await fetchUserScript(maskSDK_URL)) + `\n;console.log("[@masknet/sdk] SDK reloaded.")`
                 for (const tab of await browser.tabs.query({})) {
                     browser.tabs.executeScript(tab.id!, { code }).then(noop)

--- a/packages/maskbook/src/extension/background-script/Jobs/SettingListeners.ts
+++ b/packages/maskbook/src/extension/background-script/Jobs/SettingListeners.ts
@@ -1,6 +1,6 @@
 import { Environment, isEnvironment } from '@dimensiondev/holoflows-kit'
 import { SettingsEventName, ToBeListened } from '../../../settings/listener'
-import { MaskMessage } from '../../../utils'
+import { MaskMessages } from '../../../utils'
 
 export default function (signal: AbortSignal) {
     if (!isEnvironment(Environment.ManifestBackground)) return
@@ -9,7 +9,7 @@ export default function (signal: AbortSignal) {
         const key = _key as keyof SettingsEventName
         signal.addEventListener(
             'abort',
-            obj[key].addListener((data: any) => MaskMessage.events[key].sendToAll(data as never)),
+            obj[key].addListener((data: any) => MaskMessages.events[key].sendToAll(data as never)),
         )
     }
 }

--- a/packages/maskbook/src/extension/dashboard/index.tsx
+++ b/packages/maskbook/src/extension/dashboard/index.tsx
@@ -4,7 +4,7 @@ import Services from '../service'
 import { WalletRPC, WalletMessages } from '../../plugins/Wallet/messages'
 import { PluginTransakMessages } from '../../plugins/Transak/messages'
 import { PluginTraderMessages, PluginTraderRPC } from '../../plugins/Trader/messages'
-import { MaskMessage } from '../../utils/messages'
+import { MaskMessages } from '../../utils/messages'
 import { startPluginDashboard } from '@masknet/plugin-infra'
 import { createPluginHost } from '../../plugin-infra/host'
 import type { DashboardPluginMessages, DashboardPluginServices } from '@masknet/shared'
@@ -22,7 +22,7 @@ const rpc: DashboardPluginServices = {
 // @ts-ignore To avoid build failure due to the circular project reference
 setService(Services)
 // @ts-ignore
-setMessages(MaskMessage)
+setMessages(MaskMessages)
 // @ts-ignore
 setPluginServices(rpc)
 // @ts-ignore

--- a/packages/maskbook/src/extension/mask-sdk/hmr-sdk.ts
+++ b/packages/maskbook/src/extension/mask-sdk/hmr-sdk.ts
@@ -1,10 +1,10 @@
-import { MaskMessage, startEffect } from '../../utils'
+import { MaskMessages, startEffect } from '../../utils'
 
 startEffect(import.meta.webpackHot, (signal) => {
     if (process.env.NODE_ENV === 'development') {
         document.addEventListener(
             'mask-sdk-reload',
-            () => MaskMessage.events.maskSDKHotModuleReload.sendToBackgroundPage(undefined),
+            () => MaskMessages.events.maskSDKHotModuleReload.sendToBackgroundPage(undefined),
             { signal },
         )
     }

--- a/packages/maskbook/src/extension/popups/SignRequest/index.tsx
+++ b/packages/maskbook/src/extension/popups/SignRequest/index.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react'
 import { useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useMyPersonas } from '../../../components/DataSource/useMyPersonas'
-import { MaskMessage } from '../../../utils'
+import { MaskMessages } from '../../../utils'
 import { MissingParameter } from '../MissingParameter'
 import type { SignRequest } from './utils'
 
@@ -38,7 +38,7 @@ function SignRequestHandler(props: SignRequest) {
         setSelected(personas[0].identifier.toText())
     }, [selected, personas])
     const onSign = () => {
-        MaskMessage.events.signRequestApproved.sendToBackgroundPage({
+        MaskMessages.events.signRequestApproved.sendToBackgroundPage({
             requestID: props.requestID,
             selectedPersona: Identifier.fromString<ECKeyIdentifier>(selected, ECKeyIdentifier).unwrap(),
         })

--- a/packages/maskbook/src/extension/popups/pages/Personas/hooks/usePersonaContext.ts
+++ b/packages/maskbook/src/extension/popups/pages/Personas/hooks/usePersonaContext.ts
@@ -5,7 +5,7 @@ import { useAsyncRetry } from 'react-use'
 import Services from '../../../../service'
 import { head } from 'lodash-es'
 import { useEffect, useState } from 'react'
-import { MaskMessage } from '../../../../../utils'
+import { MaskMessages } from '../../../../../utils'
 
 function usePersonaContext() {
     const [deletingPersona, setDeletingPersona] = useState<PersonaInformation>()
@@ -13,7 +13,7 @@ function usePersonaContext() {
     const currentIdentifier = useValueRef(currentPersonaIdentifier)
     const { value: personas, retry } = useAsyncRetry(async () => Services.Identity.queryOwnedPersonaInformation())
     useEffect(() => {
-        return MaskMessage.events.ownPersonaChanged.on(retry)
+        return MaskMessages.events.ownPersonaChanged.on(retry)
     }, [retry])
 
     const currentPersona = personas?.find((x) =>

--- a/packages/maskbook/src/plugin-infra/host.ts
+++ b/packages/maskbook/src/plugin-infra/host.ts
@@ -6,7 +6,7 @@ import { Emitter } from '@servie/events'
 import { currentPluginEnabledStatus } from '../settings/settings'
 import { isEnvironment, Environment } from '@dimensiondev/holoflows-kit'
 // Do not export from '../utils/' to prevent initialization failure
-import { MaskMessage } from '../utils/messages'
+import { MaskMessages } from '../utils/messages'
 import i18nNextInstance from '../utils/i18n-next'
 import { createI18NBundle } from '@masknet/shared'
 
@@ -23,8 +23,8 @@ export function createPluginHost(signal?: AbortSignal): Plugin.__Host.Host {
                 // TODO: move it elsewhere.
                 if (isEnvironment(Environment.ManifestBackground)) {
                     status.addListener((newVal) => {
-                        if (newVal) MaskMessage.events.pluginEnabled.sendToAll(id)
-                        else MaskMessage.events.pluginDisabled.sendToAll(id)
+                        if (newVal) MaskMessages.events.pluginEnabled.sendToAll(id)
+                        else MaskMessages.events.pluginDisabled.sendToAll(id)
                     })
                 }
             }

--- a/packages/maskbook/src/plugins/External/SNSAdaptor/index.tsx
+++ b/packages/maskbook/src/plugins/External/SNSAdaptor/index.tsx
@@ -6,7 +6,7 @@ import { base } from '../base'
 import { ThirdPartyPluginCompositionEntry } from '../components/CompositionEntry'
 import { ExternalPluginMessages } from '../messages'
 import { isLocalContext } from '../sns-context'
-import { MaskMessage } from '../../../utils'
+import { MaskMessages } from '../../../utils'
 import { makeTypedMessageText } from '@masknet/shared-base'
 
 const sns: Plugin.SNSAdaptor.Definition = {
@@ -20,7 +20,7 @@ const sns: Plugin.SNSAdaptor.Definition = {
             if (!isLocalContext(data.context)) return
 
             // TODO: should ask for user.
-            MaskMessage.events.replaceComposition.sendToLocal(makeTypedMessageText(data.appendText, data.payload))
+            MaskMessages.events.replaceComposition.sendToLocal(makeTypedMessageText(data.appendText, data.payload))
         })
         signal.addEventListener('abort', a)
         signal.addEventListener('abort', b)

--- a/packages/maskbook/src/plugins/External/components/CompositionEntry.tsx
+++ b/packages/maskbook/src/plugins/External/components/CompositionEntry.tsx
@@ -3,13 +3,13 @@ import { usePortalShadowRoot } from '@masknet/theme'
 import { MaskDialog } from '@masknet/theme'
 import { DialogContent } from '@material-ui/core'
 import { useEffect } from 'react'
-import { MaskMessage } from '../../../utils'
+import { MaskMessages } from '../../../utils'
 import { PluginLoader } from './PluginLoader'
 
 export function ThirdPartyPluginCompositionEntry(props: Plugin.SNSAdaptor.CompositionDialogEntry_DialogProps) {
     useEffect(
         () =>
-            MaskMessage.events.replaceComposition.on(() => {
+            MaskMessages.events.replaceComposition.on(() => {
                 props.onClose()
             }),
         [props.onClose],

--- a/packages/maskbook/src/social-network-adaptor/facebook.com/automation/openComposeBox.ts
+++ b/packages/maskbook/src/social-network-adaptor/facebook.com/automation/openComposeBox.ts
@@ -1,5 +1,5 @@
 import { LiveSelector } from '@dimensiondev/holoflows-kit'
-import { MaskMessage, CompositionRequest } from '../../../utils/messages'
+import { MaskMessages, CompositionRequest } from '../../../utils/messages'
 import { i18n } from '../../../utils/i18n-next'
 import { delay } from '../../../utils/utils'
 import { untilDocumentReady } from '../../../utils/dom'
@@ -57,7 +57,7 @@ export async function taskOpenComposeBoxFacebook(
     }
 
     await delay(800)
-    MaskMessage.events.requestComposition.sendToLocal({
+    MaskMessages.events.requestComposition.sendToLocal({
         reason: 'popup',
         open: true,
         content: typeof content === 'string' ? makeTypedMessageText(content) : content,

--- a/packages/maskbook/src/social-network-adaptor/facebook.com/automation/pasteTextToComposition.ts
+++ b/packages/maskbook/src/social-network-adaptor/facebook.com/automation/pasteTextToComposition.ts
@@ -3,7 +3,7 @@ import { delay, timeout } from '../../../utils/utils'
 import { isMobileFacebook } from '../utils/isMobile'
 import type { SocialNetworkUI } from '../../../social-network/types'
 import { untilDocumentReady } from '../../../utils/dom'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { inputText, pasteText } from '@masknet/injected-script'
 
 async function openPostDialogFacebook() {
@@ -101,6 +101,6 @@ export async function pasteTextToCompositionFacebook(
     scrollBack()
     function copyFailed(error: unknown) {
         console.warn('Text not pasted to the text area', error)
-        if (recover) MaskMessage.events.autoPasteFailed.sendToLocal({ text })
+        if (recover) MaskMessages.events.autoPasteFailed.sendToLocal({ text })
     }
 }

--- a/packages/maskbook/src/social-network-adaptor/facebook.com/automation/pasteToCommentBoxFacebook.ts
+++ b/packages/maskbook/src/social-network-adaptor/facebook.com/automation/pasteToCommentBoxFacebook.ts
@@ -1,12 +1,12 @@
 import { selectElementContents, delay } from '../../../utils/utils'
 import { isMobileFacebook } from '../utils/isMobile'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import type { PostInfo } from '../../../social-network/PostInfo'
 import { inputText, pasteText } from '@masknet/injected-script'
 
 export async function pasteToCommentBoxFacebook(encryptedComment: string, current: PostInfo, dom: HTMLElement | null) {
     const fail = () => {
-        MaskMessage.events.autoPasteFailed.sendToLocal({ text: encryptedComment })
+        MaskMessages.events.autoPasteFailed.sendToLocal({ text: encryptedComment })
     }
     if (isMobileFacebook) {
         const root = dom || current.commentBoxSelector!.evaluate()[0]

--- a/packages/maskbook/src/social-network-adaptor/facebook.com/injection/Composition.tsx
+++ b/packages/maskbook/src/social-network-adaptor/facebook.com/injection/Composition.tsx
@@ -4,7 +4,7 @@ import { createReactRootShadowed } from '../../../utils/shadow-root/renderInShad
 import { Composition } from '../../../components/CompositionDialog/Composition'
 import { isMobileFacebook } from '../utils/isMobile'
 import { PostDialogHint } from '../../../components/InjectedComponents/PostDialogHint'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { startWatch } from '../../../utils/watcher'
 let composeBox: LiveSelector<Element>
 if (isMobileFacebook) {
@@ -25,7 +25,7 @@ export function injectCompositionFacebook(signal: AbortSignal) {
 }
 function UI() {
     const onHintButtonClicked = useCallback(
-        () => MaskMessage.events.requestComposition.sendToLocal({ reason: 'popup', open: true }),
+        () => MaskMessages.events.requestComposition.sendToLocal({ reason: 'popup', open: true }),
         [],
     )
     return (

--- a/packages/maskbook/src/social-network-adaptor/instagram.com/injection/Entry.tsx
+++ b/packages/maskbook/src/social-network-adaptor/instagram.com/injection/Entry.tsx
@@ -3,7 +3,7 @@ import { Create } from '@material-ui/icons'
 import { Composition } from '../../../components/CompositionDialog/Composition'
 import { useState, useEffect } from 'react'
 import { LiveSelector, MutationObserverWatcher } from '@dimensiondev/holoflows-kit'
-import { MaskMessage } from '../../../utils'
+import { MaskMessages } from '../../../utils'
 
 const Container = styled('div')`
     position: fixed;
@@ -30,7 +30,7 @@ export function Entry() {
             <Fab
                 variant="extended"
                 onClick={() => {
-                    MaskMessage.events.requestComposition.sendToLocal({ open: true, reason: 'timeline' })
+                    MaskMessages.events.requestComposition.sendToLocal({ open: true, reason: 'timeline' })
                 }}>
                 <Create />
                 Create with Mask

--- a/packages/maskbook/src/social-network-adaptor/minds.com/automation/AttachImageToComposition.ts
+++ b/packages/maskbook/src/social-network-adaptor/minds.com/automation/AttachImageToComposition.ts
@@ -1,5 +1,5 @@
 import type { SocialNetworkUI } from '../../../social-network'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { downloadUrl } from '../../../utils/utils'
 import { composerModalTextAreaSelector, composerPreviewSelector } from '../utils/selector'
 import { pasteTextToCompositionMinds } from './pasteTextToComposition'
@@ -24,7 +24,7 @@ export function pasteImageToCompositionMinds() {
             // clear clipboard
             return navigator.clipboard.writeText('')
         } else if (recover) {
-            MaskMessage.events.autoPasteFailed.sendToLocal({ text: relatedTextPayload || '', image })
+            MaskMessages.events.autoPasteFailed.sendToLocal({ text: relatedTextPayload || '', image })
         }
     }
 }

--- a/packages/maskbook/src/social-network-adaptor/minds.com/automation/openComposeBox.ts
+++ b/packages/maskbook/src/social-network-adaptor/minds.com/automation/openComposeBox.ts
@@ -1,7 +1,7 @@
 import { makeTypedMessageText, TypedMessage } from '../../../protocols/typed-message'
 import { untilDocumentReady } from '../../../utils/dom'
 import { i18n } from '../../../utils/i18n-next'
-import { MaskMessage, CompositionRequest } from '../../../utils/messages'
+import { MaskMessages, CompositionRequest } from '../../../utils/messages'
 import { delay } from '../../../utils/utils'
 import { composeButtonSelector, composeDialogIndicatorSelector, composeTextareaSelector } from '../utils/selector'
 
@@ -24,7 +24,7 @@ export async function openComposeBoxMinds(content: string | TypedMessage, option
     }
 
     await delay(800)
-    MaskMessage.events.requestComposition.sendToLocal({
+    MaskMessages.events.requestComposition.sendToLocal({
         reason: 'popup',
         open: true,
         content: typeof content === 'string' ? makeTypedMessageText(content) : content,

--- a/packages/maskbook/src/social-network-adaptor/minds.com/automation/pasteTextToComposition.ts
+++ b/packages/maskbook/src/social-network-adaptor/minds.com/automation/pasteTextToComposition.ts
@@ -1,6 +1,6 @@
 import type { SocialNetworkUI } from '../../../social-network'
 import { untilElementAvailable } from '../../../utils/dom'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { delay, selectElementContents } from '../../../utils/utils'
 import { inputText } from '@masknet/injected-script'
 import { getEditorContent, hasEditor, hasFocus, isCompose } from '../utils/postBox'
@@ -49,7 +49,7 @@ export const pasteTextToCompositionMinds: SocialNetworkUI.AutomationCapabilities
         }
 
         const fail = (e: Error) => {
-            if (opt?.recover) MaskMessage.events.autoPasteFailed.sendToLocal({ text })
+            if (opt?.recover) MaskMessages.events.autoPasteFailed.sendToLocal({ text })
             throw e
         }
 

--- a/packages/maskbook/src/social-network-adaptor/minds.com/automation/pasteToCommentBoxMinds.ts
+++ b/packages/maskbook/src/social-network-adaptor/minds.com/automation/pasteToCommentBoxMinds.ts
@@ -1,11 +1,11 @@
 import type { PostInfo } from '../../../social-network/PostInfo'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { delay, selectElementContents } from '../../../utils/utils'
 import { pasteText } from '@masknet/injected-script'
 
 export async function pasteToCommentBoxMinds(encryptedComment: string, current: PostInfo, dom: HTMLElement | null) {
     const fail = () => {
-        MaskMessage.events.autoPasteFailed.sendToLocal({ text: encryptedComment })
+        MaskMessages.events.autoPasteFailed.sendToLocal({ text: encryptedComment })
     }
     const root = dom || current.rootNode
     if (!root) return fail()

--- a/packages/maskbook/src/social-network-adaptor/minds.com/injection/PostDialogHint.tsx
+++ b/packages/maskbook/src/social-network-adaptor/minds.com/injection/PostDialogHint.tsx
@@ -2,7 +2,7 @@ import { LiveSelector, MutationObserverWatcher } from '@dimensiondev/holoflows-k
 import { makeStyles } from '@masknet/theme'
 import { useCallback } from 'react'
 import { PostDialogHint } from '../../../components/InjectedComponents/PostDialogHint'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { createReactRootShadowed } from '../../../utils/shadow-root/renderInShadowRoot'
 import { startWatch } from '../../../utils/watcher'
 import { postEditorInPopupSelector, postEditorInTimelineSelector } from '../utils/selector'
@@ -40,7 +40,7 @@ function PostDialogHintAtMinds({ reason }: { reason: 'timeline' | 'popup' }) {
     const { classes } = useStyles({ reason })
 
     const onHintButtonClicked = useCallback(
-        () => MaskMessage.events.requestComposition.sendToLocal({ reason, open: true }),
+        () => MaskMessages.events.requestComposition.sendToLocal({ reason, open: true }),
         [reason],
     )
     return (

--- a/packages/maskbook/src/social-network-adaptor/options-page/index.ts
+++ b/packages/maskbook/src/social-network-adaptor/options-page/index.ts
@@ -2,7 +2,7 @@ import { defineSocialNetworkUI, SocialNetworkUI, SocialNetwork } from '../../soc
 import { isEnvironment, Environment, ValueRef } from '@dimensiondev/holoflows-kit'
 import { IdentifierMap } from '../../database/IdentifierMap'
 import Services from '../../extension/service'
-import { MaskMessage } from '../../utils/messages'
+import { MaskMessages } from '../../utils/messages'
 import { currentImportingBackup } from '../../settings/settings'
 
 const base: SocialNetwork.Base = {
@@ -39,7 +39,7 @@ const define: SocialNetworkUI.Definition = {
             if (signal.aborted) return
             state.profiles.value = x
         }
-        signal.addEventListener('abort', MaskMessage.events.profilesChanged.on(load))
+        signal.addEventListener('abort', MaskMessages.events.profilesChanged.on(load))
         await load()
         return state
     },

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/automation/openComposeBox.ts
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/automation/openComposeBox.ts
@@ -1,8 +1,8 @@
-import { MaskMessage, CompositionRequest } from '../../../utils/messages'
+import { MaskMessages, CompositionRequest } from '../../../utils/messages'
 import { makeTypedMessageText, TypedMessage } from '../../../protocols/typed-message'
 
 export function openComposeBoxTwitter(content: string | TypedMessage, options?: CompositionRequest['options']) {
-    MaskMessage.events.requestComposition.sendToLocal({
+    MaskMessages.events.requestComposition.sendToLocal({
         reason: 'timeline',
         open: true,
         content: typeof content === 'string' ? makeTypedMessageText(content) : content,

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/automation/pasteTextToComposition.ts
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/automation/pasteTextToComposition.ts
@@ -5,7 +5,7 @@ import type { SocialNetworkUI } from '../../../social-network'
 import { getEditorContent, hasFocus, isCompose, hasEditor } from '../utils/postBox'
 import { untilElementAvailable } from '../../../utils/dom'
 import { isMobileTwitter } from '../utils/isMobile'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 
 /**
  * Wait for up to 5000 ms
@@ -44,7 +44,7 @@ export const pasteTextToCompositionTwitter: SocialNetworkUI.AutomationCapabiliti
         }
 
         const fail = (e: Error) => {
-            if (opt?.recover) MaskMessage.events.autoPasteFailed.sendToLocal({ text })
+            if (opt?.recover) MaskMessages.events.autoPasteFailed.sendToLocal({ text })
             throw e
         }
 

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/injection/NFT/NFTAvatarInTwitter.tsx
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/injection/NFT/NFTAvatarInTwitter.tsx
@@ -1,4 +1,4 @@
-import { createReactRootShadowed, MaskMessage, NFTAvatarEvent, startWatch } from '../../../../utils'
+import { createReactRootShadowed, MaskMessages, NFTAvatarEvent, startWatch } from '../../../../utils'
 import { searchTwitterAvatarSelector } from '../../utils/selector'
 import { MutationObserverWatcher } from '@dimensiondev/holoflows-kit'
 import { makeStyles, useCustomSnackbar } from '@masknet/theme'
@@ -61,7 +61,7 @@ function NFTAvatarInTwitter(props: NFTAvatarInTwitterProps) {
     )
 
     useEffect(() => {
-        return MaskMessage.events.NFTAvatarUpdated.on((data) => {
+        return MaskMessages.events.NFTAvatarUpdated.on((data) => {
             onUpdate(data)
         })
     }, [onUpdate])

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/injection/NFT/profileNFTAvatar.tsx
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/injection/NFT/profileNFTAvatar.tsx
@@ -7,7 +7,7 @@ import { useMyPersonas } from '../../../../components/DataSource/useMyPersonas'
 import { useNFTAvatar } from '../../../../components/InjectedComponents/NFT/hooks'
 import { NFTAvatar } from '../../../../components/InjectedComponents/NFT/NFTAvatar'
 import { activatedSocialNetworkUI } from '../../../../social-network'
-import { createReactRootShadowed, Flags, MaskMessage, NFTAvatarEvent, startWatch } from '../../../../utils'
+import { createReactRootShadowed, Flags, MaskMessages, NFTAvatarEvent, startWatch } from '../../../../utils'
 import { searchProfileAvatarSelector, searchProfileSaveSelector } from '../../utils/selector'
 import { getAvatar, getAvatarId, getTwitterId } from '../../utils/user'
 
@@ -62,7 +62,7 @@ function NFTAvatarInTwitter(props: NFTAvatarInTwitterProps) {
 
     const handler = () => {
         if (!avatarEvent) return
-        MaskMessage.events.NFTAvatarUpdated.sendToLocal(avatarEvent)
+        MaskMessages.events.NFTAvatarUpdated.sendToLocal(avatarEvent)
     }
 
     useEffect(() => {

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/injection/PostDialogHint.tsx
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/injection/PostDialogHint.tsx
@@ -3,7 +3,7 @@ import { MutationObserverWatcher, LiveSelector } from '@dimensiondev/holoflows-k
 import { postEditorInTimelineSelector, postEditorInPopupSelector } from '../utils/selector'
 import { createReactRootShadowed } from '../../../utils/shadow-root/renderInShadowRoot'
 import { PostDialogHint } from '../../../components/InjectedComponents/PostDialogHint'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { hasEditor, isCompose } from '../utils/postBox'
 import { startWatch } from '../../../utils/watcher'
 
@@ -28,7 +28,7 @@ function renderPostDialogHintTo<T>(reason: 'timeline' | 'popup', ls: LiveSelecto
 
 function PostDialogHintAtTwitter({ reason }: { reason: 'timeline' | 'popup' }) {
     const onHintButtonClicked = useCallback(
-        () => MaskMessage.events.requestComposition.sendToLocal({ reason, open: true }),
+        () => MaskMessages.events.requestComposition.sendToLocal({ reason, open: true }),
         [reason],
     )
     return <PostDialogHint onHintButtonClicked={onHintButtonClicked} />

--- a/packages/maskbook/src/social-network-adaptor/twitter.com/injection/PostDialogIcon.tsx
+++ b/packages/maskbook/src/social-network-adaptor/twitter.com/injection/PostDialogIcon.tsx
@@ -2,7 +2,7 @@ import { MutationObserverWatcher, LiveSelector } from '@dimensiondev/holoflows-k
 import { postEditorToolbarSelector } from '../utils/selector'
 import { createReactRootShadowed } from '../../../utils/shadow-root/renderInShadowRoot'
 import { PostDialogIcon } from '../../../components/InjectedComponents/PostDialogIcon'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { isCompose, isMobile } from '../utils/postBox'
 import { makeStyles } from '@masknet/theme'
 import { startWatch } from '../../../utils/watcher'
@@ -32,6 +32,6 @@ const useTwitterMaskIcon = makeStyles()((theme) => ({
 
 function PostDialogIconAtTwitter() {
     const { classes } = useTwitterMaskIcon()
-    const onIconClicked = () => MaskMessage.events.requestComposition.sendToLocal({ reason: 'timeline', open: true })
+    const onIconClicked = () => MaskMessages.events.requestComposition.sendToLocal({ reason: 'timeline', open: true })
     return <PostDialogIcon classes={classes} onClick={onIconClicked} />
 }

--- a/packages/maskbook/src/social-network/defaults/automation/AttachImageToComposition.ts
+++ b/packages/maskbook/src/social-network/defaults/automation/AttachImageToComposition.ts
@@ -1,6 +1,6 @@
 import { activatedSocialNetworkUI, SocialNetworkUI } from '../../index'
 import { untilDocumentReady } from '../../../utils/dom'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { delay, downloadUrl, pasteImageToActiveElements } from '../../../utils/utils'
 
 export function pasteImageToCompositionDefault(hasSucceed: () => Promise<boolean> | boolean) {
@@ -20,7 +20,7 @@ export function pasteImageToCompositionDefault(hasSucceed: () => Promise<boolean
 
         if (await hasSucceed()) return
         if (recover) {
-            MaskMessage.events.autoPasteFailed.sendToLocal({ text: relatedTextPayload || '', image })
+            MaskMessages.events.autoPasteFailed.sendToLocal({ text: relatedTextPayload || '', image })
         }
     }
 }

--- a/packages/maskbook/src/social-network/defaults/inject/CommentBox.tsx
+++ b/packages/maskbook/src/social-network/defaults/inject/CommentBox.tsx
@@ -7,7 +7,7 @@ import { createReactRootShadowed } from '../../../utils/shadow-root/renderInShad
 import { makeStyles } from '@masknet/theme'
 import { usePostInfoDetails, usePostInfo, PostInfoProvider } from '../../../components/DataSource/usePostInfo'
 import { noop } from 'lodash-es'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import { startWatch } from '../../../utils/watcher'
 import { extractTextFromTypedMessage } from '../../../protocols/typed-message'
 
@@ -16,7 +16,7 @@ const defaultOnPasteToCommentBox = async (
     _current: PostInfo,
     _realCurrent: HTMLElement | null,
 ) => {
-    MaskMessage.events.autoPasteFailed.sendToLocal({ text: encryptedComment })
+    MaskMessages.events.autoPasteFailed.sendToLocal({ text: encryptedComment })
 }
 
 // TODO: should not rely on onPasteToCommentBoxFacebook.

--- a/packages/maskbook/src/social-network/defaults/state/InitFriends.ts
+++ b/packages/maskbook/src/social-network/defaults/state/InitFriends.ts
@@ -2,7 +2,7 @@ import { IdentifierMap, ProfileIdentifier } from '@masknet/shared'
 import produce from 'immer'
 import type { Profile } from '../../../database'
 import Services from '../../../extension/service'
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import type { SocialNetworkUI } from '../../types'
 
 function hasFingerprint(x: Profile) {
@@ -24,7 +24,7 @@ export function InitAutonomousStateFriends(
     })
     signal.addEventListener(
         'abort',
-        MaskMessage.events.profilesChanged.on(async (events) => {
+        MaskMessages.events.profilesChanged.on(async (events) => {
             // eslint-disable-next-line @typescript-eslint/await-thenable
             const newVal = await produce(ref.value, async (draft) => {
                 for (const event of events) {

--- a/packages/maskbook/src/social-network/defaults/state/InitProfiles.ts
+++ b/packages/maskbook/src/social-network/defaults/state/InitProfiles.ts
@@ -1,4 +1,4 @@
-import { MaskMessage } from '../../../utils/messages'
+import { MaskMessages } from '../../../utils/messages'
 import Services from '../../../extension/service'
 import type { SocialNetworkUI } from '../../types'
 import type { ValueRef } from '@dimensiondev/holoflows-kit'
@@ -12,7 +12,7 @@ export function InitAutonomousStateProfiles(
     query(network, ref)
     signal.addEventListener(
         'abort',
-        MaskMessage.events.ownPersonaChanged.on(() => query(network, ref)),
+        MaskMessages.events.ownPersonaChanged.on(() => query(network, ref)),
     )
 
     async function query(network: string, ref: ValueRef<readonly Profile[]>) {

--- a/packages/maskbook/src/social-network/ui.ts
+++ b/packages/maskbook/src/social-network/ui.ts
@@ -15,7 +15,7 @@ import { startPluginSNSAdaptor } from '@masknet/plugin-infra'
 import { getCurrentSNSNetwork } from '../social-network-adaptor/utils'
 import { createPluginHost } from '../plugin-infra/host'
 import { definedSocialNetworkUIs } from './define'
-import { MaskMessage } from '../utils/messages'
+import { MaskMessages } from '../utils/messages'
 
 const definedSocialNetworkUIsResolved = new Map<string, SocialNetworkUI.Definition>()
 export let activatedSocialNetworkUI: SocialNetworkUI.Definition = {
@@ -165,7 +165,7 @@ export async function activateSocialNetworkUIInner(ui_deferred: SocialNetworkUI.
         if (!plugin) return
 
         await delay(500)
-        MaskMessage.events.requestComposition.sendToLocal({
+        MaskMessages.events.requestComposition.sendToLocal({
             open: true,
             reason: 'timeline',
             options: plugin === 'none' ? {} : { startupPlugin: plugin },

--- a/packages/maskbook/src/utils/messages.ts
+++ b/packages/maskbook/src/utils/messages.ts
@@ -75,6 +75,6 @@ export interface MaskMessages extends SettingsEvents {
     NFTAvatarUpdated: NFTAvatarEvent
     maskSDKHotModuleReload: void
 }
-export const MaskMessage = new WebExtensionMessage<MaskMessages>({ domain: 'mask' })
-Object.assign(globalThis, { MaskMessage })
-MaskMessage.serialization = Serialization
+export const MaskMessages = new WebExtensionMessage<MaskMessages>({ domain: 'mask' })
+Object.assign(globalThis, { MaskMessage: MaskMessages })
+MaskMessages.serialization = Serialization

--- a/packages/maskbook/src/web3/context.ts
+++ b/packages/maskbook/src/web3/context.ts
@@ -75,7 +75,6 @@ function createWeb3Context(disablePopup = false, isMask = false): Web3ProviderTy
         fetchERC20TokensFromTokenLists: Services.Ethereum.fetchERC20TokensFromTokenLists,
         getTransactionList: WalletRPC.getTransactionList,
         createMnemonicWords: WalletRPC.createMnemonicWords,
-        getNonce: Services.Ethereum.getNonce,
     }
 }
 

--- a/packages/maskbook/src/web3/context.ts
+++ b/packages/maskbook/src/web3/context.ts
@@ -16,7 +16,7 @@ import {
     currentMaskWalletAccountWalletSettings,
     currentMaskWalletBalanceSettings,
 } from '../plugins/Wallet/settings'
-import { Flags } from '../utils'
+import { Flags, MaskMessages } from '../utils'
 import type { InternalSettings } from '../settings/createSettings'
 import { createExternalProvider } from './helpers'
 import Services from '../extension/service'
@@ -145,6 +145,7 @@ function createStaticSubscription<T>(getter: () => T) {
         subscribe: () => noop,
     }
 }
+
 function createSubscriptionFromAsync<T>(
     f: () => Promise<T>,
     defaultValue: T,

--- a/packages/maskbook/src/web3/context.ts
+++ b/packages/maskbook/src/web3/context.ts
@@ -1,27 +1,17 @@
-import { noop, omit } from 'lodash-es'
-import type { Subscription } from 'use-subscription'
-import { ERC20TokenDetailed, EthereumTokenType, ProviderType, Web3ProviderType } from '@masknet/web3-shared'
+import { createWeb3Context, ProviderType, Web3ProviderType } from '@masknet/web3-shared'
 import { WalletMessages, WalletRPC } from '../plugins/Wallet/messages'
 import {
-    currentBlockNumberSettings,
-    currentBalanceSettings,
     currentAccountSettings,
-    currentNetworkSettings,
     currentProviderSettings,
     currentChainIdSettings,
-    currentPortfolioDataProviderSettings,
-    currentTokenPricesSettings,
     currentMaskWalletChainIdSettings,
-    currentMaskWalletNetworkSettings,
     currentMaskWalletAccountWalletSettings,
-    currentMaskWalletBalanceSettings,
 } from '../plugins/Wallet/settings'
-import { Flags, MaskMessages } from '../utils'
-import type { InternalSettings } from '../settings/createSettings'
+import { MaskMessages } from '../utils'
 import { createExternalProvider } from './helpers'
 import Services from '../extension/service'
 
-function createWeb3Context(disablePopup = false, isMask = false): Web3ProviderType {
+function createWeb3ContextInner(disablePopup = false, isMask = false): Web3ProviderType {
     const Web3Provider = createExternalProvider(
         () => {
             return isMask
@@ -42,163 +32,18 @@ function createWeb3Context(disablePopup = false, isMask = false): Web3ProviderTy
             }
         },
     )
-    return {
-        provider: createStaticSubscription(() => Web3Provider),
-        allowTestnet: createStaticSubscription(() => Flags.wallet_allow_testnet),
-        chainId: createSubscriptionFromSettings(isMask ? currentMaskWalletChainIdSettings : currentChainIdSettings),
-        account: createSubscriptionFromSettings(
-            isMask ? currentMaskWalletAccountWalletSettings : currentAccountSettings,
-        ),
-        balance: createSubscriptionFromSettings(isMask ? currentMaskWalletBalanceSettings : currentBalanceSettings),
-        blockNumber: createSubscriptionFromSettings(currentBlockNumberSettings),
-        tokenPrices: createSubscriptionFromSettings(currentTokenPricesSettings),
-        walletPrimary: createSubscriptionFromAsync(getWalletPrimary, null, WalletMessages.events.walletsUpdated.on),
-        wallets: createSubscriptionFromAsync(getWallets, [], WalletMessages.events.walletsUpdated.on),
-        providerType: isMask
-            ? createStaticSubscription(() => ProviderType.MaskWallet)
-            : createSubscriptionFromSettings(currentProviderSettings),
-        networkType: createSubscriptionFromSettings(isMask ? currentMaskWalletNetworkSettings : currentNetworkSettings),
-        erc20Tokens: createSubscriptionFromAsync(getERC20Tokens, [], WalletMessages.events.erc20TokensUpdated.on),
-        erc20TokensCount: createSubscriptionFromAsync(
-            WalletRPC.getERC20TokensCount,
-            0,
-            WalletMessages.events.erc20TokensUpdated.on,
-        ),
-        portfolioProvider: createSubscriptionFromSettings(currentPortfolioDataProviderSettings),
-        addERC20Token: WalletRPC.addERC20Token,
-        trustERC20Token: WalletRPC.trustERC20Token,
-        getERC20TokensPaged,
-        getAssetsList: WalletRPC.getAssetsList,
-        getAssetsListNFT: WalletRPC.getAssetsListNFT,
-        getAddressNamesList: WalletRPC.getAddressNames,
-        getERC721TokensPaged,
-        fetchERC20TokensFromTokenLists: Services.Ethereum.fetchERC20TokensFromTokenLists,
-        getTransactionList: WalletRPC.getTransactionList,
-        createMnemonicWords: WalletRPC.createMnemonicWords,
-    }
-}
-
-export const Web3Context = createWeb3Context()
-export const PopupWeb3Context = createWeb3Context(true, true)
-export const SwapWeb3Context = createWeb3Context(false, true)
-
-async function getWallets() {
-    const wallets = await WalletRPC.getWallets()
-    return wallets.map((x) => ({
-        ...omit(x, 'derivationPath', 'storedKeyInfo'),
-        hasStoredKeyInfo: !!x.storedKeyInfo,
-        hasDerivationPath: !!x.derivationPath,
-    }))
-}
-
-export async function getWalletPrimary() {
-    const wallet = await WalletRPC.getWalletPrimary()
-    if (!wallet) return null
-    return {
-        ...omit(wallet, 'derivationPath', 'storedKeyInfo'),
-        hasStoredKeyInfo: !!wallet.storedKeyInfo,
-        hasDerivationPath: !!wallet.derivationPath,
-    }
-}
-
-async function getERC20Tokens() {
-    const raw = await WalletRPC.getERC20Tokens()
-    return raw.map<ERC20TokenDetailed>((x) => ({
-        type: EthereumTokenType.ERC20,
-        ...x,
-    }))
-}
-
-async function getERC20TokensPaged(index: number, count: number, query?: string) {
-    const raw = await WalletRPC.getERC20TokensPaged(index, count, query)
-    return raw.map<ERC20TokenDetailed>((x) => ({
-        type: EthereumTokenType.ERC20,
-        ...x,
-    }))
-}
-
-async function getERC721TokensPaged(index: number, count: number, query?: string) {
-    return WalletRPC.getERC721TokensPaged(index, count, query)
-}
-
-// utils
-function createSubscriptionFromSettings<T>(settings: InternalSettings<T>): Subscription<T> {
-    const { trigger, subscribe } = getEventTarget()
-    settings.readyPromise.finally(trigger)
-    return {
-        getCurrentValue: () => {
-            if (!settings.ready) throw settings.readyPromise
-            return settings.value
+    return createWeb3Context(Web3Provider, {
+        MaskMessages: MaskMessages,
+        MaskServices: Services,
+        PluginServices: {
+            Wallet: WalletRPC,
         },
-        subscribe: (f) => {
-            const a = subscribe(f)
-            const b = settings.addListener(() => trigger())
-            return () => void [a(), b()]
+        PluginMessages: {
+            Wallet: WalletMessages,
         },
-    }
+    })
 }
 
-function createStaticSubscription<T>(getter: () => T) {
-    return {
-        getCurrentValue: getter,
-        subscribe: () => noop,
-    }
-}
-
-function createSubscriptionFromAsync<T>(
-    f: () => Promise<T>,
-    defaultValue: T,
-    onChange: (callback: () => void) => () => void,
-): Subscription<T> {
-    // 0 - idle, 1 - updating state, > 1 - waiting state
-    let beats = 0
-    let state = defaultValue
-    let isLoading = true
-    const { subscribe, trigger } = getEventTarget()
-    const init = f()
-        .then((v) => {
-            state = v
-        })
-        .finally(trigger)
-        .finally(() => (isLoading = false))
-    const flush = async () => {
-        state = await f()
-        beats -= 1
-        if (beats > 0) {
-            beats = 1
-            setTimeout(flush, 0)
-        } else if (beats < 0) {
-            beats = 0
-        }
-        trigger()
-    }
-    return {
-        getCurrentValue: () => {
-            if (isLoading) throw init
-            return state
-        },
-        subscribe: (sub) => {
-            const a = subscribe(sub)
-            const b = onChange(() => {
-                beats += 1
-                if (beats === 1) flush()
-            })
-            return () => void [a(), b()]
-        },
-    }
-}
-function getEventTarget() {
-    const event = new EventTarget()
-    const EVENT = 'event'
-    let timer: NodeJS.Timeout
-    function trigger() {
-        clearTimeout(timer)
-        // delay to update state to ensure that all settings to be synced globally
-        timer = setTimeout(() => event.dispatchEvent(new Event(EVENT)), 600)
-    }
-    function subscribe(f: () => void) {
-        event.addEventListener(EVENT, f)
-        return () => event.removeEventListener(EVENT, f)
-    }
-    return { trigger, subscribe }
-}
+export const Web3Context = createWeb3ContextInner()
+export const PopupWeb3Context = createWeb3ContextInner(true, true)
+export const SwapWeb3Context = createWeb3ContextInner(false, true)

--- a/packages/web3-shared/src/context/context.ts
+++ b/packages/web3-shared/src/context/context.ts
@@ -100,7 +100,6 @@ export function createWeb3Context(
         getTransactionList: hub.PluginServices.Wallet.getTransactionList,
         fetchERC20TokensFromTokenLists: hub.MaskServices.Ethereum.fetchERC20TokensFromTokenLists,
         createMnemonicWords: hub.PluginServices.Wallet.createMnemonicWords,
-        getNonce: hub.MaskServices.Ethereum.getNonce,
     }
 }
 

--- a/packages/web3-shared/src/context/context.ts
+++ b/packages/web3-shared/src/context/context.ts
@@ -1,0 +1,164 @@
+import { noop } from 'lodash-es'
+import type { Subscription } from 'use-subscription'
+import type { provider as Web3Provider } from 'web3-core'
+import type { MaskMessage } from '../../../maskbook/dist/utils/messages'
+import type { Services as MaskServices } from '../../../maskbook/dist/extension/service'
+import { ChainId, NetworkType, PortfolioProvider, ProviderType } from '..'
+import type { Web3ProviderType } from '.'
+
+export interface PluginServices {
+    Wallet: typeof import('../../../maskbook/dist/plugins/Wallet/messages').WalletRPC
+    Swap: typeof import('../../../maskbook/dist/plugins/Trader/messages').PluginTraderRPC
+}
+export interface PluginMessages {
+    Wallet: typeof import('../../../plugins/Wallet/dist/messages').WalletMessages
+    Transak: typeof import('../../../maskbook/dist/plugins/Transak/messages').PluginTransakMessages
+    Swap: typeof import('../../../maskbook/dist/plugins/Trader/messages').PluginTraderMessages
+}
+
+export function createWeb3Context(
+    provider: Web3Provider,
+    hub: {
+        MaskServices: typeof MaskServices
+        MaskMessages: typeof MaskMessage
+        PluginServices: PluginServices
+        PluginMessages: PluginMessages
+    },
+): Web3ProviderType {
+    return {
+        provider: createStaticSubscription(() => provider),
+        allowTestnet: createSubscriptionFromAsync(hub.MaskServices.Settings.getWalletAllowTestChain, false, () => {
+            return () => {}
+        }),
+        account: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getSelectedWalletAddress,
+            '',
+            hub.MaskMessages.events.currentAccountSettings.on,
+        ),
+        tokenPrices: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getTokenPrices,
+            {},
+            hub.MaskMessages.events.currentTokenPricesSettings.on,
+        ),
+        balance: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getBalance,
+            '0',
+            hub.MaskMessages.events.currentBalanceSettings.on,
+        ),
+        blockNumber: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getBlockNumber,
+            0,
+            hub.MaskMessages.events.currentBlockNumberSettings.on,
+        ),
+        chainId: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getChainId,
+            ChainId.Mainnet,
+            hub.MaskMessages.events.currentChainIdSettings.on,
+        ),
+        providerType: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getCurrentSelectedWalletProvider,
+            ProviderType.MaskWallet,
+            hub.MaskMessages.events.currentProviderSettings.on,
+        ),
+        networkType: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getCurrentSelectedWalletNetwork,
+            NetworkType.Ethereum,
+            hub.MaskMessages.events.currentNetworkSettings.on,
+        ),
+        walletPrimary: createSubscriptionFromAsync(
+            hub.PluginServices.Wallet.getWalletPrimary,
+            null,
+            hub.PluginMessages.Wallet.events.walletsUpdated.on,
+        ),
+        wallets: createSubscriptionFromAsync(
+            hub.PluginServices.Wallet.getWallets,
+            [],
+            hub.PluginMessages.Wallet.events.walletsUpdated.on,
+        ),
+        erc20Tokens: createSubscriptionFromAsync(
+            hub.PluginServices.Wallet.getERC20Tokens,
+            [],
+            hub.PluginMessages.Wallet.events.erc20TokensUpdated.on,
+        ),
+        addERC20Token: hub.PluginServices.Wallet.addERC20Token,
+        trustERC20Token: hub.PluginServices.Wallet.trustERC20Token,
+        erc20TokensCount: createSubscriptionFromAsync(
+            hub.PluginServices.Wallet.getERC20TokensCount,
+            0,
+            hub.PluginMessages.Wallet.events.erc20TokensUpdated.on,
+        ),
+        getERC20TokensPaged: hub.PluginServices.Wallet.getERC20TokensPaged,
+        getERC721TokensPaged: hub.PluginServices.Wallet.getERC721TokensPaged,
+        portfolioProvider: createSubscriptionFromAsync(
+            hub.MaskServices.Settings.getCurrentPortfolioDataProvider,
+            PortfolioProvider.DEBANK,
+            hub.MaskMessages.events.currentPortfolioDataProviderSettings.on,
+        ),
+        getAssetsList: hub.PluginServices.Wallet.getAssetsList,
+        getAssetsListNFT: hub.PluginServices.Wallet.getAssetsListNFT,
+        getAddressNamesList: hub.PluginServices.Wallet.getAddressNames,
+        getTransactionList: hub.PluginServices.Wallet.getTransactionList,
+        fetchERC20TokensFromTokenLists: hub.MaskServices.Ethereum.fetchERC20TokensFromTokenLists,
+        createMnemonicWords: hub.PluginServices.Wallet.createMnemonicWords,
+        getNonce: hub.MaskServices.Ethereum.getNonce,
+    }
+}
+
+function createStaticSubscription<T>(getter: () => T) {
+    return {
+        getCurrentValue: getter,
+        subscribe: () => noop,
+    }
+}
+
+function getEventTarget() {
+    const event = new EventTarget()
+    const EVENT = 'event'
+    let timer: NodeJS.Timeout
+    function trigger() {
+        clearTimeout(timer)
+        // delay to update state to ensure that all settings to be synced globally
+        timer = setTimeout(() => event.dispatchEvent(new Event(EVENT)), 600)
+    }
+    function subscribe(f: () => void) {
+        event.addEventListener(EVENT, f)
+        return () => event.removeEventListener(EVENT, f)
+    }
+    return { trigger, subscribe }
+}
+
+function createSubscriptionFromAsync<T>(
+    f: () => Promise<T>,
+    defaultValue: T,
+    onChange: (callback: () => void) => () => void,
+): Subscription<T> {
+    // 0 - idle, 1 - updating state, > 1 - waiting state
+    let beats = 0
+    let state = defaultValue
+    const { subscribe, trigger } = getEventTarget()
+    f()
+        .then((v) => (state = v))
+        .finally(trigger)
+    const flush = async () => {
+        state = await f()
+        beats -= 1
+        if (beats > 0) {
+            beats = 1
+            setTimeout(flush, 0)
+        } else if (beats < 0) {
+            beats = 0
+        }
+        trigger()
+    }
+    return {
+        getCurrentValue: () => state,
+        subscribe: (sub) => {
+            const a = subscribe(sub)
+            const b = onChange(async () => {
+                beats += 1
+                if (beats === 1) flush()
+            })
+            return () => void [a(), b()]
+        },
+    }
+}

--- a/packages/web3-shared/src/context/context.ts
+++ b/packages/web3-shared/src/context/context.ts
@@ -1,26 +1,23 @@
 import { noop } from 'lodash-es'
 import type { Subscription } from 'use-subscription'
 import type { provider as Web3Provider } from 'web3-core'
-import type { MaskMessage } from '../../../maskbook/dist/utils/messages'
+import type { MaskMessages } from '../../../maskbook/dist/utils/messages'
 import type { Services as MaskServices } from '../../../maskbook/dist/extension/service'
 import { ChainId, NetworkType, PortfolioProvider, ProviderType } from '..'
 import type { Web3ProviderType } from '.'
 
 export interface PluginServices {
     Wallet: typeof import('../../../maskbook/dist/plugins/Wallet/messages').WalletRPC
-    Swap: typeof import('../../../maskbook/dist/plugins/Trader/messages').PluginTraderRPC
 }
 export interface PluginMessages {
     Wallet: typeof import('../../../plugins/Wallet/dist/messages').WalletMessages
-    Transak: typeof import('../../../maskbook/dist/plugins/Transak/messages').PluginTransakMessages
-    Swap: typeof import('../../../maskbook/dist/plugins/Trader/messages').PluginTraderMessages
 }
 
 export function createWeb3Context(
     provider: Web3Provider,
     hub: {
         MaskServices: typeof MaskServices
-        MaskMessages: typeof MaskMessage
+        MaskMessages: typeof MaskMessages
         PluginServices: PluginServices
         PluginMessages: PluginMessages
     },

--- a/packages/web3-shared/src/context/index.tsx
+++ b/packages/web3-shared/src/context/index.tsx
@@ -4,6 +4,8 @@ import { useSubscription } from 'use-subscription'
 import type { Web3ProviderType } from './type'
 import { getChainDetailed, isChainIdValid } from '../utils'
 
+export * from './context'
+
 export type { Web3ProviderType } from './type'
 
 export const Web3ProviderContext = createContext<Web3ProviderType>(null!)

--- a/packages/web3-shared/src/context/type.ts
+++ b/packages/web3-shared/src/context/type.ts
@@ -56,5 +56,4 @@ export interface Web3ProviderType {
     }>
     fetchERC20TokensFromTokenLists: (urls: string[], chainId: ChainId) => Promise<ERC20TokenDetailed[]>
     createMnemonicWords: () => Promise<string[]>
-    getNonce: (address: string) => Promise<number>
 }

--- a/packages/web3-shared/src/hooks/useNonce.ts
+++ b/packages/web3-shared/src/hooks/useNonce.ts
@@ -1,9 +1,0 @@
-import { useAsyncRetry } from 'react-use'
-import { useWeb3Context } from '../context'
-
-export function useNonce(address: string) {
-    const { getNonce } = useWeb3Context()
-    return useAsyncRetry(async () => {
-        return getNonce(address)
-    }, [address])
-}

--- a/packages/web3-shared/tsconfig.json
+++ b/packages/web3-shared/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "./dist/",
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": ["./src", "./src/**/*.json"]
+  "include": ["./src", "./src/**/*.json"],
+  "references": [{ "path": "../public-api" }, { "path": "../maskbook/" }]
 }


### PR DESCRIPTION
It's hard to maintain two files with a lot of duplicate code. This PR merges `dashboard/context.ts` and `maskbook/context.ts` into a single file.

+ [x] Rename `MaskMessage` to `MaskMessages` 
+ [x] Remove `useNonce`
+ [ ] Add new package `@masknet/web3-context`

closes #
