### PR TITLE
fix: nft avatar price display problem on safari

### DIFF
--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatarRing.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatarRing.tsx
@@ -89,12 +89,8 @@ export function NFTAvatarRing(props: NFTAvatarRingProps) {
                 </text>
 
                 <text x="0%" textAnchor="middle" fill={`url(#${id}-pattern)`} fontFamily="sans-serif">
-                    <textPath
-                        xlinkHref={`#${id}-path-price`}
-                        startOffset="50%"
-                        rotate="auto"
-                        dominantBaseline="mathematical">
-                        <tspan fontWeight="bold" fontSize={fontSize}>
+                    <textPath xlinkHref={`#${id}-path-price`} startOffset="50%" rotate="auto">
+                        <tspan fontWeight="bold" fontSize={fontSize} dy="0.5em">
                             {price}
                         </tspan>
                     </textPath>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes MASK-736 

https://stackoverflow.com/questions/35565063/svg-dominant-baseline-not-working-in-safari

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
