### PR TITLE
fix: fb image paste not work

### DIFF
--- a/packages/injected-script/main/EventListenerPatch/capture.ts
+++ b/packages/injected-script/main/EventListenerPatch/capture.ts
@@ -135,7 +135,7 @@ export function dispatchEventRaw<T extends Event>(
             event,
             clone_into({
                 get(target, key) {
-                    if (key === 'currentTarget' || key === 'target') return unwrapXRay_CPPBindingObject(currentTarget())
+                    if (key === 'currentTarget') return unwrapXRay_CPPBindingObject(currentTarget())
                     return (source as any)[key] ?? (unwrapXRay_CPPBindingObject(target) as any)[key]
                 },
             }),


### PR DESCRIPTION
<!-- Please refer to the related issue number -->

closes #4701
