### PR TITLE
fix: failed to restore the initial wallet

### DIFF
--- a/packages/mask/src/extension/background-script/WelcomeServices/restoreBackup.ts
+++ b/packages/mask/src/extension/background-script/WelcomeServices/restoreBackup.ts
@@ -8,17 +8,23 @@ import {
     createOrUpdatePersonaDB,
     createOrUpdateProfileDB,
 } from '../../../database/Persona/Persona.db'
+import { currySameAddress } from '@masknet/web3-shared-evm'
 import { PersonaRecordFromJSONFormat } from '../../../utils/type-transform/BackupFormat/JSON/DBRecord-JSON/PersonaRecord'
 import { ProfileRecordFromJSONFormat } from '../../../utils/type-transform/BackupFormat/JSON/DBRecord-JSON/ProfileRecord'
 import { PostRecordFromJSONFormat } from '../../../utils/type-transform/BackupFormat/JSON/DBRecord-JSON/PostRecord'
 import { createOrUpdatePostDB, PostDBAccess } from '../../../database'
 import { WalletRecordFromJSONFormat } from '../../../utils/type-transform/BackupFormat/JSON/DBRecord-JSON/WalletRecord'
-import { recoverWalletFromMnemonic, recoverWalletFromPrivateKey } from '../../../plugins/Wallet/services'
+import {
+    getDerivableAccounts,
+    recoverWalletFromMnemonic,
+    recoverWalletFromPrivateKey,
+} from '../../../plugins/Wallet/services'
 import { activatedPluginsWorker, registeredPluginIDs } from '@masknet/plugin-infra'
 import { Result } from 'ts-results'
 import { addWallet } from '../../../plugins/Wallet/services/wallet/database'
 import { patchCreateNewRelation, patchCreateOrUpdateRelation } from '../IdentityService'
 import { RelationRecordFromJSONFormat } from '../../../utils/type-transform/BackupFormat/JSON/DBRecord-JSON/RelationRecord'
+import { HD_PATH_WITHOUT_INDEX_ETHEREUM } from '@masknet/plugin-wallet'
 
 /**
  * Restore the backup
@@ -54,7 +60,16 @@ export async function restoreBackup(json: object, whoAmI?: ProfileIdentifier) {
             if (record.storedKeyInfo && record.derivationPath)
                 await addWallet(record.address, name, record.derivationPath, record.storedKeyInfo)
             else if (record.privateKey) await recoverWalletFromPrivateKey(name, record.privateKey)
-            else if (record.mnemonic) await recoverWalletFromMnemonic(name, record.mnemonic, record.derivationPath)
+            else if (record.mnemonic) {
+                // fix a backup bug of pre-v2.2.2 versions
+                const accounts = await getDerivableAccounts(record.mnemonic, 1, 5)
+                const index = accounts.findIndex(currySameAddress(record.address))
+                await recoverWalletFromMnemonic(
+                    name,
+                    record.mnemonic,
+                    index > -1 ? `${HD_PATH_WITHOUT_INDEX_ETHEREUM}/${index}` : record.derivationPath,
+                )
+            }
         } catch (error) {
             console.error(error)
         }

--- a/packages/mask/src/plugins/Wallet/services/wallet/index.ts
+++ b/packages/mask/src/plugins/Wallet/services/wallet/index.ts
@@ -206,7 +206,7 @@ export async function deriveWallet(name: string) {
             latestDerivationPath,
         })
 
-        // found a valid candidate, import it by its private key
+        // found a valid candidate, get the private key of it
         const exported = await sdk.exportPrivateKeyOfPath({
             coin: api.Coin.Ethereum,
             password: password_,
@@ -214,6 +214,8 @@ export async function deriveWallet(name: string) {
             StoredKeyData: primaryWallet.storedKeyInfo.data,
         })
         if (!exported?.privateKey) throw new Error(`Failed to export private key at path: ${latestDerivationPath}`)
+
+        // import the candidate by the private key
         return recoverWalletFromPrivateKey(name, exported.privateKey)
     }
 }

--- a/packages/mask/src/plugins/Wallet/services/wallet/index.ts
+++ b/packages/mask/src/plugins/Wallet/services/wallet/index.ts
@@ -171,7 +171,8 @@ export async function deriveWallet(name: string) {
     if (!primaryWallet?.storedKeyInfo) throw new Error('Cannot find the primary wallet.')
 
     let derivedTimes = 0
-    let derivationPath = primaryWallet.derivationPath
+    let latestDerivationPath = primaryWallet.latestDerivationPath ?? primaryWallet.derivationPath
+    if (!latestDerivationPath) throw new Error('Failed to derive wallet without derivation path.')
 
     while (true) {
         derivedTimes += 1
@@ -179,40 +180,40 @@ export async function deriveWallet(name: string) {
         // protect from endless looping
         if (derivedTimes >= MAX_DERIVE_COUNT) {
             await database.updateWallet(primaryWallet.address, {
-                derivationPath,
+                latestDerivationPath,
             })
             throw new Error('Exceed the max derivation times.')
         }
 
         // bump index
-        derivationPath = bumpDerivationPath(derivationPath)
+        latestDerivationPath = bumpDerivationPath(latestDerivationPath)
 
         // derive a new wallet
         const created = await sdk.createAccountOfCoinAtPath({
             coin: api.Coin.Ethereum,
             name,
             password: password_,
-            derivationPath,
+            derivationPath: latestDerivationPath,
             StoredKeyData: primaryWallet.storedKeyInfo.data,
         })
-        if (!created?.account?.address) throw new Error(`Failed to create account at path: ${derivationPath}.`)
+        if (!created?.account?.address) throw new Error(`Failed to create account at path: ${latestDerivationPath}.`)
 
         // check its existence in DB
         if (await database.hasWallet(created.account.address)) continue
 
         // update the primary wallet
         await database.updateWallet(primaryWallet.address, {
-            derivationPath,
+            latestDerivationPath,
         })
 
         // found a valid candidate, import it by its private key
         const exported = await sdk.exportPrivateKeyOfPath({
             coin: api.Coin.Ethereum,
             password: password_,
-            derivationPath,
+            derivationPath: latestDerivationPath,
             StoredKeyData: primaryWallet.storedKeyInfo.data,
         })
-        if (!exported?.privateKey) throw new Error(`Failed to export private key at path: ${derivationPath}`)
+        if (!exported?.privateKey) throw new Error(`Failed to export private key at path: ${latestDerivationPath}`)
         return recoverWalletFromPrivateKey(name, exported.privateKey)
     }
 }

--- a/packages/mask/src/plugins/Wallet/services/wallet/type.ts
+++ b/packages/mask/src/plugins/Wallet/services/wallet/type.ts
@@ -26,6 +26,7 @@ export interface WalletRecord extends Omit<Wallet, 'configurable' | 'hasStoredKe
     id: string
     type: 'wallet'
     derivationPath?: string
+    latestDerivationPath?: string
     storedKeyInfo?: api.IStoredKeyInfo
     createdAt: Date
     updatedAt: Date


### PR DESCRIPTION
Avoid updating the `derivationPath` of the wallet record, use `latestDerivationPath` to serve the same purpose.
closes #5111
