### PR TITLE
feat: make network tabs scrollable

### DIFF
--- a/packages/mask/src/components/shared/AbstractTab.tsx
+++ b/packages/mask/src/components/shared/AbstractTab.tsx
@@ -35,12 +35,14 @@ export interface AbstractTabProps
     margin?: true | 'top' | 'bottom'
     height?: number | string
     hasOnlyOneChild?: boolean
+    scrollable?: boolean
 }
 
 export default function AbstractTab(props: AbstractTabProps) {
-    const { tabs, state, index, height = 200, hasOnlyOneChild = false } = props
+    const { tabs, state, index, height = 200, hasOnlyOneChild = false, scrollable = false } = props
     const classes = useStylesExtends(useStyles(), props)
     const [value, setValue] = state ?? [undefined, undefined]
+    const tabIndicatorStyle = tabs.length && scrollable ? { width: 100 / tabs.length + '%' } : undefined
 
     return (
         <>
@@ -52,11 +54,12 @@ export default function AbstractTab(props: AbstractTabProps) {
                         flexContainer: classes.flexContainer,
                     }}
                     value={index ? index : value ? value : 0}
-                    variant="scrollable"
                     indicatorColor="primary"
                     textColor="primary"
-                    scrollButtons
-                    allowScrollButtonsMobile
+                    variant={scrollable ? 'scrollable' : 'fullWidth'}
+                    TabIndicatorProps={{ style: tabIndicatorStyle }}
+                    scrollButtons={scrollable}
+                    allowScrollButtonsMobile={scrollable}
                     onChange={(_: React.SyntheticEvent, newValue: number) => setValue?.(newValue)}>
                     {tabs.map((tab, i) => (
                         <Tab

--- a/packages/mask/src/components/shared/AbstractTab.tsx
+++ b/packages/mask/src/components/shared/AbstractTab.tsx
@@ -41,7 +41,6 @@ export default function AbstractTab(props: AbstractTabProps) {
     const { tabs, state, index, height = 200, hasOnlyOneChild = false } = props
     const classes = useStylesExtends(useStyles(), props)
     const [value, setValue] = state ?? [undefined, undefined]
-    const tabIndicatorStyle = tabs.length ? { width: 100 / tabs.length + '%' } : undefined
 
     return (
         <>
@@ -53,10 +52,11 @@ export default function AbstractTab(props: AbstractTabProps) {
                         flexContainer: classes.flexContainer,
                     }}
                     value={index ? index : value ? value : 0}
-                    TabIndicatorProps={{ style: tabIndicatorStyle }}
-                    variant="fullWidth"
+                    variant="scrollable"
                     indicatorColor="primary"
                     textColor="primary"
+                    scrollButtons
+                    allowScrollButtonsMobile
                     onChange={(_: React.SyntheticEvent, newValue: number) => setValue?.(newValue)}>
                     {tabs.map((tab, i) => (
                         <Tab

--- a/packages/mask/src/components/shared/AbstractTab.tsx
+++ b/packages/mask/src/components/shared/AbstractTab.tsx
@@ -42,7 +42,7 @@ export default function AbstractTab(props: AbstractTabProps) {
     const { tabs, state, index, height = 200, hasOnlyOneChild = false, scrollable = false } = props
     const classes = useStylesExtends(useStyles(), props)
     const [value, setValue] = state ?? [undefined, undefined]
-    const tabIndicatorStyle = tabs.length && scrollable ? { width: 100 / tabs.length + '%' } : undefined
+    const tabIndicatorStyle = tabs.length && !scrollable ? { width: 100 / tabs.length + '%' } : undefined
 
     return (
         <>

--- a/packages/mask/src/components/shared/NetworkTab.tsx
+++ b/packages/mask/src/components/shared/NetworkTab.tsx
@@ -19,15 +19,26 @@ const useStyles = makeStyles<StyleProps>()((theme, props) => ({
     },
     tabs: {
         '& .MuiTabs-flexContainer': {
-            display: 'grid',
-            gridTemplateColumns: Array(props.chainLength)
-                .fill(100 / props.chainLength + '%')
-                .join(' '),
             backgroundColor: theme.palette.background.paper,
         },
         '& .Mui-selected': {
             color: '#ffffff',
             backgroundColor: `${theme.palette.primary.main}!important`,
+        },
+        '& .MuiTabs-scroller': {
+            margin: '0 1px',
+        },
+        '& .MuiTabs-scrollButtons': {
+            width: 'unset',
+            backgroundColor: !props.isDashboard
+                ? `${theme.palette.background.default}!important`
+                : `${MaskColorVar.primaryBackground2}!important`,
+            '&.Mui-disabled': {
+                opacity: 1,
+                '& svg': {
+                    opacity: 0.3,
+                },
+            },
         },
     },
 }))

--- a/packages/mask/src/components/shared/NetworkTab.tsx
+++ b/packages/mask/src/components/shared/NetworkTab.tsx
@@ -63,6 +63,7 @@ export function NetworkTab(props: NetworkTabProps) {
         index: chains.indexOf(chainId),
         classes,
         hasOnlyOneChild: true,
+        scrollable: true,
     }
 
     return <AbstractTab {...tabProps} />


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes [MASK-809](https://mask.atlassian.net/browse/MASK-809)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews
<img width="596" alt="image" src="https://user-images.githubusercontent.com/2182308/155671512-9251a62f-f9a8-4eca-a7cd-10323f1fd7b7.png">

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
