### PR TITLE
refactor: web3 requirement

### DIFF
--- a/packages/mask/src/components/CompositionDialog/PluginEntryRender.tsx
+++ b/packages/mask/src/components/CompositionDialog/PluginEntryRender.tsx
@@ -1,5 +1,6 @@
 import {
-    useActivatedPluginSNSAdaptor_withSupportOperateChain,
+    usePluginIDContext,
+    useActivatedPluginSNSAdaptor_Web3Supported,
     useActivatedPluginsSNSAdaptor,
     Plugin,
 } from '@masknet/plugin-infra'
@@ -26,7 +27,8 @@ export const PluginEntryRender = memo(
         const [trackPluginRef] = useSetPluginEntryRenderRef(ref)
         const pluginField = usePluginI18NField()
         const chainId = useChainId()
-        const operatingSupportedChainMapping = useActivatedPluginSNSAdaptor_withSupportOperateChain(chainId)
+        const pluginID = usePluginIDContext()
+        const operatingSupportedChainMapping = useActivatedPluginSNSAdaptor_Web3Supported(chainId, pluginID)
         const result = [...useActivatedPluginsSNSAdaptor()]
             .sort((plugin) => {
                 // TODO: support priority order

--- a/packages/mask/src/plugins/ITO/base.ts
+++ b/packages/mask/src/plugins/ITO/base.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@masknet/plugin-infra'
+import { NetworkPluginID, Plugin } from '@masknet/plugin-infra'
 import { ChainId } from '@masknet/web3-shared-evm'
 import { ITO_PluginID } from './constants'
 
@@ -15,14 +15,16 @@ export const base: Plugin.Shared.Definition = {
         networks: { type: 'opt-out', networks: {} },
         target: 'stable',
         web3: {
-            supportedOperationalChains: [
-                ChainId.Mainnet,
-                ChainId.BSC,
-                ChainId.Matic,
-                ChainId.Mumbai,
-                ChainId.Arbitrum,
-                ChainId.xDai,
-            ],
+            [NetworkPluginID.PLUGIN_EVM]: {
+                supportedChainIds: [
+                    ChainId.Mainnet,
+                    ChainId.BSC,
+                    ChainId.Matic,
+                    ChainId.Mumbai,
+                    ChainId.Arbitrum,
+                    ChainId.xDai,
+                ],
+            },
         },
     },
 }

--- a/packages/mask/src/plugins/RedPacket/base.ts
+++ b/packages/mask/src/plugins/RedPacket/base.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@masknet/plugin-infra'
+import { NetworkPluginID, Plugin } from '@masknet/plugin-infra'
 import { ChainId } from '@masknet/web3-shared-evm'
 import { RedPacketPluginID } from './constants'
 
@@ -16,7 +16,9 @@ export const base: Plugin.Shared.Definition = {
         networks: { type: 'opt-out', networks: {} },
         target: 'stable',
         web3: {
-            supportedOperationalChains: [ChainId.Mainnet, ChainId.BSC, ChainId.Matic, ChainId.Arbitrum, ChainId.xDai],
+            [NetworkPluginID.PLUGIN_EVM]: {
+                supportedChainIds: [ChainId.Mainnet, ChainId.BSC, ChainId.Matic, ChainId.Arbitrum, ChainId.xDai],
+            },
         },
     },
 }

--- a/packages/mask/src/plugins/UnlockProtocol/base.ts
+++ b/packages/mask/src/plugins/UnlockProtocol/base.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@masknet/plugin-infra'
+import { NetworkPluginID, Plugin } from '@masknet/plugin-infra'
 import { ChainId } from '@masknet/web3-shared-evm'
 import { pluginDescription, pluginIcon, pluginName, pluginId } from './constants'
 
@@ -13,7 +13,9 @@ export const base: Plugin.Shared.Definition = {
         networks: { type: 'opt-out', networks: {} },
         target: 'stable',
         web3: {
-            supportedOperationalChains: [ChainId.Mainnet, ChainId.xDai, ChainId.Matic, ChainId.Rinkeby],
+            [NetworkPluginID.PLUGIN_EVM]: {
+                supportedChainIds: [ChainId.Mainnet, ChainId.xDai, ChainId.Matic, ChainId.Rinkeby],
+            },
         },
     },
 }

--- a/packages/plugin-infra/src/manager/sns-adaptor.ts
+++ b/packages/plugin-infra/src/manager/sns-adaptor.ts
@@ -3,6 +3,7 @@ import { useSubscription, Subscription } from 'use-subscription'
 import { createManager } from './manage'
 import { getPluginDefine } from './store'
 import type { CurrentSNSNetwork, Plugin } from '../types'
+import type { NetworkPluginID } from '..'
 
 const { events, activated, startDaemon } = createManager((def) => def.SNSAdaptor)
 
@@ -19,11 +20,15 @@ export function useActivatedPluginSNSAdaptor(pluginID: string) {
     return plugins.find((x) => x.ID === pluginID)
 }
 
-export function useActivatedPluginSNSAdaptor_withSupportOperateChain(chainId: number) {
+export function useActivatedPluginSNSAdaptor_Web3Supported(chainId: number, pluginID: string) {
     const plugins = useActivatedPluginsSNSAdaptor()
     return plugins.reduce<Record<string, boolean>>((acc, cur) => {
-        const operatingSupportedChains = cur.enableRequirement.web3?.supportedOperationalChains
-        acc[cur.ID] = !Boolean(operatingSupportedChains) || Boolean(operatingSupportedChains?.includes(chainId))
+        if (!cur.enableRequirement.web3) {
+            acc[cur.ID] = true
+            return acc
+        }
+        const supportedChainIds = cur.enableRequirement.web3?.[pluginID as NetworkPluginID]?.supportedChainIds
+        acc[cur.ID] = supportedChainIds?.includes(chainId) ?? false
         return acc
     }, {})
 }

--- a/packages/plugin-infra/src/types.ts
+++ b/packages/plugin-infra/src/types.ts
@@ -148,6 +148,7 @@ export namespace Plugin.Shared {
         architecture: Record<'app' | 'web', boolean>
         /** The SNS Network this plugin supports. */
         networks: SupportedNetworksDeclare
+        /** The Web3 Network this plugin supports */
         web3?: Web3Plugin.EnableRequirement
     }
     export interface ManagementProperty {

--- a/packages/plugin-infra/src/web3-types.ts
+++ b/packages/plugin-infra/src/web3-types.ts
@@ -2,14 +2,39 @@ import type { BigNumber } from 'bignumber.js'
 import type { Subscription } from 'use-subscription'
 import type { Pagination, Plugin } from './types'
 
+/**
+ * A network plugin defines the way to connect to a single chain.
+ */
+export enum NetworkPluginID {
+    PLUGIN_EVM = 'com.mask.evm',
+    PLUGIN_FLOW = 'com.mask.flow',
+}
+
+export enum CurrencyType {
+    NATIVE = 'native',
+    BTC = 'btc',
+    USD = 'usd',
+}
+
+export enum TokenType {
+    Fungible = 'Fungible',
+    NonFungible = 'NonFungible',
+}
+
 export declare namespace Web3Plugin {
-    export interface EnableRequirement {
-        /**
-         * Plugin can declare what chain it supports to trigger side effects (e.g. create a new transaction).
-         * When the current chain is not supported, the composition entry will be hidden.
-         */
-        supportedOperationalChains?: number[]
-    }
+    /**
+     * Plugin can declare what chain it supports to trigger side effects (e.g. create a new transaction).
+     * When the current chain is not supported, the composition entry will be hidden.
+     */
+    export type EnableRequirement = Partial<
+        Record<
+            NetworkPluginID,
+            {
+                supportedChainIds?: number[]
+            }
+        >
+    >
+
     export interface NetworkDescriptor {
         /** An unique ID for each network */
         ID: string
@@ -289,23 +314,4 @@ export declare namespace Web3Plugin {
             }
         }
     }
-}
-
-/**
- * A network plugin defines the way to connect to a single chain.
- */
-export enum NetworkPluginID {
-    PLUGIN_EVM = 'com.mask.evm',
-    PLUGIN_FLOW = 'com.mask.flow',
-}
-
-export enum CurrencyType {
-    NATIVE = 'native',
-    BTC = 'btc',
-    USD = 'usd',
-}
-
-export enum TokenType {
-    Fungible = 'Fungible',
-    NonFungible = 'NonFungible',
 }


### PR DESCRIPTION
A plugin can declare web3 requirements on various chains. And, from now on, if a plugin has Web3 released features. It must declare the web3 requirements in the definition phase. That information will help the plugin infra conditionally render the plugin UI in various places.

closes #
