### PR TITLE
fix: network chip background color

### DIFF
--- a/packages/dashboard/src/pages/Wallets/components/WalletStateBar/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/WalletStateBar/index.tsx
@@ -19,10 +19,25 @@ import { useNetworkSelector } from './useNetworkSelector'
 const useStyles = makeStyles()((theme) => ({
     bar: {
         minWidth: 80,
-        borderRadius: 30,
         lineHeight: '28px',
         height: '28px',
         cursor: 'pointer',
+        position: 'relative',
+        '&::after': {
+            borderRadius: 30,
+            pointerEvents: 'none',
+            content: '""',
+            inset: 0,
+            margin: 'auto',
+            position: 'absolute',
+            backgroundColor: 'var(--network-icon-color, transparent)',
+            opacity: 0.1,
+            zIndex: 0,
+        },
+        '& > span': {
+            position: 'relative',
+            zIndex: 1,
+        },
     },
     dot: {
         position: 'relative',
@@ -112,7 +127,7 @@ export const WalletStateBarUI: FC<WalletStateBarUIProps> = ({
                 direction="row"
                 alignItems="center"
                 justifyContent="center"
-                sx={{ background: network.iconColor.replace(')', ', 0.1)'), px: 2, mr: 1 }}
+                sx={{ '--network-icon-color': network.iconColor, px: 2, mr: 1 }}
                 color={network.iconColor ?? ''}
                 className={classes.bar}
                 onClick={openMenu}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3456,6 +3456,7 @@ packages:
 
   /@dimensiondev/eslint-plugin/0.0.1-20220117062517-fd3cb01_eslint@8.5.0:
     resolution: {integrity: sha512-WtUberb1MC1s554Lm3C3mno3Nf/TdVJP80htgpNWiGOcIk+WYwQi+gWqi5IlnqGd71bYRZPYpYs2MH+GS+dbuw==, tarball: download/@dimensiondev/eslint-plugin/0.0.1-20220117062517-fd3cb01/8298f20d707432bcb777cd5084173fc894362a3496e8f8bc6a5c85070adb77cf}
+    engines: {node: '>= 14'}
     peerDependencies:
       '@typescript-eslint/experimental-utils': '*'
       eslint: '>= 8'


### PR DESCRIPTION
the icon color can be other color formats than rgb

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

### before

![image](https://user-images.githubusercontent.com/1141198/149907498-30926a82-f7d6-42fc-8d2a-031e6697ee0f.png)

### after

![image](https://user-images.githubusercontent.com/1141198/149907448-be548487-c927-4bac-b3b8-d3e4df23aebe.png)

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
