### PR TITLE
fix: recovery normal style when user doesn't have an NFT avatar

### DIFF
--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTBadge.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTBadge.tsx
@@ -4,7 +4,6 @@ import Link from '@mui/material/Link'
 import BigNumber from 'bignumber.js'
 import { useNFT } from '../hooks'
 import { useNFTVerified } from '../hooks/useNFTVerified'
-import { useUserOwnerAddress } from '../hooks/useUserOwnerAddress'
 import type { AvatarMetaDB } from '../types'
 import { NFTAvatarRing } from './NFTAvatarRing'
 
@@ -40,7 +39,7 @@ function formatText(symbol: string, length: number) {
 }
 
 export function NFTBadge(props: NFTBadgeProps) {
-    const { avatar, size = 140, width = 15 } = props
+    const { avatar, size = 140 } = props
     const classes = useStylesExtends(useStyles(), props)
 
     const { value = { amount: '0', symbol: 'ETH', name: '', owner: '' }, loading } = useNFT(
@@ -48,9 +47,8 @@ export function NFTBadge(props: NFTBadgeProps) {
         avatar.tokenId,
     )
 
-    const address = useUserOwnerAddress(avatar.userId)
-    const { amount, symbol, name, owner } = value
-    const { loading: loadingNFTVerified, value: NFTVerified } = useNFTVerified(avatar.address)
+    const { amount, symbol, name } = value
+    const { loading: loadingNFTVerified } = useNFTVerified(avatar.address)
 
     return (
         <div

--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/NFT/NFTAvatarInTwitter.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/NFT/NFTAvatarInTwitter.tsx
@@ -122,8 +122,8 @@ function NFTAvatarInTwitter() {
             // create rainbow shadow border
             if (linkDom.lastElementChild?.tagName !== 'STYLE') {
                 borderElement.current = linkDom.firstElementChild
-                // remove useless border
 
+                // remove useless border
                 linkDom.removeChild(linkDom.firstElementChild)
                 const style = document.createElement('style')
                 style.innerText = `

--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/NFT/NFTAvatarInTwitter.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/NFT/NFTAvatarInTwitter.tsx
@@ -4,7 +4,7 @@ import { MutationObserverWatcher } from '@dimensiondev/holoflows-kit'
 import { makeStyles } from '@masknet/theme'
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useCurrentVisitingIdentity } from '../../../../components/DataSource/useActivatedUI'
-import { useWallet } from '@masknet/web3-shared-evm'
+import { resolveOpenSeaLink, useWallet } from '@masknet/web3-shared-evm'
 import type { AvatarMetaDB } from '../../../../plugins/Avatar/types'
 import { useNFTAvatar } from '../../../../plugins/Avatar/hooks'
 import { getAvatarId } from '../../utils/user'
@@ -170,6 +170,22 @@ function NFTAvatarInTwitter() {
             setAvatar(undefined)
         }
     }, [location, identity])
+
+    useUpdateEffect(() => {
+        const linkParentDom = searchTwitterAvatarLinkSelector().evaluate()?.closest('div')
+
+        if (!avatar || !linkParentDom) return
+
+        const handler = () => {
+            window.open(resolveOpenSeaLink(avatar.address, avatar.tokenId), '_blank')
+        }
+
+        linkParentDom.addEventListener('click', handler)
+
+        return () => {
+            linkParentDom.removeEventListener('click', handler)
+        }
+    }, [avatar])
 
     if (!avatar || !size) return null
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MASK-538
## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
