### PR TITLE
fix: stringify hook dependency

### DIFF
--- a/packages/web3-shared/evm/hooks/useERC721TokenDetailed.ts
+++ b/packages/web3-shared/evm/hooks/useERC721TokenDetailed.ts
@@ -29,7 +29,7 @@ export function useERC721TokenDetailed(
                 hasTokenDetailed: true,
                 name: info.name ?? tokenDetailedRef.current.info.name,
             }
-    }, [tokenId, contractDetailed, erc721TokenContract, GET_SINGLE_ASSET_URL])
+    }, [tokenId, JSON.stringify(contractDetailed), erc721TokenContract, GET_SINGLE_ASSET_URL])
 
     return { asyncRetry, tokenDetailed: tokenDetailedRef.current }
 }


### PR DESCRIPTION
## Description
`JSON.stringify()` hook object type dependency to avoid infinite calling NFT red packet ERC721 method.

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
