### PR TITLE
fix: turn off address spell checking (#5172)

### DIFF
--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC20.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC20.tsx
@@ -246,7 +246,7 @@ export const TransferERC20 = memo<TransferERC20Props>(({ token }) => {
                                 if (!!ensContent) setPopoverOpen(true)
                                 setMinPopoverWidth(event.currentTarget.clientWidth)
                             },
-                            spellCheck: false
+                            spellCheck: false,
                         }}
                         onChange={(e) => setAddress(e.currentTarget.value)}
                         label={t.wallets_transfer_to_address()}

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC20.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC20.tsx
@@ -246,7 +246,7 @@ export const TransferERC20 = memo<TransferERC20Props>(({ token }) => {
                                 if (!!ensContent) setPopoverOpen(true)
                                 setMinPopoverWidth(event.currentTarget.clientWidth)
                             },
-                            spellCheck: {false}
+                            spellCheck: false
                         }}
                         onChange={(e) => setAddress(e.currentTarget.value)}
                         label={t.wallets_transfer_to_address()}

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC20.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC20.tsx
@@ -246,6 +246,7 @@ export const TransferERC20 = memo<TransferERC20Props>(({ token }) => {
                                 if (!!ensContent) setPopoverOpen(true)
                                 setMinPopoverWidth(event.currentTarget.clientWidth)
                             },
+                            spellCheck: {false}
                         }}
                         onChange={(e) => setAddress(e.currentTarget.value)}
                         label={t.wallets_transfer_to_address()}

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
@@ -313,7 +313,7 @@ export const TransferERC721 = memo(() => {
                                             if (!!ensContent) setPopoverOpen(true)
                                             setMinPopoverWidth(event.currentTarget.clientWidth)
                                         },
-                                        spellCheck: {false}
+                                        spellCheck: false
                                     }}
                                     label={t.wallets_transfer_to_address()}
                                 />

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
@@ -313,6 +313,7 @@ export const TransferERC721 = memo(() => {
                                             if (!!ensContent) setPopoverOpen(true)
                                             setMinPopoverWidth(event.currentTarget.clientWidth)
                                         },
+                                        spellCheck: {false}
                                     }}
                                     label={t.wallets_transfer_to_address()}
                                 />

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/TransferERC721.tsx
@@ -313,7 +313,7 @@ export const TransferERC721 = memo(() => {
                                             if (!!ensContent) setPopoverOpen(true)
                                             setMinPopoverWidth(event.currentTarget.clientWidth)
                                         },
-                                        spellCheck: false
+                                        spellCheck: false,
                                     }}
                                     label={t.wallets_transfer_to_address()}
                                 />

--- a/packages/mask/src/extension/options-page/DashboardDialogs/Wallet/TransferNFT.tsx
+++ b/packages/mask/src/extension/options-page/DashboardDialogs/Wallet/TransferNFT.tsx
@@ -113,6 +113,7 @@ export function DashboardWalletTransferDialogNFT(props: WrappedDialogProps<{ tok
                             placeholder={t('wallet_transfer_to_address')}
                             value={address}
                             onChange={(e) => setAddress(e.target.value)}
+                            inputProps={{ spellCheck: 'false' }}
                         />
                         <Button
                             className={classes.button}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The browser's built-in syntax check in the text field is not required when entering address of the transfer destination. This turns it off.

Closes #5172

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->
None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
