### PR TITLE
fix: get openocean estimated gas from api

### DIFF
--- a/packages/mask/src/plugins/Trader/apis/openocean/index.ts
+++ b/packages/mask/src/plugins/Trader/apis/openocean/index.ts
@@ -18,11 +18,12 @@ export async function swapOO(request: SwapOORequest): Promise<SwapOOData> {
         }),
     )
     const payload = await response.json()
-    const { data, outAmount, minOutAmount, to, value } = payload
+    const { data, outAmount, minOutAmount, to, value, estimatedGas } = payload
     const _resAmount = leftShift(outAmount, request.toToken.decimals).toNumber()
     const _fromAmount = leftShift(request.fromAmount, request.fromToken.decimals).toNumber()
     return {
         data,
+        estimatedGas,
         targetApproveAddr: request.fromToken.address,
         targetDecimals: request.fromToken.decimals,
         resAmount: _resAmount,

--- a/packages/mask/src/plugins/Trader/trader/openocean/useTradeGasLimit.ts
+++ b/packages/mask/src/plugins/Trader/trader/openocean/useTradeGasLimit.ts
@@ -1,4 +1,4 @@
-import type { SwapRouteData, TradeComputed } from '../../types'
+import type { SwapOOData, TradeComputed } from '../../types'
 import { useMemo } from 'react'
 import { useAccount, useWeb3 } from '@masknet/web3-shared-evm'
 import { TargetChainIdContext } from '../useTargetChainIdContext'
@@ -6,8 +6,9 @@ import { pick } from 'lodash-unified'
 import type { TransactionConfig } from 'web3-core'
 import { useAsync } from 'react-use'
 import type { AsyncState } from 'react-use/lib/useAsyncFn'
+import BigNumber from 'bignumber.js'
 
-export function useTradeGasLimit(tradeComputed: TradeComputed<SwapRouteData> | null): AsyncState<number> {
+export function useTradeGasLimit(tradeComputed: TradeComputed<SwapOOData> | null): AsyncState<number> {
     const { targetChainId } = TargetChainIdContext.useContainer()
 
     const web3 = useWeb3(false, targetChainId)
@@ -21,7 +22,8 @@ export function useTradeGasLimit(tradeComputed: TradeComputed<SwapRouteData> | n
     }, [account, tradeComputed])
 
     return useAsync(async () => {
+        if (tradeComputed?.trade_?.estimatedGas) return new BigNumber(tradeComputed.trade_.estimatedGas).toNumber()
         if (!config) return 0
         return web3.eth.estimateGas(config)
-    }, [config, web3])
+    }, [config, web3, tradeComputed?.trade_?.estimatedGas])
 }

--- a/packages/mask/src/plugins/Trader/trader/useAllTradeComputed.ts
+++ b/packages/mask/src/plugins/Trader/trader/useAllTradeComputed.ts
@@ -2,7 +2,7 @@ import type { FungibleTokenDetailed } from '@masknet/web3-shared-evm'
 import { multipliedBy, pow10 } from '@masknet/web3-shared-base'
 import { useTrade as useNativeTokenTrade } from './native/useTrade'
 import { useTradeComputed as useNativeTokenTradeComputed } from './native/useTradeComputed'
-import { TagType, TradeInfo, TradeStrategy } from '../types'
+import { SwapOOData, TagType, TradeInfo, TradeStrategy } from '../types'
 import { useV2Trade as useUniswapV2Trade, useV3Trade as useUniswapV3Trade } from './uniswap/useTrade'
 import { useTradeComputed as useUniswapTradeComputed } from './uniswap/useTradeComputed'
 import { useTradeGasLimit as useUniswapTradeGasLimit } from './uniswap/useTradeGasLimit'
@@ -20,11 +20,12 @@ import { useTradeComputed as useBancorTradeComputed } from './bancor/useTradeCom
 import { useTradeGasLimit as useBancorTradeGasLimit } from './bancor/useTradeGasLimit'
 import { useTradeComputed as useOpenOceanTradeComputed } from './openocean/useTradeComputed'
 import { useTrade as useOpenOceanTrade } from './openocean/useTrade'
+import { useTradeGasLimit as useOpenOceanTradeGasLimit } from './openocean/useTradeGasLimit'
 import { TradeProvider } from '@masknet/public-api'
 import { useAvailableTraderProviders } from '../trending/useAvailableTraderProviders'
 import { useNativeTradeGasLimit } from './useNativeTradeGasLimit'
 import { TargetChainIdContext } from './useTargetChainIdContext'
-import type { TradeComputed, SwapRouteData } from '../types'
+import type { TradeComputed } from '../types'
 
 export function useAllTradeComputed(
     inputAmount: string,
@@ -185,7 +186,7 @@ export function useAllTradeComputed(
         inputToken,
         outputToken,
     )
-    const openoceanSwapEstimateGas = useDODOTradeGasLimit(openocean as TradeComputed<SwapRouteData> | null)
+    const openoceanSwapEstimateGas = useOpenOceanTradeGasLimit(openocean as TradeComputed<SwapOOData> | null)
 
     const allTradeResult = [
         { provider: TradeProvider.UNISWAP_V2, ...uniswapV2_, value: uniswapV2, gas: uniswapV2EstimateGas },

--- a/packages/mask/src/plugins/Trader/types/openocean.ts
+++ b/packages/mask/src/plugins/Trader/types/openocean.ts
@@ -27,6 +27,7 @@ export interface SwapOOErrorResponse {
 
 export interface SwapOOData {
     data: string
+    estimatedGas: string
     priceImpact: number
     resAmount: number
     resCostGas: number


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MASK-631 

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
