### PR TITLE
fix: walkaround of GeckoView's JSON serialization bug by stringifying the JSON object

### DIFF
--- a/packages/mask/src/extension/background-script/EthereumServices/send.ts
+++ b/packages/mask/src/extension/background-script/EthereumServices/send.ts
@@ -512,7 +512,13 @@ export async function INTERNAL_nativeSend(
         payload.method = EthereumMethodType.ETH_GET_TRANSACTION_RECEIPT
 
     try {
-        const response = await nativeAPI?.api.send(payload)
+        let response: JsonRpcResponse | undefined
+        if (nativeAPI?.type === 'Android') {
+            const jsonResponse = await nativeAPI?.api.sendJsonString(JSON.stringify(payload))
+            response = JSON.parse(jsonResponse)
+        } else {
+            response = await nativeAPI?.api.send(payload)
+        }
         callback(null, response)
         if (payload.method === EthereumMethodType.ETH_SEND_TRANSACTION) {
             handleNonce(chainIdFinally, account, null, response)

--- a/packages/public-api/src/mobile.ts
+++ b/packages/public-api/src/mobile.ts
@@ -19,4 +19,6 @@ export interface iOSNativeAPIs extends SharedNativeAPIs {}
 /**
  * APIs that only implemented by Android Mask Network
  */
-export interface AndroidNativeAPIs extends SharedNativeAPIs {}
+export interface AndroidNativeAPIs extends SharedNativeAPIs {
+    sendJsonString(payload: string): Promise<string>
+}


### PR DESCRIPTION
Due to GeckoView's bug

> GeckoView fails to serialize a JSON object with a nested array while communicating between JS and native, this makes the native side CANNOT receive some messages from `public-api`

This PR introduces a walkaround of stringifying the JSON before sending it to the message channel.
Tested positive on Android