### PR TITLE
fix: should keep login status when restore persona which not have private key

### DIFF
--- a/packages/dashboard/src/locales/en-US.json
+++ b/packages/dashboard/src/locales/en-US.json
@@ -86,6 +86,8 @@
     "wallet_transfer_error_no_address_has_been_set_name": "The address of the receiver is invalid.",
     "wallet_transfer_error_no_ens_support": "Network does not support ENS.",
     "wallets_transfer_error_insufficient_balance": "Insufficient {{symbol}} balance",
+    "wallets_transfer_error_same_address_with_current_account": "This receiving address is the same as the sending address. Please check again.",
+    "wallets_transfer_error_is_contract_address": "The receiving address is contract address. Please check again.",
     "wallets_transfer_send": "Send",
     "wallets_transfer_memo_placeholder": "Optional message",
     "wallets_transfer_contract": "Contract",

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
@@ -118,15 +118,23 @@ export const TransferERC721 = memo(() => {
 
     const allFormFields = watch()
 
+    //#region resolve ENS domain
+    const {
+        value: registeredAddress = '',
+        error: resolveDomainError,
+        loading: resolveDomainLoading,
+    } = useLookupAddress(allFormFields.recipient, NetworkPluginID.PLUGIN_EVM)
+    //#endregion
+
     //#region check contract address and account address
     useAsync(async () => {
         const recipient = allFormFields.recipient
         setRecipientError(null)
-        if (!recipient) return
-        if (!isValidAddress(recipient)) return
+        if (!recipient && !registeredAddress) return
+        if (!isValidAddress(recipient) && !isValidAddress(registeredAddress)) return
 
         clearErrors()
-        if (isSameAddress(recipient, account)) {
+        if (isSameAddress(recipient, account) || isSameAddress(registeredAddress, account)) {
             setRecipientError({
                 type: 'account',
                 message: t.wallets_transfer_error_same_address_with_current_account(),
@@ -139,15 +147,7 @@ export const TransferERC721 = memo(() => {
                 message: t.wallets_transfer_error_is_contract_address(),
             })
         }
-    }, [allFormFields.recipient, clearErrors])
-    //#endregion
-
-    //#region resolve ENS domain
-    const {
-        value: registeredAddress = '',
-        error: resolveDomainError,
-        loading: resolveDomainLoading,
-    } = useLookupAddress(allFormFields.recipient, NetworkPluginID.PLUGIN_EVM)
+    }, [allFormFields.recipient, clearErrors, registeredAddress])
     //#endregion
 
     const erc721GasLimit = useGasLimit(

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
@@ -8,6 +8,7 @@ import {
     EthereumTokenType,
     formatWeiToEther,
     isSameAddress,
+    isValidAddress,
     TransactionStateType,
     useAccount,
     useChainId,
@@ -37,8 +38,9 @@ import { unionBy } from 'lodash-unified'
 import { TransferTab } from './types'
 import { NetworkPluginID, useLookupAddress, useNetworkDescriptor, useWeb3State } from '@masknet/plugin-infra'
 import { NetworkType } from '@masknet/public-api'
-import { useUpdateEffect } from 'react-use'
+import { useAsync, useUpdateEffect } from 'react-use'
 import { multipliedBy } from '@masknet/web3-shared-base'
+import { Services } from '../../../../API'
 
 const useStyles = makeStyles()((theme) => ({
     disabled: {
@@ -65,6 +67,10 @@ export const TransferERC721 = memo(() => {
     const [defaultToken, setDefaultToken] = useState<ERC721TokenDetailed | null>(null)
     const navigate = useNavigate()
     const [popoverOpen, setPopoverOpen] = useState(false)
+    const [recipientError, setRecipientError] = useState<{
+        type: 'account' | 'contractAddress'
+        message: string
+    } | null>(null)
     const [minPopoverWidth, setMinPopoverWidth] = useState(0)
     const [contract, setContract] = useState<ERC721ContractDetailed>()
     const [offset, setOffset] = useState(0)
@@ -111,6 +117,30 @@ export const TransferERC721 = memo(() => {
     }, [state])
 
     const allFormFields = watch()
+
+    //#region check contract address and account address
+    useAsync(async () => {
+        const recipient = allFormFields.recipient
+        setRecipientError(null)
+        if (!recipient) return
+        if (!isValidAddress(recipient)) return
+
+        clearErrors()
+        if (isSameAddress(recipient, account)) {
+            setRecipientError({
+                type: 'account',
+                message: t.wallets_transfer_error_same_address_with_current_account(),
+            })
+        }
+        const result = await Services.Ethereum.getCode(recipient)
+        if (result !== '0x') {
+            setRecipientError({
+                type: 'contractAddress',
+                message: t.wallets_transfer_error_is_contract_address(),
+            })
+        }
+    }, [allFormFields.recipient, clearErrors])
+    //#endregion
 
     //#region resolve ENS domain
     const {
@@ -275,8 +305,11 @@ export const TransferERC721 = memo(() => {
                                     {...field}
                                     required
                                     onChange={(e) => setValue('recipient', e.currentTarget.value)}
-                                    helperText={errors.recipient?.message}
-                                    error={!!errors.recipient}
+                                    helperText={errors.recipient?.message || recipientError?.message}
+                                    error={
+                                        !!errors.recipient ||
+                                        (!!recipientError && recipientError.type === 'contractAddress')
+                                    }
                                     value={field.field.value}
                                     InputProps={{
                                         onClick: (event) => {

--- a/packages/mask/background/database/persona/db.ts
+++ b/packages/mask/background/database/persona/db.ts
@@ -308,11 +308,16 @@ export async function createOrUpdatePersonaDB(
     t: PersonasTransaction<'readwrite'>,
 ) {
     const personaInDB = await t.objectStore('personas').get(record.identifier.toText())
+
+    if (howToMerge.protectPrivateKey && !!personaInDB?.privateKey && !record.privateKey) return
+
     if (howToMerge.protectPrivateKey && !!personaInDB?.privateKey) {
         const nextRecord = personaRecordOutDB(personaInDB)
         nextRecord.hasLogout = false
+
         return updatePersonaDB(nextRecord, howToMerge, t)
     }
+
     if (personaInDB) return updatePersonaDB(record, howToMerge, t)
     else
         return createPersonaDB(

--- a/packages/web3-shared/evm/hooks/useERC721TokenTransferCallback.ts
+++ b/packages/web3-shared/evm/hooks/useERC721TokenTransferCallback.ts
@@ -33,7 +33,7 @@ export function useERC721TokenTransferCallback(address?: string) {
             // error: invalid ownership
             const ownerOf = await erc721Contract.methods.ownerOf(tokenId).call()
 
-            if (!ownerOf || !isSameAddress(ownerOf, account) || isSameAddress(ownerOf, recipient)) {
+            if (!ownerOf || !isSameAddress(ownerOf, account)) {
                 setTransferState({
                     type: TransactionStateType.FAILED,
                     error: new Error('Invalid ownership'),


### PR DESCRIPTION
1. Should keep login status when restore persona which not have private key
2. User can send NFT to self in dashboard
