### PR TITLE
fix: popup's position is too low when do image payload on Facebook

### DIFF
--- a/packages/mask/src/components/InjectedComponents/PageInspector.tsx
+++ b/packages/mask/src/components/InjectedComponents/PageInspector.tsx
@@ -46,7 +46,7 @@ export function PageInspector(props: PageInspectorProps) {
                                   vertical: 'bottom',
                                   horizontal: 'center',
                               }
-                            : { horizontal: 'left', vertical: 'bottom' },
+                            : { horizontal: 'right', vertical: 'top' },
                         key,
                         action: <></>,
                     },


### PR DESCRIPTION
<!-- Please refer to the related issue number -->
closes #5047
