### PR TITLE
chore: update investable.token.address to investable.address

### DIFF
--- a/packages/mask/src/plugins/Furucombo/UI/FurucomboView.tsx
+++ b/packages/mask/src/plugins/Furucombo/UI/FurucomboView.tsx
@@ -98,7 +98,7 @@ export function FurucomboView(props: PoolViewProps) {
 
     const investable = investables.find(
         (investable: Investable) =>
-            isSameAddress(investable.token.address, props.address) &&
+            isSameAddress(investable.address, props.address) &&
             investable.chainId === currentChainId &&
             investable.category === props.category,
     )

--- a/packages/mask/src/plugins/Furucombo/UI/InvestmentsView.tsx
+++ b/packages/mask/src/plugins/Furucombo/UI/InvestmentsView.tsx
@@ -217,7 +217,7 @@ export function InvestmentsView(props: InvestmentsProps) {
                         ? investables.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                         : investables
                     ).map((row: Investable) => (
-                        <TableRow key={row.token.address} className={classes.row}>
+                        <TableRow key={row.address} className={classes.row}>
                             <TableCell
                                 className={classes.cell}
                                 component="th"
@@ -231,7 +231,7 @@ export function InvestmentsView(props: InvestmentsProps) {
                                 <Button
                                     className={classes.invest}
                                     size="small"
-                                    href={`${BASE_URL}/${row.category}/${row.chainId}/${row.token.address}`}
+                                    href={`${BASE_URL}/${row.category}/${row.chainId}/${row.address}`}
                                     target="_blank">
                                     {t('plugin_furucombo_invest')}
                                 </Button>

--- a/packages/mask/src/plugins/Furucombo/UI/PoolView.tsx
+++ b/packages/mask/src/plugins/Furucombo/UI/PoolView.tsx
@@ -86,16 +86,7 @@ interface PoolProps {
 export function PoolView(props: PoolProps) {
     const { classes } = useStyles()
     const { t } = useI18N()
-    const {
-        category,
-        chainId,
-        address,
-        name,
-        protocol,
-        liquidity,
-        apy,
-        angels,
-    } = props.investable
+    const { category, chainId, address, name, protocol, liquidity, apy, angels } = props.investable
 
     const displayRewardIcon = (rewardToken: Token) => {
         if (rewardToken.symbol === 'WMATIC') return <WmaticIcon />

--- a/packages/mask/src/plugins/Furucombo/UI/PoolView.tsx
+++ b/packages/mask/src/plugins/Furucombo/UI/PoolView.tsx
@@ -89,7 +89,7 @@ export function PoolView(props: PoolProps) {
     const {
         category,
         chainId,
-        token: { address },
+        address,
         name,
         protocol,
         liquidity,

--- a/packages/mask/src/plugins/Furucombo/types.tsx
+++ b/packages/mask/src/plugins/Furucombo/types.tsx
@@ -12,6 +12,7 @@ export interface Investable {
     stakingToken: Token | null
     strategies: Strategy[]
     swapProtocol: string | null
+    address: string;
     token: Token
     tokens: Token[]
     updatedAt: string

--- a/packages/mask/src/plugins/Furucombo/types.tsx
+++ b/packages/mask/src/plugins/Furucombo/types.tsx
@@ -12,7 +12,7 @@ export interface Investable {
     stakingToken: Token | null
     strategies: Strategy[]
     swapProtocol: string | null
-    address: string;
+    address: string
     token: Token
     tokens: Token[]
     updatedAt: string


### PR DESCRIPTION
Furucombo will release some investable without pool token. So I have update investable.token.address to investable.address. To make sure the plugin is normal.