### PR TITLE
fix: show user guide on decrypt post fail mask icon

### DIFF
--- a/packages/maskbook/src/components/GuideStep/index.tsx
+++ b/packages/maskbook/src/components/GuideStep/index.tsx
@@ -90,10 +90,19 @@ export interface GuideStepProps extends PropsWithChildren<{}> {
     step: number
     tip: string
     arrow?: boolean
+    disabled?: boolean
     onComplete?: () => void
 }
 
-export default function GuideStep({ total, step, tip, children, arrow = true, onComplete }: GuideStepProps) {
+export default function GuideStep({
+    total,
+    step,
+    tip,
+    children,
+    arrow = true,
+    disabled = false,
+    onComplete,
+}: GuideStepProps) {
     const { t } = useI18N()
     const { classes } = useStyles()
     const childrenRef = useRef<HTMLElement>()
@@ -105,11 +114,13 @@ export default function GuideStep({ total, step, tip, children, arrow = true, on
     const lastStep = useValueRef(lastStepRef)
 
     useEffect(() => {
+        if (disabled) return
         const open = +lastStep === step
         setOpen(open)
     }, [lastStep])
 
     useEffect(() => {
+        if (disabled) return
         document.body.style.overflow = open ? 'hidden' : ''
     }, [open])
 

--- a/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptPostFailed.tsx
+++ b/packages/maskbook/src/components/InjectedComponents/DecryptedPost/DecryptPostFailed.tsx
@@ -19,7 +19,7 @@ export const DecryptPostFailed = memo(function DecryptPostFailed(props: DecryptP
     const { AdditionalContentProps, NotSetupYetPromptProps, author, postedBy, error } = props
     const { t } = useI18N()
     if (error?.message === DecryptFailedReason.MyCryptoKeyNotFound)
-        return <NotSetupYetPrompt {...NotSetupYetPromptProps} />
+        return <NotSetupYetPrompt {...NotSetupYetPromptProps} description="decryptPostFailed" />
     return (
         <AdditionalContent
             title={t('service_decryption_failed')}

--- a/packages/maskbook/src/components/Welcomes/Banner.tsx
+++ b/packages/maskbook/src/components/Welcomes/Banner.tsx
@@ -39,7 +39,7 @@ export function BannerUI(props: BannerUIProps) {
     const { t } = useI18N()
 
     return props.nextStep === 'hidden' ? null : (
-        <GuideStep step={3} total={3} tip={t('user_guide_tip_3')}>
+        <GuideStep step={3} total={3} tip={t('user_guide_tip_3')} disabled={props.description === 'decryptPostFailed'}>
             <IconButton size="large" className={classes.buttonText} onClick={props.nextStep.onClick}>
                 <MaskSharpIcon color="primary" />
             </IconButton>


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #
