### PR TITLE
refactor: the separated connection status

### DIFF
--- a/packages/dashboard/src/pages/Wallets/components/AddCollectibleDialog/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/AddCollectibleDialog/index.tsx
@@ -4,6 +4,7 @@ import { Box, Button, DialogActions, DialogContent } from '@mui/material'
 import {
     EthereumTokenType,
     isSameAddress,
+    useChainId,
     useERC721ContractDetailed,
     useERC721TokenDetailedCallback,
     useWallet,
@@ -32,6 +33,7 @@ enum FormErrorType {
 
 export const AddCollectibleDialog = memo<AddCollectibleDialogProps>(({ open, onClose }) => {
     const wallet = useWallet()
+    const chainId = useChainId()
     const [address, setAddress] = useState('')
     const { value: contractDetailed, loading: contractDetailLoading } = useERC721ContractDetailed(address)
     const [tokenId, setTokenId, erc721TokenDetailedCallback] = useERC721TokenDetailedCallback(contractDetailed)
@@ -39,7 +41,7 @@ export const AddCollectibleDialog = memo<AddCollectibleDialogProps>(({ open, onC
     const onSubmit = useCallback(async () => {
         if (contractDetailLoading || !wallet) return
 
-        const tokenInDB = await PluginServices.Wallet.getToken(EthereumTokenType.ERC721, address, tokenId)
+        const tokenInDB = await PluginServices.Wallet.getToken(chainId, EthereumTokenType.ERC721, address, tokenId)
         if (tokenInDB) throw new Error(FormErrorType.Added)
 
         const tokenDetailed = await erc721TokenDetailedCallback()

--- a/packages/dashboard/stories/components/Persona/PersonaSetup.tsx
+++ b/packages/dashboard/stories/components/Persona/PersonaSetup.tsx
@@ -1,6 +1,7 @@
 import { story } from '@masknet/storybook-shared'
 import { PersonaSetup as C } from '../../../src/pages/Personas/components/PersonaSetup'
 import { action } from '@storybook/addon-actions'
+import { SocialNetworkID } from '../../../../mask/shared'
 
 const { meta, of } = story(C)
 
@@ -10,7 +11,7 @@ export default meta({
 
 export const PersonaSetup = of({
     args: {
-        networkIdentifier: 'twitter.com',
+        networkIdentifier: SocialNetworkID.Twitter,
         onConnect: action('onConnect'),
     },
 })

--- a/packages/dashboard/stories/components/Persona/UnconnectedPersonaLine.tsx
+++ b/packages/dashboard/stories/components/Persona/UnconnectedPersonaLine.tsx
@@ -1,6 +1,7 @@
 import { story } from '@masknet/storybook-shared'
 import { UnconnectedPersonaLine as C } from '../../../src/pages/Personas/components/PersonaLine'
 import { action } from '@storybook/addon-actions'
+import { SocialNetworkID } from '../../../../mask/shared'
 
 const { meta, of } = story(C)
 
@@ -10,7 +11,7 @@ export default meta({
 
 export const UnconnectedPersonaLine = of({
     args: {
-        networkIdentifier: 'twitter',
+        networkIdentifier: SocialNetworkID.Twitter,
         onConnect: action('onConnect'),
     },
 })

--- a/packages/mask/shared/index.ts
+++ b/packages/mask/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './messages'
+export * from './types'
 export * from './flags'
 export { InMemoryStorages, PersistentStorages } from './kv-storage'
 export * from './helpers/download'

--- a/packages/mask/shared/types.ts
+++ b/packages/mask/shared/types.ts
@@ -1,0 +1,8 @@
+export enum SocialNetworkID {
+    Dashboard = 'localhost.dashboard',
+    BrowserAction = 'localhost.browser_action',
+    Twitter = 'twitter.com',
+    Facebook = 'facebook.com',
+    Minds = 'minds.com',
+    Instagram = 'instagram.com',
+}

--- a/packages/mask/src/components/InjectedComponents/CommentBox.tsx
+++ b/packages/mask/src/components/InjectedComponents/CommentBox.tsx
@@ -2,7 +2,7 @@ import { makeStyles } from '@masknet/theme'
 import { InputBase, Box } from '@mui/material'
 import { useI18N } from '../../utils'
 import { activatedSocialNetworkUI } from '../../social-network'
-import { MINDS_ID } from '../../social-network-adaptor/minds.com/base'
+import { SocialNetworkID } from '../../../shared'
 
 interface StyleProps {
     snsId: string
@@ -13,7 +13,7 @@ const useStyles = makeStyles<StyleProps>()((theme, { snsId }) => ({
         flex: 1,
         fontSize: 13,
         background: '#3a3b3c',
-        width: snsId === MINDS_ID ? '96%' : '100%',
+        width: snsId === SocialNetworkID.Minds ? '96%' : '100%',
         height: 34,
         borderRadius: 20,
         padding: '2px 1em',

--- a/packages/mask/src/components/shared/InjectedDialog.tsx
+++ b/packages/mask/src/components/shared/InjectedDialog.tsx
@@ -20,8 +20,7 @@ import { isDashboardPage } from '@masknet/shared-base'
 import { useI18N, usePortalShadowRoot } from '../../utils'
 import { DialogDismissIconUI } from '../InjectedComponents/DialogDismissIcon'
 import { activatedSocialNetworkUI } from '../../social-network'
-import { MINDS_ID } from '../../social-network-adaptor/minds.com/base'
-import { FACEBOOK_ID } from '../../social-network-adaptor/facebook.com/base'
+import { SocialNetworkID } from '../../../shared'
 
 interface StyleProps {
     snsId: string
@@ -41,7 +40,9 @@ const useStyles = makeStyles<StyleProps>()((theme, { snsId }) => ({
         color: theme.palette.text.primary,
     },
     paper: {
-        ...(snsId === MINDS_ID || snsId === FACEBOOK_ID ? { width: 'auto', backgroundImage: 'none' } : {}),
+        ...(snsId === SocialNetworkID.Minds || snsId === SocialNetworkID.Facebook
+            ? { width: 'auto', backgroundImage: 'none' }
+            : {}),
     },
 }))
 

--- a/packages/mask/src/extension/popups/components/NetworkSelector/index.tsx
+++ b/packages/mask/src/extension/popups/components/NetworkSelector/index.tsx
@@ -2,14 +2,12 @@ import { memo, useCallback } from 'react'
 import { Box, MenuItem, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { Flags } from '../../../../../shared'
-import { ChainId, ProviderType, useAccount } from '@masknet/web3-shared-evm'
+import { ChainId, ProviderType, useAccount, useChainId, useProviderType } from '@masknet/web3-shared-evm'
 import { getRegisteredWeb3Networks, NetworkPluginID, Web3Plugin } from '@masknet/plugin-infra'
 import {
     currentMaskWalletAccountSettings,
-    currentMaskWalletChainIdSettings,
-    currentProviderSettings,
 } from '../../../../plugins/Wallet/settings'
-import { ChainIcon, useMenu, useValueRef, WalletIcon } from '@masknet/shared'
+import { ChainIcon, useMenu, WalletIcon } from '@masknet/shared'
 import { ArrowDownRound } from '@masknet/icons'
 import { WalletRPC } from '../../../../plugins/Wallet/messages'
 
@@ -49,8 +47,8 @@ const useStyles = makeStyles()((theme) => ({
 export const NetworkSelector = memo(() => {
     const networks = getRegisteredWeb3Networks()
     const account = useAccount()
-    const currentChainId = useValueRef(currentMaskWalletChainIdSettings)
-    const currentProvider = useValueRef(currentProviderSettings)
+    const currentChainId = useChainId()
+    const currentProvider = useProviderType()
     const onChainChange = useCallback(
         async (chainId: ChainId) => {
             if (currentProvider === ProviderType.MaskWallet) {

--- a/packages/mask/src/extension/popups/pages/Personas/components/ProfileList/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Personas/components/ProfileList/index.tsx
@@ -69,7 +69,7 @@ export const ProfileList = memo(() => {
 
     const definedSocialNetworks = compact(
         [...definedSocialNetworkUIs.values()].map(({ networkIdentifier }) => {
-            if (networkIdentifier === 'localhost') return null
+            if (networkIdentifier.includes('localhost')) return null
             return networkIdentifier
         }),
     )

--- a/packages/mask/src/extension/popups/pages/Personas/components/ProfileList/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Personas/components/ProfileList/index.tsx
@@ -69,7 +69,7 @@ export const ProfileList = memo(() => {
 
     const definedSocialNetworks = compact(
         [...definedSocialNetworkUIs.values()].map(({ networkIdentifier }) => {
-            if (networkIdentifier.includes('localhost')) return null
+            if (networkIdentifier.startsWith('localhost')) return null
             return networkIdentifier
         }),
     )

--- a/packages/mask/src/extension/popups/pages/Wallet/ContractInteraction/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/ContractInteraction/index.tsx
@@ -15,8 +15,9 @@ import {
     useChainId,
     useERC20TokenDetailed,
     useNativeTokenDetailed,
+    useNetworkType,
 } from '@masknet/web3-shared-evm'
-import { FormattedBalance, FormattedCurrency, TokenIcon, useValueRef } from '@masknet/shared'
+import { FormattedBalance, FormattedCurrency, TokenIcon, } from '@masknet/shared'
 import { Link, Typography } from '@mui/material'
 import { useI18N } from '../../../../../utils'
 import { PopupRoutes } from '@masknet/shared-base'
@@ -24,7 +25,6 @@ import { LoadingButton } from '@mui/lab'
 import { unreachable } from '@dimensiondev/kit'
 import { WalletRPC } from '../../../../../plugins/Wallet/messages'
 import Services from '../../../../service'
-import { currentNetworkSettings } from '../../../../../plugins/Wallet/settings'
 import BigNumber from 'bignumber.js'
 import { useNativeTokenPrice, useTokenPrice } from '../../../../../plugins/Wallet/hooks/useTokenPrice'
 import { LoadingPlaceholder } from '../../../components/LoadingPlaceholder'
@@ -136,7 +136,7 @@ const ContractInteraction = memo(() => {
     const location = useLocation()
     const history = useHistory()
     const chainId = useChainId()
-    const networkType = useValueRef(currentNetworkSettings)
+    const networkType = useNetworkType()
     const [transferError, setTransferError] = useState(false)
     const { value: request, loading: requestLoading } = useUnconfirmedRequest()
 

--- a/packages/mask/src/extension/popups/pages/Wallet/GasSetting/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/GasSetting/index.tsx
@@ -1,12 +1,10 @@
 import { memo } from 'react'
 import { makeStyles } from '@masknet/theme'
 import { Typography } from '@mui/material'
-import { useValueRef } from '@masknet/shared'
-import { NetworkType } from '@masknet/web3-shared-evm'
+import { NetworkType, useNetworkType } from '@masknet/web3-shared-evm'
 import { useI18N } from '../../../../../utils'
 import { GasSetting1559 } from './GasSetting1559'
 import { Prior1559GasSetting } from './Prior1559GasSetting'
-import { currentNetworkSettings } from '../../../../../plugins/Wallet/settings'
 
 const useStyles = makeStyles()(() => ({
     container: {
@@ -30,7 +28,7 @@ const useStyles = makeStyles()(() => ({
 const GasSetting = memo(() => {
     const { t } = useI18N()
     const { classes } = useStyles()
-    const networkType = useValueRef(currentNetworkSettings)
+    const networkType = useNetworkType()
     return (
         <main className={classes.container}>
             <Typography className={classes.title}>{t('popups_wallet_gas_fee_settings')}</Typography>

--- a/packages/mask/src/extension/popups/pages/Wallet/ReplaceTransaction/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/ReplaceTransaction/index.tsx
@@ -12,9 +12,8 @@ import {
     getChainIdFromNetworkType,
     isEIP1559Supported,
     useNativeTokenDetailed,
+    useNetworkType,
 } from '@masknet/web3-shared-evm'
-import { useValueRef } from '@masknet/shared'
-import { currentNetworkSettings } from '../../../../../plugins/Wallet/settings'
 import BigNumber from 'bignumber.js'
 import { useI18N } from '../../../../../utils'
 import { hexToNumber, toHex } from 'web3-utils'
@@ -79,7 +78,7 @@ const ReplaceTransaction = memo(() => {
 
     const { value: nativeToken } = useNativeTokenDetailed()
     const nativeTokenPrice = useNativeTokenPrice(nativeToken?.chainId)
-    const networkType = useValueRef(currentNetworkSettings)
+    const networkType = useNetworkType()
     const is1559 = isEIP1559Supported(getChainIdFromNetworkType(networkType))
 
     const schema = useMemo(() => {

--- a/packages/mask/src/extension/popups/pages/Wallet/Transfer/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/Transfer/index.tsx
@@ -1,11 +1,10 @@
 import { memo, useMemo, useState } from 'react'
 import { makeStyles } from '@masknet/theme'
-import { formatBalance, NetworkType, ProviderType, useWallets } from '@masknet/web3-shared-evm'
+import { formatBalance, NetworkType, ProviderType, useNetworkType, useWallets } from '@masknet/web3-shared-evm'
 import { MenuItem, Typography } from '@mui/material'
-import { FormattedBalance, TokenIcon, useMenu, useValueRef } from '@masknet/shared'
+import { FormattedBalance, TokenIcon, useMenu } from '@masknet/shared'
 import { useContainer } from 'unstated-next'
 import { WalletContext } from '../hooks/useWalletContext'
-import { currentNetworkSettings } from '../../../../../plugins/Wallet/settings'
 import { Transfer1559 } from './Transfer1559'
 import { Prior1559Transfer } from './Prior1559Transfer'
 
@@ -26,7 +25,7 @@ const useStyles = makeStyles()({
 
 const Transfer = memo(() => {
     const { classes } = useStyles()
-    const networkType = useValueRef(currentNetworkSettings)
+    const networkType = useNetworkType()
     const wallets = useWallets(ProviderType.MaskWallet)
     const { assets, currentToken } = useContainer(WalletContext)
     const [selectedAsset, setSelectedAsset] = useState(currentToken)

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/CompositionDialog.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/CompositionDialog.tsx
@@ -19,8 +19,8 @@ import { ConfirmDialog } from './ConfirmDialog'
 import { WalletMessages } from '../../Wallet/messages'
 import { omit, set } from 'lodash-unified'
 import { useCompositionContext } from '../../../components/CompositionDialog/CompositionContext'
-import { MINDS_ID } from '../../../social-network-adaptor/minds.com/base'
 import { activatedSocialNetworkUI } from '../../../social-network'
+import { SocialNetworkID } from '../../../../shared'
 
 interface StyleProps {
     snsId: string
@@ -28,7 +28,7 @@ interface StyleProps {
 
 const useStyles = makeStyles<StyleProps>()((theme, { snsId }) => ({
     content: {
-        ...(snsId === MINDS_ID ? { minWidth: 600 } : {}),
+        ...(snsId === SocialNetworkID.Minds ? { minWidth: 600 } : {}),
         position: 'relative',
         paddingTop: 50,
     },

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/ITO.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/ITO.tsx
@@ -41,9 +41,9 @@ import { StyledLinearProgress } from './StyledLinearProgress'
 import { SwapGuide, SwapStatus } from './SwapGuide'
 import urlcat from 'urlcat'
 import { startCase } from 'lodash-unified'
-import { FACEBOOK_ID } from '../../../social-network-adaptor/facebook.com/base'
 import { isFacebook } from '../../../social-network-adaptor/facebook.com/base'
 import { isTwitter } from '../../../social-network-adaptor/twitter.com/base'
+import { SocialNetworkID } from '../../../../shared'
 
 export interface IconProps {
     size?: number
@@ -77,8 +77,8 @@ const useStyles = makeStyles<StyleProps>()((theme, props) => ({
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'end',
-        width: props.snsId === FACEBOOK_ID ? '98%' : '100%',
-        maxWidth: props.snsId === FACEBOOK_ID ? 'auto' : 470,
+        width: props.snsId === SocialNetworkID.Facebook ? '98%' : '100%',
+        maxWidth: props.snsId === SocialNetworkID.Facebook ? 'auto' : 470,
     },
     title: {
         fontSize: props.titleLength! > 31 ? '1.3rem' : '1.6rem',
@@ -124,7 +124,7 @@ const useStyles = makeStyles<StyleProps>()((theme, props) => ({
     footer: {
         position: 'absolute',
         width: '90%',
-        maxWidth: props.snsId === FACEBOOK_ID ? 'auto' : 470,
+        maxWidth: props.snsId === SocialNetworkID.Facebook ? 'auto' : 470,
         bottom: theme.spacing(2),
         display: 'flex',
         justifyContent: 'space-between',

--- a/packages/mask/src/plugins/MaskBox/SNSAdaptor/components/TokenCard.tsx
+++ b/packages/mask/src/plugins/MaskBox/SNSAdaptor/components/TokenCard.tsx
@@ -1,7 +1,12 @@
-import { makeStyles } from '@masknet/theme'
-import { ERC721ContractDetailed, NonFungibleAssetProvider, useERC721TokenDetailed } from '@masknet/web3-shared-evm'
-import { Typography } from '@mui/material'
 import { memo } from 'react'
+import { makeStyles } from '@masknet/theme'
+import { Typography } from '@mui/material'
+import {
+    ChainId,
+    ERC721ContractDetailed,
+    NonFungibleAssetProvider,
+    useERC721TokenDetailed,
+} from '@masknet/web3-shared-evm'
 import { CollectibleCard } from '../../../../extension/options-page/DashboardComponents/CollectibleList/CollectibleCard'
 
 const useStyles = makeStyles()((theme) => ({
@@ -27,6 +32,8 @@ export const TokenCard = memo<TokenCardProps>((props: TokenCardProps) => {
     const { classes } = useStyles()
     const {
         value: tokenDetailed = {
+            // TODO: read from currentChainIdSettings
+            chainId: ChainId.Mainnet,
             tokenId,
             contractDetailed,
             info: {},

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryList.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryList.tsx
@@ -1,9 +1,9 @@
+import { useRef, useState } from 'react'
+import classNames from 'classnames'
 import { useScrollBottomEvent } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
-import classNames from 'classnames'
 import { ERC721ContractDetailed, useAccount, useChainId } from '@masknet/web3-shared-evm'
 import { List, Popper, Typography } from '@mui/material'
-import { useRef, useState } from 'react'
 import type { NftRedPacketHistory } from '../types'
 import { useNftRedPacketHistory } from './hooks/useNftRedPacketHistory'
 import { NftRedPacketHistoryItem } from './NftRedPacketHistoryItem'
@@ -77,7 +77,7 @@ export function NftRedPacketHistoryList({ onSend }: Props) {
     const { t } = useI18N()
     const account = useAccount()
     const chainId = useChainId()
-    const { histories, fetchMore, loading } = useNftRedPacketHistory(account, chainId)
+    const { histories, fetchMore, loading } = useNftRedPacketHistory(chainId, account)
     const containerRef = useRef(null)
     const [popperText, setPopperText] = useState('')
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketCreateNew.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketCreateNew.tsx
@@ -3,10 +3,10 @@ import { RedPacketFormProps, RedPacketERC20Form } from './RedPacketERC20Form'
 import { RedPacketERC721Form } from './RedPacketERC721Form'
 import AbstractTab, { AbstractTabProps } from '../../../components/shared/AbstractTab'
 import { useI18N } from '../../../utils'
-import { MINDS_ID } from '../../../social-network-adaptor/minds.com/base'
 import { activatedSocialNetworkUI } from '../../../social-network'
 
 import { IconURLs } from './IconURL'
+import { SocialNetworkID } from '../../../../shared'
 
 interface StyleProps {
     snsId: string
@@ -21,7 +21,7 @@ const useStyles = makeStyles<StyleProps>()((theme, { snsId }) => ({
     tabs: {
         height: 36,
         minHeight: 36,
-        margin: `0 ${snsId === MINDS_ID ? '12px' : 'auto'}`,
+        margin: `0 ${snsId === SocialNetworkID.Minds ? '12px' : 'auto'}`,
         borderRadius: 4,
         backgroundColor: theme.palette.background.default,
         '& .Mui-selected': {

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/hooks/useNftRedPacketHistory.ts
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/hooks/useNftRedPacketHistory.ts
@@ -3,13 +3,13 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { RedPacketRPC } from '../../messages'
 import type { NftRedPacketHistory } from '../../types'
 
-export function useNftRedPacketHistory(address: string, chainId: ChainId) {
+export function useNftRedPacketHistory(chainId: ChainId, address: string) {
     const [allHistories, setAllHistories] = useState<NftRedPacketHistory[]>([])
     const pageRef = useRef(1)
     const [loading, setLoading] = useState(false)
 
     const getHistories = useCallback(async () => {
-        const histories = await RedPacketRPC.getNftRedPacketHistory(address, chainId, pageRef.current)
+        const histories = await RedPacketRPC.getNftRedPacketHistory(chainId, address, pageRef.current)
         setLoading(false)
         if (histories.length) {
             pageRef.current += 1

--- a/packages/mask/src/plugins/RedPacket/Worker/apis/nftRedpacket.ts
+++ b/packages/mask/src/plugins/RedPacket/Worker/apis/nftRedpacket.ts
@@ -1,8 +1,7 @@
-import { EthereumTokenType, getChainName, getNftRedPacketConstants } from '@masknet/web3-shared-evm'
+import { ChainId, EthereumTokenType, getChainName, getNftRedPacketConstants } from '@masknet/web3-shared-evm'
 import stringify from 'json-stable-stringify'
 import { first, pick } from 'lodash-unified'
 import { tokenIntoMask } from '../../../ITO/SNSAdaptor/helpers'
-import { currentChainIdSettings } from '../../../Wallet/settings'
 import type {
     NftRedPacketHistory,
     NftRedPacketJSONPayload,
@@ -62,8 +61,8 @@ const RED_PACKET_FIELDS = `
     }
 `
 
-async function fetchFromNFTRedPacketSubgraph<T>(query: string) {
-    const subgraphURL = getNftRedPacketConstants(currentChainIdSettings.value).SUBGRAPH_URL
+async function fetchFromNFTRedPacketSubgraph<T>(chainId: ChainId, query: string) {
+    const subgraphURL = getNftRedPacketConstants(chainId).SUBGRAPH_URL
     if (!subgraphURL) return null
     const response = await fetch(subgraphURL, {
         method: 'POST',
@@ -76,20 +75,25 @@ async function fetchFromNFTRedPacketSubgraph<T>(query: string) {
     return data
 }
 
-export async function getNftRedPacketTxid(rpid: string) {
-    const data = await fetchFromNFTRedPacketSubgraph<{ redPackets: NftRedPacketSubgraphOutMask[] }>(`
+export async function getNftRedPacketTxid(chainId: ChainId, rpid: string) {
+    const data = await fetchFromNFTRedPacketSubgraph<{ redPackets: NftRedPacketSubgraphOutMask[] }>(
+        chainId,
+        `
     {
         nftredPackets (where: { rpid: "${rpid.toLowerCase()}" }) {
             ${RED_PACKET_FIELDS}
         }
     }
-    `)
+    `,
+    )
     return first(data?.redPackets)?.txid
 }
 
 const PAGE_SIZE = 5
-export async function getNftRedPacketHistory(address: string, page: number) {
-    const data = await fetchFromNFTRedPacketSubgraph<{ nftredPackets: NftRedPacketSubgraphOutMask[] }>(`
+export async function getNftRedPacketHistory(chainId: ChainId, address: string, page: number) {
+    const data = await fetchFromNFTRedPacketSubgraph<{ nftredPackets: NftRedPacketSubgraphOutMask[] }>(
+        chainId,
+        `
     {
         nftredPackets (
           where: { creator: "${address.toLowerCase()}" },
@@ -101,7 +105,8 @@ export async function getNftRedPacketHistory(address: string, page: number) {
             ${RED_PACKET_FIELDS}
         }
     }
-    `)
+    `,
+    )
     if (!data?.nftredPackets) return []
     return data.nftredPackets.map((x) => {
         const nftRedPacketSubgraphInMask = {

--- a/packages/mask/src/plugins/RedPacket/Worker/services.ts
+++ b/packages/mask/src/plugins/RedPacket/Worker/services.ts
@@ -49,8 +49,8 @@ export async function getRedPacketHistory(address: string, chainId: ChainId, end
     //#endregion
 }
 
-export async function getNftRedPacketHistory(address: string, chainId: ChainId, page: number) {
-    const histories = await subgraph.getNftRedPacketHistory(address, page)
+export async function getNftRedPacketHistory(chainId: ChainId, address: string, page: number) {
+    const histories = await subgraph.getNftRedPacketHistory(chainId, address, page)
     const historiesWithPassword = []
     for (const history of histories) {
         const record = await nftDb.getRedPacketNft(history.txid)

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/Trader.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/Trader.tsx
@@ -193,20 +193,15 @@ export function Trader(props: TraderProps) {
         }
 
         if (chainId && currentProvider && currentAccount) {
-            const cacheBalance = currentBalancesSettings.value[currentProvider]?.[chainId]
+            let balance = currentBalancesSettings.value[chainId]
 
-            let balance: string
-
-            if (cacheBalance) balance = cacheBalance
-            else {
+            if (!balance) {
                 balance = await Services.Ethereum.getBalance(currentAccount, {
                     chainId: chainId,
                     providerType: currentProvider,
                 })
                 await WalletRPC.updateBalances({
-                    [currentProvider]: {
-                        [chainId]: balance,
-                    },
+                    [chainId]: balance,
                 })
             }
 

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TraderDialog.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TraderDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { ChainId, getChainIdFromNetworkType, useChainId, useChainIdValid } from '@masknet/web3-shared-evm'
+import { useUpdateEffect } from 'react-use'
+import { ChainId, getChainIdFromNetworkType, NetworkType, useChainId, useChainIdValid } from '@masknet/web3-shared-evm'
 import { DialogContent } from '@mui/material'
 import { InjectedDialog } from '../../../../components/shared/InjectedDialog'
 import { useRemoteControlledDialog } from '@masknet/shared'
@@ -11,9 +12,8 @@ import { useI18N } from '../../../../utils'
 import { makeStyles, MaskColorVar } from '@masknet/theme'
 import { WalletStatusBox } from '../../../../components/shared/WalletStatusBox'
 import { NetworkTab } from '../../../../components/shared/NetworkTab'
-import { useAsync, useUpdateEffect } from 'react-use'
-import { WalletRPC } from '../../../Wallet/messages'
 import { isDashboardPage } from '@masknet/shared-base'
+import { getEnumAsArray } from '@dimensiondev/kit'
 
 const useStyles = makeStyles<{ isDashboard: boolean }>()((theme, { isDashboard }) => ({
     walletStatusBox: {
@@ -68,8 +68,8 @@ interface TraderDialogProps {
 }
 
 export function TraderDialog({ open, onClose }: TraderDialogProps) {
-    const isDashboard = isDashboardPage()
     const { t } = useI18N()
+    const isDashboard = isDashboardPage()
     const { classes } = useStyles({ isDashboard })
     const currentChainId = useChainId()
     const chainIdValid = useChainIdValid()
@@ -82,11 +82,7 @@ export function TraderDialog({ open, onClose }: TraderDialogProps) {
             if (ev?.traderProps) setTraderProps(ev.traderProps)
         },
     )
-
-    const { value: chains } = useAsync(async () => {
-        const networks = await WalletRPC.getSupportedNetworks()
-        return networks.map((network) => getChainIdFromNetworkType(network))
-    }, [])
+    const chains = getEnumAsArray(NetworkType).map(({ value }) => getChainIdFromNetworkType(value))
 
     useEffect(() => {
         if (!chainIdValid) closeDialog()

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/SelectTokenDialog.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/SelectTokenDialog.tsx
@@ -9,8 +9,8 @@ import { WalletMessages } from '../../Wallet/messages'
 import { useI18N } from '../../../utils'
 import { ERC20TokenList, ERC20TokenListProps, useRemoteControlledDialog } from '@masknet/shared'
 import { delay } from '@masknet/shared-base'
-import { MINDS_ID } from '../../../social-network-adaptor/minds.com/base'
 import { activatedSocialNetworkUI } from '../../../social-network'
+import { SocialNetworkID } from '../../../../shared'
 
 interface StyleProps {
     snsId: string
@@ -19,7 +19,7 @@ interface StyleProps {
 
 const useStyles = makeStyles<StyleProps>()((theme, { snsId, isDashboard }) => ({
     content: {
-        ...(snsId === MINDS_ID ? { minWidth: 552 } : {}),
+        ...(snsId === SocialNetworkID.Minds ? { minWidth: 552 } : {}),
         padding: theme.spacing(3),
         paddingTop: isDashboard ? 0 : theme.spacing(2.8),
     },

--- a/packages/mask/src/plugins/Wallet/services/account.ts
+++ b/packages/mask/src/plugins/Wallet/services/account.ts
@@ -18,7 +18,6 @@ import {
 } from '../settings'
 import { getWallets, hasWallet, updateWallet } from './wallet'
 import { hasNativeAPI, nativeAPI } from '../../../utils'
-import { Flags } from '../../../../shared'
 
 export async function updateAccount(
     options: {
@@ -115,14 +114,4 @@ export async function setDefaultWallet() {
             account: address,
             providerType: ProviderType.MaskWallet,
         })
-}
-
-export async function getSupportedNetworks() {
-    return [
-        NetworkType.Ethereum,
-        Flags.bsc_enabled ? NetworkType.Binance : undefined,
-        Flags.polygon_enabled ? NetworkType.Polygon : undefined,
-        Flags.arbitrum_enabled ? NetworkType.Arbitrum : undefined,
-        Flags.xdai_enabled ? NetworkType.xDai : undefined,
-    ].filter(Boolean) as NetworkType[]
 }

--- a/packages/mask/src/plugins/Wallet/services/chain.ts
+++ b/packages/mask/src/plugins/Wallet/services/chain.ts
@@ -1,4 +1,4 @@
-import { uniq, throttle } from 'lodash-unified'
+import { throttle } from 'lodash-unified'
 import { BalanceOfChains, BlockNumberOfChains, ProviderType } from '@masknet/web3-shared-evm'
 import { pollingTask } from '@masknet/shared-base'
 import { getBalance, getBlockNumber, resetAllNonce } from '../../../extension/background-script/EthereumService'

--- a/packages/mask/src/plugins/Wallet/services/transaction/database.ts
+++ b/packages/mask/src/plugins/Wallet/services/transaction/database.ts
@@ -2,7 +2,6 @@ import { uniqBy } from 'lodash-unified'
 import type { JsonRpcPayload } from 'web3-core-helpers'
 import { WalletMessages } from '@masknet/plugin-wallet'
 import { ChainId, formatEthereumAddress } from '@masknet/web3-shared-evm'
-import { currentChainIdSettings } from '../../settings'
 import { PluginDB } from '../../database/Plugin.db'
 
 export const MAX_RECENT_TRANSACTIONS_SIZE = 20
@@ -90,7 +89,7 @@ export async function removeRecentTransaction(chainId: ChainId, address: string,
     await PluginDB.add({
         type: 'recent-transactions',
         id: recordId,
-        chainId: currentChainIdSettings.value,
+        chainId,
         address: formatEthereumAddress(address),
         transactions: chunk.transactions.filter((x) => x.hash !== hash),
         createdAt: chunk.createdAt,

--- a/packages/mask/src/plugins/Wallet/services/wallet/index.ts
+++ b/packages/mask/src/plugins/Wallet/services/wallet/index.ts
@@ -25,7 +25,7 @@ export {
     getToken,
     getTokens,
     getTokensCount,
-    getTokensPaged,
+    getTokensByPagination,
     hasToken,
     addToken,
     removeToken,

--- a/packages/mask/src/plugins/Wallet/settings.ts
+++ b/packages/mask/src/plugins/Wallet/settings.ts
@@ -10,6 +10,7 @@ import {
     ProviderType,
     LockStatus,
     BalanceOfChains,
+    BlockNumberOfChains,
 } from '@masknet/web3-shared-evm'
 import { PLUGIN_IDENTIFIER } from './constants'
 import { isEqual } from 'lodash-unified'
@@ -60,6 +61,11 @@ export const currentAccountSettings = createGlobalSettings<string>(`${PLUGIN_IDE
     primary: () => 'DO NOT DISPLAY IT IN UI',
 })
 
+export const currentChainIdSettings = createGlobalSettings<number>(`${PLUGIN_IDENTIFIER}+chainId`, ChainId.Mainnet, {
+    primary: () => i18n.t('settings_choose_eth_network'),
+    secondary: () => 'This only affects the built-in wallet.',
+})
+
 export const currentNetworkSettings = createGlobalSettings<NetworkType>(
     `${PLUGIN_IDENTIFIER}+selectedWalletNetwork`,
     NetworkType.Ethereum,
@@ -94,14 +100,18 @@ export const currentNonFungibleAssetDataProviderSettings = createGlobalSettings<
     },
 )
 
-export const currentChainIdSettings = createGlobalSettings<number>(`${PLUGIN_IDENTIFIER}+chainId`, ChainId.Mainnet, {
-    primary: () => i18n.t('settings_choose_eth_network'),
-    secondary: () => 'This only affects the built-in wallet.',
-})
-
 export const currentBlockNumberSettings = createGlobalSettings<number>(`${PLUGIN_IDENTIFIER}+blockNumber`, 0, {
     primary: () => 'DO NOT DISPLAY IT IN UI',
 })
+
+export const currentBlockNumbersSettings = createGlobalSettings<BlockNumberOfChains>(
+    `${PLUGIN_IDENTIFIER}+blockNumbers`,
+    {},
+    {
+        primary: () => 'DO NOT DISPLAY IT IN UI',
+    },
+    (a, b) => isEqual(a, b),
+)
 
 export const currentBalanceSettings = createGlobalSettings<string>(`${PLUGIN_IDENTIFIER}+balance`, '0', {
     primary: () => 'DO NOT DISPLAY IT IN UI',

--- a/packages/mask/src/settings/createSettings.ts
+++ b/packages/mask/src/settings/createSettings.ts
@@ -111,7 +111,7 @@ export function createSocialNetworkSettings<T extends browser.storage.StorageVal
 ) {
     const cached: SocialNetworkSettings<T> = {}
 
-    // setup inital value
+    // setup initial value
     getEnumAsArray(SocialNetworkID).forEach(({ value }) => {
         cached[value] = createInternalSettings(`${value}+${settingsKey}`, defaultValue)
     })

--- a/packages/mask/src/settings/settings.ts
+++ b/packages/mask/src/settings/settings.ts
@@ -1,10 +1,11 @@
-import { createGlobalSettings, createNetworkSettings, NetworkSettings } from './createSettings'
+import { createGlobalSettings, createSocialNetworkSettings, SocialNetworkSettings } from './createSettings'
 import { i18n } from '../../shared-ui/locales_legacy'
 import { LaunchPage } from './types'
 import { Appearance } from '@masknet/theme'
 import { LanguageOptions } from '@masknet/public-api'
 import { Identifier, ProfileIdentifier } from '@masknet/shared-base'
 import { PLUGIN_ID } from '../plugins/EVM/constants'
+import { ChainId, NetworkType, ProviderType } from '@masknet/web3-shared-evm'
 
 /**
  * Does the debug mode on
@@ -43,28 +44,21 @@ export const pluginIDSettings = createGlobalSettings<string>('pluginID', PLUGIN_
 //#endregion
 
 //#region network setting
+export const currentSelectedIdentity: SocialNetworkSettings<string> = createSocialNetworkSettings(
+    'currentSelectedIdentity',
+    '',
+)
 
-/**
- * Expected Usage：export const currentImagePayloadStatus = createNetworkSettings('currentImagePayloadStatus')
- *
- * Work around the issue:
- *      https://github.com/microsoft/TypeScript/issues/42873
- *      https://github.com/microsoft/TypeScript/issues/30858
- *
- * References:
- *      PluginGitcoinMessages: packages/mask/src/plugins/Gitcoin/messages.ts
- *      PluginTraderMessages: packages/mask/src/plugins/Trader/messages.ts
- *      PluginTransakMessages: packages/mask/src/plugins/Transak/messages.ts
- */
-export const currentImagePayloadStatus: NetworkSettings<string> = createNetworkSettings('currentImagePayloadStatus', '')
-export const currentSelectedIdentity: NetworkSettings<string> = createNetworkSettings('currentSelectedIdentity', '')
 export function getCurrentSelectedIdentity(network: string) {
     return Identifier.fromString<ProfileIdentifier>(currentSelectedIdentity[network].value, ProfileIdentifier).unwrapOr(
         ProfileIdentifier.unknown,
     )
 }
-export const currentSetupGuideStatus: NetworkSettings<string> = createNetworkSettings('currentSetupGuideStatus', '')
-export const userGuideStatus: NetworkSettings<string> = createNetworkSettings('userGuideStatus', '')
+export const currentSetupGuideStatus: SocialNetworkSettings<string> = createSocialNetworkSettings(
+    'currentSetupGuideStatus',
+    '',
+)
+export const userGuideStatus: SocialNetworkSettings<string> = createSocialNetworkSettings('userGuideStatus', '')
 // This is a misuse of concept "NetworkSettings" as "namespaced settings"
 // The refactor is tracked in https://github.com/DimensionDev/Maskbook/issues/1884
 /**
@@ -73,7 +67,29 @@ export const userGuideStatus: NetworkSettings<string> = createNetworkSettings('u
  * use `useActivatedPluginsSNSAdaptor().find((x) => x.ID === PLUGIN_ID)` or
  * `useActivatedPluginsDashboard().find((x) => x.ID === PLUGIN_ID)` instead
  */
-export const currentPluginEnabledStatus: NetworkSettings<boolean> = createNetworkSettings('pluginsEnabled', true)
+export const currentPluginEnabledStatus: SocialNetworkSettings<boolean> = createSocialNetworkSettings(
+    'pluginsEnabled',
+    true,
+)
+//#endregion
+
+//#region web3 network settings
+export const currentAccountSettings: SocialNetworkSettings<string> = createSocialNetworkSettings(
+    'currentAccountSettings',
+    '',
+)
+export const currentChainIdSettings: SocialNetworkSettings<number> = createSocialNetworkSettings(
+    'currentChainIdSettings',
+    ChainId.Mainnet,
+)
+export const currentNetworkSettings: SocialNetworkSettings<string> = createSocialNetworkSettings(
+    'currentNetworkSettings',
+    NetworkType.Ethereum,
+)
+export const currentProviderSettings: SocialNetworkSettings<string> = createSocialNetworkSettings(
+    'currentProviderSettings',
+    ProviderType.MaskWallet,
+)
 //#endregion
 
 export const launchPageSettings = createGlobalSettings<LaunchPage>('launchPage', LaunchPage.dashboard, {

--- a/packages/mask/src/social-network-adaptor/browser-action/index.ts
+++ b/packages/mask/src/social-network-adaptor/browser-action/index.ts
@@ -1,9 +1,10 @@
-import { defineSocialNetworkUI, definedSocialNetworkUIs, SocialNetworkUI, SocialNetwork } from '../../social-network'
-import { isEnvironment, Environment, ValueRef } from '@dimensiondev/holoflows-kit'
 import { IdentifierMap } from '@masknet/shared-base'
+import { isEnvironment, Environment, ValueRef } from '@dimensiondev/holoflows-kit'
+import { SocialNetworkID } from '../../../shared'
+import { defineSocialNetworkUI, definedSocialNetworkUIs, SocialNetworkUI, SocialNetwork } from '../../social-network'
 
 const base: SocialNetwork.Base = {
-    networkIdentifier: 'localhost',
+    networkIdentifier: SocialNetworkID.BrowserAction,
     name: '',
     declarativePermissions: { origins: [] },
     shouldActivate(location) {
@@ -35,7 +36,7 @@ const define: SocialNetworkUI.Definition = {
         if (activeTab === undefined) return state
         const location = new URL(activeTab.url || globalThis.location.href)
         for (const ui of definedSocialNetworkUIs.values()) {
-            if (ui.shouldActivate(location) && ui.networkIdentifier !== 'localhost') {
+            if (ui.shouldActivate(location) && ui.networkIdentifier !== SocialNetworkID.BrowserAction) {
                 const _ = (await ui.load()).default
                 if (signal.aborted) return state
                 // TODO: heck, this is not what we expected.

--- a/packages/mask/src/social-network-adaptor/facebook.com/base.ts
+++ b/packages/mask/src/social-network-adaptor/facebook.com/base.ts
@@ -1,19 +1,19 @@
+import { SocialNetworkID } from '../../../shared'
 import type { SocialNetwork, SocialNetworkWorker } from '../../social-network/types'
 
 const origins = ['https://www.facebook.com/*', 'https://m.facebook.com/*', 'https://facebook.com/*']
 
-export const FACEBOOK_ID = 'facebook.com'
 export const facebookBase: SocialNetwork.Base = {
-    networkIdentifier: FACEBOOK_ID,
+    networkIdentifier: SocialNetworkID.Facebook,
     name: 'facebook',
     declarativePermissions: { origins },
     shouldActivate(location) {
-        return location.hostname.endsWith(FACEBOOK_ID)
+        return location.hostname.endsWith(SocialNetworkID.Facebook)
     },
 }
 
 export function isFacebook(ui: SocialNetwork.Base) {
-    return ui.networkIdentifier === FACEBOOK_ID
+    return ui.networkIdentifier === SocialNetworkID.Facebook
 }
 
 export const facebookWorkerBase: SocialNetworkWorker.WorkerBase & SocialNetwork.Base = {

--- a/packages/mask/src/social-network-adaptor/facebook.com/utils/resolveFacebookLink.ts
+++ b/packages/mask/src/social-network-adaptor/facebook.com/utils/resolveFacebookLink.ts
@@ -1,5 +1,5 @@
-import { FACEBOOK_ID } from '../base'
+import { SocialNetworkID } from '../../../../shared'
 
 export function resolveFacebookLink(link: string, id: string) {
-    return id === FACEBOOK_ID ? link.replace(/\?fbclid=[\S\s]*#/, '#') : link
+    return id === SocialNetworkID.Facebook ? link.replace(/\?fbclid=[\S\s]*#/, '#') : link
 }

--- a/packages/mask/src/social-network-adaptor/instagram.com/base.ts
+++ b/packages/mask/src/social-network-adaptor/instagram.com/base.ts
@@ -1,17 +1,17 @@
+import { SocialNetworkID } from '../../../shared'
 import type { SocialNetwork, SocialNetworkWorker } from '../../social-network/types'
 
-const id = 'instagram.com'
 const origins = ['https://www.instagram.com/*', 'https://m.instagram.com/*', 'https://instagram.com/*']
 export const instagramBase: SocialNetwork.Base = {
-    networkIdentifier: id,
+    networkIdentifier: SocialNetworkID.Instagram,
     name: 'instagram',
     declarativePermissions: { origins },
     shouldActivate(location) {
-        return location.host.endsWith(id)
+        return location.host.endsWith(SocialNetworkID.Instagram)
     },
     notReadyForProduction: true,
 }
 export const instagramWorkerBase: SocialNetworkWorker.WorkerBase & SocialNetwork.Base = {
     ...instagramBase,
-    gunNetworkHint: id,
+    gunNetworkHint: SocialNetworkID.Instagram,
 }

--- a/packages/mask/src/social-network-adaptor/minds.com/base.ts
+++ b/packages/mask/src/social-network-adaptor/minds.com/base.ts
@@ -1,9 +1,9 @@
+import { SocialNetworkID } from '../../../shared'
 import type { SocialNetwork, SocialNetworkWorker } from '../../social-network/types'
 
-export const MINDS_ID = 'minds.com'
 const origins = ['https://www.minds.com/*', 'https://minds.com/*', 'https://cdn.minds.com/*']
 export const mindsBase: SocialNetwork.Base = {
-    networkIdentifier: MINDS_ID,
+    networkIdentifier: SocialNetworkID.Minds,
     name: 'minds',
     declarativePermissions: { origins },
     shouldActivate(location) {
@@ -12,7 +12,7 @@ export const mindsBase: SocialNetwork.Base = {
 }
 
 export function isMinds(ui: SocialNetwork.Base) {
-    return ui.networkIdentifier === MINDS_ID
+    return ui.networkIdentifier === SocialNetworkID.Minds
 }
 
 export const mindsWorkerBase: SocialNetworkWorker.WorkerBase & SocialNetwork.Base = {

--- a/packages/mask/src/social-network-adaptor/twitter.com/base.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/base.ts
@@ -1,9 +1,9 @@
+import { SocialNetworkID } from '../../../shared'
 import type { SocialNetwork, SocialNetworkWorker } from '../../social-network/types'
 
-const id = 'twitter.com'
 const origins = ['https://mobile.twitter.com/*', 'https://twitter.com/*']
 export const twitterBase: SocialNetwork.Base = {
-    networkIdentifier: id,
+    networkIdentifier: SocialNetworkID.Twitter,
     name: 'twitter',
     declarativePermissions: { origins },
     shouldActivate(location) {
@@ -12,7 +12,7 @@ export const twitterBase: SocialNetwork.Base = {
 }
 
 export function isTwitter(ui: SocialNetwork.Base) {
-    return ui.networkIdentifier === id
+    return ui.networkIdentifier === SocialNetworkID.Twitter
 }
 
 export const twitterWorkerBase: SocialNetworkWorker.WorkerBase & SocialNetwork.Base = {

--- a/packages/mask/src/social-network/ui.ts
+++ b/packages/mask/src/social-network/ui.ts
@@ -2,7 +2,7 @@ import '../utils/debug/general'
 import '../utils/debug/ui'
 import Services from '../extension/service'
 import { untilDomLoaded } from '../utils/dom'
-import { Flags } from '../../shared'
+import { Flags, SocialNetworkID } from '../../shared'
 import i18nNextInstance from '../../shared-ui/locales_legacy'
 import type { SocialNetworkUI } from './types'
 import { managedStateCreator } from './utils'
@@ -31,7 +31,7 @@ export let activatedSocialNetworkUI: SocialNetworkUI.Definition = {
         throw new Error()
     },
     injection: {},
-    networkIdentifier: 'localhost',
+    networkIdentifier: SocialNetworkID.Dashboard,
     name: '',
     shouldActivate: () => false,
     utils: { createPostContext: null! },

--- a/packages/web3-shared/evm/hooks/useERC721TokenDetailedOwnerList.ts
+++ b/packages/web3-shared/evm/hooks/useERC721TokenDetailedOwnerList.ts
@@ -140,6 +140,7 @@ export async function getERC721TokenDetailedOwnerListFromOpensea(
 
     return assets.map(
         (asset): ERC721TokenDetailed => ({
+            chainId,
             tokenId: asset.token_id,
             contractDetailed: contractDetailed ?? {
                 type: EthereumTokenType.ERC721,

--- a/packages/web3-shared/evm/types/index.ts
+++ b/packages/web3-shared/evm/types/index.ts
@@ -29,9 +29,11 @@ export interface BalanceOfChainRecord {
 }
 
 export interface BalanceOfChains {
-    [provider: string]: {
-        [chainId: number]: string
-    }
+    [chainId: string]: string
+}
+
+export interface BlockNumberOfChains {
+    [chainId: string]: number
 }
 
 // bigint is not in our list. iOS doesn't support that.
@@ -170,6 +172,7 @@ export interface ERC721TokenDetailed {
     tokenId: string
     info: ERC721TokenInfo
     contractDetailed: ERC721ContractDetailed
+    chainId: ChainId
 }
 
 export interface ERC721TokenRecordInDatabase extends ERC721TokenDetailed {

--- a/packages/web3-shared/evm/utils/token.ts
+++ b/packages/web3-shared/evm/utils/token.ts
@@ -80,6 +80,7 @@ export function createERC721Token(
         contractDetailed,
         info,
         tokenId,
+        chainId: contractDetailed.chainId,
     }
 }
 


### PR DESCRIPTION
This PR makes each SNS website maintains its web3 state rather than sharing with the global state. It's more intuitive. Also, it may introduce a problem: the users may get lost if they connect too many different accounts on different websites. We may refactor the UI later to make it easier to use upon this integration.

### TODOs

+ [ ] No more read settings by accessing theirs `value` directly.
+ [x] Refactor web3 related settings as network settings.
+ [ ] Read web3 related settings in hooks with the current SNS network ID. Since we need each SNS website to read its web3 state. No more state sharing between them. It will help us to resolve some long-existing problems. E.g., The user has to switch Twitter's account settings on the dashboard page.
+ [ ] MetaMask: On the front page, use the injected one; on the background page, use the extension bridge.
+ [ ] WalletConnect: Use different instance for these two pages.


<!-- Please refer to the related issue number -->
closes #
