### PR TITLE
fix: transaction state related issue && ito unlock info display

### DIFF
--- a/packages/mask/shared-ui/locales/en-US.json
+++ b/packages/mask/shared-ui/locales/en-US.json
@@ -582,6 +582,7 @@
     "plugin_ito_unlocking_symbol": "Unlocking {{symbol}}",
     "plugin_ito_continue": "Continue",
     "plugin_ito_view_on_explorer": "View on Explorer",
+    "plugin_ito_unlock_tip": "Allow the contract <contractLink>{{address}}</contractLink> to use your {{symbol}} tokens when a new ITO round starts later.",
     "plugin_collectible_you": "You",
     "plugin_collectible_done": "Done",
     "plugin_collectible_retry": "Retry",

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/UnlockDialog.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/UnlockDialog.tsx
@@ -2,7 +2,7 @@ import { Link, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { useCallback, useState } from 'react'
 import { v4 as uuid } from 'uuid'
-import { FormattedAddress, useRemoteControlledDialog } from '@masknet/shared'
+import { useRemoteControlledDialog } from '@masknet/shared'
 import { useI18N } from '../../../utils'
 import ActionButton from '../../../extension/options-page/DashboardComponents/ActionButton'
 import {
@@ -103,23 +103,18 @@ export function UnlockDialog(props: UnlockDialogProps) {
             {ITO2_CONTRACT_ADDRESS ? (
                 <Typography className={classes.tip} variant="body2" color="textSecondary">
                     <Trans
+                        i18nKey="plugin_ito_unlock_tip"
                         components={{
-                            link: (
+                            contractLink: (
                                 <Link
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     href={resolveAddressLinkOnExplorer(chainId, ITO2_CONTRACT_ADDRESS)}
                                 />
                             ),
-                            address: (
-                                <FormattedAddress
-                                    address={ITO2_CONTRACT_ADDRESS}
-                                    size={4}
-                                    formatter={formatEthereumAddress}
-                                />
-                            ),
                         }}
                         values={{
+                            address: formatEthereumAddress(ITO2_CONTRACT_ADDRESS, 4),
                             symbol: token.symbol ?? 'Unknown',
                         }}
                     />

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
@@ -194,7 +194,7 @@ export default function RedPacketDialog(props: RedPacketDialogProps) {
         // storing the created red packet in DB, it helps retrieve red packet password later
         // save to the database early, otherwise red-packet would lose when close the tx dialog or
         //  web page before create successfully.
-        if (createState.type === TransactionStateType.WAIT_FOR_CONFIRMING && createState.hash) {
+        if (createState.type === TransactionStateType.HASH && createState.hash) {
             payload.current.txid = createState.hash
             const record: RedPacketRecord = {
                 id: createState.hash!,

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketNftConfirmDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketNftConfirmDialog.tsx
@@ -179,7 +179,7 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
         WalletMessages.events.walletStatusDialogUpdated,
     )
 
-    const isSending = createState.type === TransactionStateType.WAIT_FOR_CONFIRMING
+    const isSending = [TransactionStateType.WAIT_FOR_CONFIRMING, TransactionStateType.HASH].includes(createState.type)
     const onSendTx = useCallback(() => createCallback(publicKey), [publicKey])
     const [txid, setTxid] = useState('')
     const onSendPost = useCallback(
@@ -202,7 +202,7 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
         [duration, message, senderName, contract, privateKey, txid],
     )
     useEffect(() => {
-        if (createState.type === TransactionStateType.WAIT_FOR_CONFIRMING && createState.hash) {
+        if (createState.type === TransactionStateType.HASH && createState.hash) {
             setTxid(createState.hash)
             RedPacketRPC.addRedPacketNft({ id: createState.hash, password: privateKey, contract_version: 1 })
         }

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/hooks/useCreateCallback.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/hooks/useCreateCallback.tsx
@@ -171,7 +171,7 @@ export function useCreateCallback(redPacketSettings: RedPacketSettings, version:
                 .send(config as PayableTx)
                 .on(TransactionEventType.TRANSACTION_HASH, (hash: string) => {
                     setCreateState({
-                        type: TransactionStateType.WAIT_FOR_CONFIRMING,
+                        type: TransactionStateType.HASH,
                         hash,
                     })
                     transactionHashRef.current = hash

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/hooks/useCreateNftRedpacketCallback.ts
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/hooks/useCreateNftRedpacketCallback.ts
@@ -101,7 +101,7 @@ export function useCreateNftRedpacketCallback(
                     // Note: DO NOT remove this event listener since it relates to password saving.
                     .on(TransactionEventType.TRANSACTION_HASH, (hash: string) => {
                         setCreateState({
-                            type: TransactionStateType.WAIT_FOR_CONFIRMING,
+                            type: TransactionStateType.HASH,
                             hash,
                         })
                     })

--- a/packages/web3-shared/evm/hooks/useERC721TokenDetailed.ts
+++ b/packages/web3-shared/evm/hooks/useERC721TokenDetailed.ts
@@ -64,6 +64,7 @@ export async function getERC721TokenDetailedFromOpensea(
                 description: data.description,
                 mediaUrl: data.image_url || data.animation_url,
                 owner: first(data.top_ownerships)?.owner.address ?? '',
+                hasTokenDetailed: true,
             },
             tokenId,
         )


### PR DESCRIPTION
## Description
1. fix erc20 and nft red packet password issue
2. fix ito ito unlock dialog contract info display
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

closes https://github.com/DimensionDev/Maskbook/issues/5373

![image](https://user-images.githubusercontent.com/63733714/148003520-3796a121-2507-4066-9ba6-05a114aa0e51.png)


## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
