### PR TITLE
fix: nft avatar filter image

### DIFF
--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
@@ -197,6 +197,13 @@ interface NFTImageCollectibleAvatarProps {
 }
 
 function NFTImageCollectibleAvatar({ token, setSelectedToken, selectedToken }: NFTImageCollectibleAvatarProps) {
-    const { value: imageToken } = useImageNFTFilter(token)
+    const { classes } = useStyles()
+    const { value: imageToken, loading } = useImageNFTFilter(token)
+    if (loading)
+        return (
+            <div className={classes.skeletonBox}>
+                <Skeleton animation="wave" variant="rectangular" className={classes.skeleton} />
+            </div>
+        )
     return imageToken ? <NFTImage token={imageToken} selectedToken={selectedToken} onChange={setSelectedToken} /> : null
 }

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
@@ -17,6 +17,7 @@ import { useI18N } from '../../../utils'
 import { EthereumChainBoundary } from '../../../web3/UI/EthereumChainBoundary'
 import { AddNFT } from './AddNFT'
 import { NFTImage } from './NFTImage'
+import { useImageNFTFilter } from '../hooks/useImageNFTFilter'
 
 const useStyles = makeStyles()((theme) => ({
     root: {},
@@ -160,20 +161,15 @@ export function NFTAvatar(props: NFTAvatarProps) {
                                 : uniqBy(
                                       [...collectibles_, ...collectibles],
                                       (x) => x.contractDetailed.address && x.tokenId,
-                                  )
-                                      .filter(
-                                          (token: ERC721TokenDetailed) =>
-                                              token.info.imageURL &&
-                                              !token.info.imageURL?.match(/\.(mp4|webm|mov|ogg|mp3|wav)$/i),
-                                      )
-                                      .map((token: ERC721TokenDetailed, i) => (
-                                          <NFTImage
+                                  ).map((token: ERC721TokenDetailed, i) => (
+                                      <div key={i}>
+                                          <NFTImageCollectibleAvatar
                                               token={token}
-                                              key={i}
                                               selectedToken={selectedToken}
-                                              onChange={setSelectedToken}
+                                              setSelectedToken={setSelectedToken}
                                           />
-                                      ))}
+                                      </div>
+                                  ))}
                         </Box>
                         <Box className={classes.buttons}>
                             <Button variant="outlined" size="small" onClick={() => setOpen_(true)}>
@@ -194,4 +190,14 @@ export function NFTAvatar(props: NFTAvatarProps) {
             <AddNFT open={open_} onClose={() => setOpen_(false)} onAddClick={onAddClick} />
         </>
     )
+}
+interface NFTImageCollectibleAvatarProps {
+    token: ERC721TokenDetailed
+    setSelectedToken: React.Dispatch<React.SetStateAction<ERC721TokenDetailed | undefined>>
+    selectedToken?: ERC721TokenDetailed
+}
+
+function NFTImageCollectibleAvatar({ token, setSelectedToken, selectedToken }: NFTImageCollectibleAvatarProps) {
+    const { value: imageToken } = useImageNFTFilter(token)
+    return imageToken ? <NFTImage token={imageToken} selectedToken={selectedToken} onChange={setSelectedToken} /> : null
 }

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
@@ -162,13 +162,12 @@ export function NFTAvatar(props: NFTAvatarProps) {
                                       [...collectibles_, ...collectibles],
                                       (x) => x.contractDetailed.address && x.tokenId,
                                   ).map((token: ERC721TokenDetailed, i) => (
-                                      <div key={i}>
-                                          <NFTImageCollectibleAvatar
-                                              token={token}
-                                              selectedToken={selectedToken}
-                                              setSelectedToken={setSelectedToken}
-                                          />
-                                      </div>
+                                      <NFTImageCollectibleAvatar
+                                          key={i}
+                                          token={token}
+                                          selectedToken={selectedToken}
+                                          setSelectedToken={setSelectedToken}
+                                      />
                                   ))}
                         </Box>
                         <Box className={classes.buttons}>

--- a/packages/mask/src/plugins/Avatar/hooks/useImageNFTFilter.ts
+++ b/packages/mask/src/plugins/Avatar/hooks/useImageNFTFilter.ts
@@ -1,0 +1,31 @@
+import type { ERC721TokenDetailed } from '@masknet/web3-shared-evm'
+import { useAsync } from 'react-use'
+
+// filter out nft with image resource
+export function useImageNFTFilter(collectible: ERC721TokenDetailed) {
+    return useAsync(async () => {
+        if (!collectible.info?.imageURL) return null
+        const { pathname } = new URL(collectible.info?.imageURL ?? '')
+        if (/\.(gif|svg|png|webp|jpg|jpeg)$/.test(pathname)) return collectible
+        if (/\.(mp4|webm|mov|ogg|mp3|wav)$/.test(pathname)) return null
+        const contentType = await getContentType(collectible.info?.imageURL ?? '')
+        if (contentType.startsWith('image/')) return collectible
+        return null
+    }, [collectible])
+}
+
+async function getContentType(url: string) {
+    if (!/^https?:/.test(url)) {
+        return ''
+    }
+    return Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve(''), 20000)),
+        new Promise((resolve) => {
+            fetch(url, { method: 'HEAD', mode: 'cors' })
+                .then((response) =>
+                    response.status !== 200 ? resolve('') : resolve(response.headers.get('content-type')),
+                )
+                .catch(() => resolve(''))
+        }),
+    ]) as Promise<string>
+}


### PR DESCRIPTION
## Description
Filter out NFT with image resource for NFT Avatar.

Closes 
https://mask.atlassian.net/browse/MASK-693
## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

## Checklist

- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
