### PR TITLE
fix: guarding gas config in useTransactionCallback

### DIFF
--- a/packages/mask/src/plugins/MaskBox/SNSAdaptor/components/DrawDialog.tsx
+++ b/packages/mask/src/plugins/MaskBox/SNSAdaptor/components/DrawDialog.tsx
@@ -254,7 +254,7 @@ export function DrawDialog(props: DrawDialogProps) {
                                 </Typography>
                                 <Box className={classes.content}>
                                     <GasSettingBar
-                                        gasLimit={openBoxTransactionGasLimit}
+                                        gasLimit={openBoxTransactionGasLimit || 0}
                                         onChange={setOpenBoxTransactionOverrides}
                                     />
                                 </Box>

--- a/packages/mask/src/plugins/MaskBox/SNSAdaptor/components/DrawDialog.tsx
+++ b/packages/mask/src/plugins/MaskBox/SNSAdaptor/components/DrawDialog.tsx
@@ -9,7 +9,6 @@ import {
     formatBalance,
     formatEthereumAddress,
     useAccount,
-    useProviderType,
     useChainId,
     useMaskBoxConstants,
     EthereumTokenType,
@@ -115,7 +114,6 @@ export function DrawDialog(props: DrawDialogProps) {
     const providerDescriptor = useProviderDescriptor()
     const account = useAccount()
     const chainId = useChainId()
-    const providerType = useProviderType()
 
     const onCount = useCallback(
         (step: number) => {

--- a/packages/mask/src/plugins/MaskBox/helpers/formatCountdown.ts
+++ b/packages/mask/src/plugins/MaskBox/helpers/formatCountdown.ts
@@ -3,5 +3,5 @@ import intervalToDuration from 'date-fns/intervalToDuration'
 
 export function formatCountdown(from: number, to: number) {
     const duration = intervalToDuration({ start: from, end: to })
-    return formatDuration(duration, { zero: true })
+    return formatDuration(duration)
 }

--- a/packages/mask/src/plugins/MaskBox/helpers/formatCountdown.ts
+++ b/packages/mask/src/plugins/MaskBox/helpers/formatCountdown.ts
@@ -13,20 +13,16 @@ const units = [
 export function formatCountdown(countdown: number) {
     if (countdown <= 0) return ''
 
-    const amounts: number[] = []
+    const segs: string[] = []
 
-    ;[msPerDay, msPerHour, msPerMinute, msPerSecond].reduce((accumulator, x) => {
-        amounts.push(Math.floor(accumulator / x))
+    ;[msPerDay, msPerHour, msPerMinute, msPerSecond].reduce((accumulator, x, index, list) => {
+        const isLast = index === list.length - 1
+        const value = isLast ? Math.ceil(accumulator / x) : Math.floor(accumulator / x)
+        if (segs.length !== 0 || value !== 0) {
+            segs.push(`${value} ${units[index][value === 1 ? 0 : 1]}`)
+        }
         return accumulator % x
     }, countdown)
 
-    return amounts
-        .map((x, i) => {
-            if (x <= 0) return ''
-            if (x === 1) return `${x} ${units[i][0]}`
-            return `${x} ${units[i][1]}`
-        })
-        .filter(Boolean)
-        .join(' ')
-        .trim()
+    return segs.join(' ')
 }

--- a/packages/mask/src/plugins/MaskBox/helpers/formatCountdown.ts
+++ b/packages/mask/src/plugins/MaskBox/helpers/formatCountdown.ts
@@ -1,28 +1,7 @@
-const msPerSecond = 1000
-const msPerMinute = msPerSecond * 60
-const msPerHour = msPerMinute * 60
-const msPerDay = msPerHour * 24
+import formatDuration from 'date-fns/formatDuration'
+import intervalToDuration from 'date-fns/intervalToDuration'
 
-const units = [
-    ['day', 'days'],
-    ['hour', 'hours'],
-    ['minute', 'minutes'],
-    ['second', 'seconds'],
-]
-
-export function formatCountdown(countdown: number) {
-    if (countdown <= 0) return ''
-
-    const segs: string[] = []
-
-    ;[msPerDay, msPerHour, msPerMinute, msPerSecond].reduce((accumulator, x, index, list) => {
-        const isLast = index === list.length - 1
-        const value = isLast ? Math.ceil(accumulator / x) : Math.floor(accumulator / x)
-        if (segs.length !== 0 || value !== 0) {
-            segs.push(`${value} ${units[index][value === 1 ? 0 : 1]}`)
-        }
-        return accumulator % x
-    }, countdown)
-
-    return segs.join(' ')
+export function formatCountdown(from: number, to: number) {
+    const duration = intervalToDuration({ start: from, end: to })
+    return formatDuration(duration, { zero: true })
 }

--- a/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
+++ b/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
@@ -92,8 +92,8 @@ function useContext(initialState?: { boxId: string }) {
         const totalComputed = total && remaining && remaining > total ? remaining : total
         const sold = Math.max(0, totalComputed - remaining)
         const personalRemaining = Math.max(0, personalLimit - purchasedTokens.length)
-        const startAt = Number.parseInt(maskBoxCreationSuccessEvent?.returnValues.start_time ?? '0', 10)
-        const endAt = Number.parseInt(maskBoxCreationSuccessEvent?.returnValues.end_time ?? '0', 10)
+        const startAt = Number.parseInt(maskBoxCreationSuccessEvent?.returnValues.start_time || '0', 10)
+        const endAt = Number.parseInt(maskBoxCreationSuccessEvent?.returnValues.end_time || '0', 10)
         const info: BoxInfo = {
             boxId,
             creator: maskBoxInfo.creator,
@@ -186,7 +186,7 @@ function useContext(initialState?: { boxId: string }) {
             default:
                 unreachable(boxState)
         }
-    }, [boxState, heartBit])
+    }, [boxState, boxInfo?.startAt, heartBit])
     //#endregion
 
     //#region the box metadata

--- a/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
+++ b/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
@@ -253,8 +253,8 @@ function useContext(initialState?: { boxId: string }) {
     const canPurchase = !isBalanceInsufficient && isQualified && !!boxInfo?.personalRemaining
     const allowToPurchase = boxState === BoxState.READY
     const isAllowanceEnough = isNativeToken ? true : costAmount.lte(erc20Allowance ?? '0')
-    const { value: openBoxTransactionGasLimit = 0 } = useAsyncRetry(async () => {
-        if (!openBoxTransaction || !canPurchase || !allowToPurchase || !isAllowanceEnough) return 0
+    const { value: openBoxTransactionGasLimit } = useAsyncRetry(async () => {
+        if (!openBoxTransaction || !canPurchase || !allowToPurchase || !isAllowanceEnough) return
         const estimatedGas = await openBoxTransaction.method.estimateGas(omit(openBoxTransaction.config, 'gas'))
         return new BigNumber(estimatedGas).toNumber()
     }, [openBoxTransaction, canPurchase, allowToPurchase, isAllowanceEnough])

--- a/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
+++ b/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
@@ -35,12 +35,13 @@ import { useMaskBoxPurchasedTokens } from './useMaskBoxPurchasedTokens'
 import { formatCountdown } from '../helpers/formatCountdown'
 import { useOpenBoxTransaction } from './useOpenBoxTransaction'
 import { useMaskBoxMetadata } from './useMaskBoxMetadata'
-import { useHeartBit } from './useHeartBit'
+import { useHeartBeat } from './useHeartBeat'
 import { useIsWhitelisted } from './useIsWhitelisted'
 import { isGreaterThanOrEqualTo, isLessThanOrEqualTo, isZero, multipliedBy } from '@masknet/web3-shared-base'
 
 function useContext(initialState?: { boxId: string }) {
-    const heartBit = useHeartBit()
+    const now = new Date()
+    const heartBeat = useHeartBeat()
     const account = useAccount()
     const chainId = useChainId()
     const { NATIVE_TOKEN_ADDRESS } = useTokenConstants(ChainId.Mainnet)
@@ -139,13 +140,12 @@ function useContext(initialState?: { boxId: string }) {
         if (maskBoxInfo && !boxInfo) return BoxState.UNKNOWN
         if (!maskBoxInfo || !maskBoxStatus || !boxInfo) return BoxState.NOT_FOUND
         if (maskBoxStatus.canceled) return BoxState.CANCELED
-        const now = new Date()
         if (isGreaterThanOrEqualTo(boxInfo.tokenIdsPurchased.length, boxInfo.personalLimit)) return BoxState.DRAWED_OUT
         if (isLessThanOrEqualTo(boxInfo.remaining, 0)) return BoxState.SOLD_OUT
         if (boxInfo.startAt > now) return BoxState.NOT_READY
         if (boxInfo.endAt < now || maskBoxStatus?.expired) return BoxState.EXPIRED
         return BoxState.READY
-    }, [boxInfo, loadingBoxInfo, errorBoxInfo, maskBoxInfo, loadingMaskBoxInfo, errorMaskBoxInfo, heartBit])
+    }, [boxInfo, loadingBoxInfo, errorBoxInfo, maskBoxInfo, loadingMaskBoxInfo, errorMaskBoxInfo, heartBeat])
 
     const isWhitelisted = useIsWhitelisted(boxInfo?.qualificationAddress, account)
     const isQualifiedByContract =
@@ -170,10 +170,10 @@ function useContext(initialState?: { boxId: string }) {
             case BoxState.EXPIRED:
                 return 'Ended'
             case BoxState.NOT_READY:
-                const now = Date.now()
+                const nowAt = now.getTime()
                 const startAt = boxInfo?.startAt.getTime() ?? 0
-                if (startAt <= now) return 'Loading...'
-                const countdown = formatCountdown(startAt, now)
+                if (startAt <= nowAt) return 'Loading...'
+                const countdown = formatCountdown(startAt, nowAt)
                 return countdown ? `Start sale in ${countdown}` : 'Loading...'
             case BoxState.SOLD_OUT:
                 return 'Sold Out'
@@ -186,7 +186,7 @@ function useContext(initialState?: { boxId: string }) {
             default:
                 unreachable(boxState)
         }
-    }, [boxState, boxInfo?.startAt, heartBit])
+    }, [boxState, boxInfo?.startAt, heartBeat])
     //#endregion
 
     //#region the box metadata

--- a/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
+++ b/packages/mask/src/plugins/MaskBox/hooks/useContext.ts
@@ -173,7 +173,7 @@ function useContext(initialState?: { boxId: string }) {
                 const now = Date.now()
                 const startAt = boxInfo?.startAt.getTime() ?? 0
                 if (startAt <= now) return 'Loading...'
-                const countdown = formatCountdown(startAt - now)
+                const countdown = formatCountdown(startAt, now)
                 return countdown ? `Start sale in ${countdown}` : 'Loading...'
             case BoxState.SOLD_OUT:
                 return 'Sold Out'

--- a/packages/mask/src/plugins/MaskBox/hooks/useHeartBeat.ts
+++ b/packages/mask/src/plugins/MaskBox/hooks/useHeartBeat.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTimeoutFn } from 'react-use'
 
-export function useHeartBit(delay = 1000) {
+export function useHeartBeat(delay = 1000) {
     const [bit, setBit] = useState(0)
     const [, , reset] = useTimeoutFn(() => {
         setBit((x) => (x + 1) % Number.MAX_SAFE_INTEGER)

--- a/packages/mask/src/plugins/MaskBox/type.ts
+++ b/packages/mask/src/plugins/MaskBox/type.ts
@@ -47,6 +47,7 @@ export interface BoxInfo {
     sold: number
     startAt: Date
     endAt: Date
+    started: boolean
     tokenIds: string[]
     tokenIdsPurchased: string[]
     tokenAddress: string

--- a/packages/web3-shared/evm/hooks/useTransactionCallback.ts
+++ b/packages/web3-shared/evm/hooks/useTransactionCallback.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { omit } from 'lodash-unified'
 import type { PayableTransactionObject, PayableTx } from '@masknet/web3-contracts/types/types'
 import { useTransactionState } from './useTransactionState'
 import { TransactionStateType, TransactionEventType } from '../types'
@@ -24,7 +25,7 @@ export function useTransactionCallback<T extends unknown>(
         const gasExpectedConfig = { ...config }
 
         try {
-            const estimatedGas = await method.estimateGas(config)
+            const estimatedGas = await method.estimateGas(omit(config, 'gas'))
             if (!gasExpectedConfig.gas && estimatedGas) {
                 gasExpectedConfig.gas = estimatedGas
             }

--- a/packages/web3-shared/evm/hooks/useTransactionCallback.ts
+++ b/packages/web3-shared/evm/hooks/useTransactionCallback.ts
@@ -21,9 +21,13 @@ export function useTransactionCallback<T extends unknown>(
         setState({
             type: TransactionStateType.WAIT_FOR_CONFIRMING,
         })
+        const gasExpectedConfig = { ...config }
 
         try {
-            await method.estimateGas(config)
+            const estimatedGas = await method.estimateGas(config)
+            if (!gasExpectedConfig.gas && estimatedGas) {
+                gasExpectedConfig.gas = estimatedGas
+            }
         } catch (error) {
             try {
                 await method.call(config)
@@ -38,7 +42,7 @@ export function useTransactionCallback<T extends unknown>(
 
         return new Promise<void>(async (resolve, reject) => {
             method
-                .send(config)
+                .send(gasExpectedConfig)
                 .once(TransactionEventType.TRANSACTION_HASH, (hash) => {
                     if (type !== TransactionStateType.HASH) return
                     setState({


### PR DESCRIPTION
## Description

Fix the problem that requires input gas in MetaMask manually.

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
