### PR TITLE
feat: hack HTMLImageElement.prototype.src

### DIFF
--- a/packages/mask/src/setup.ui.1.ts
+++ b/packages/mask/src/setup.ui.1.ts
@@ -1,0 +1,30 @@
+import Services from './extension/service'
+
+try {
+    const old = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'src')!
+
+    const originalToBlob = new Map<string, Promise<string> | string>()
+    const blobToOriginal = new Map<string, string>()
+    Object.defineProperty(HTMLImageElement.prototype, 'src', {
+        configurable: true,
+        enumerable: old.enumerable,
+        get() {
+            const orig = old.get!.call(this)
+            return blobToOriginal.get(orig) || orig
+        },
+        set(value) {
+            value = String(value)
+            if (value.startsWith('http')) {
+                if (!originalToBlob.has(value)) {
+                    originalToBlob.set(value, Services.Helper.fetch(value).then(URL.createObjectURL))
+                }
+                Promise.resolve(originalToBlob.get(value))
+                    .catch(() => value)
+                    .then((url) => {
+                        old.set!.call(this, url)
+                        blobToOriginal.set(value, url)
+                    })
+            } else old.set!.call(this, value)
+        },
+    })
+} catch {}

--- a/packages/mask/src/setup.ui.1.ts
+++ b/packages/mask/src/setup.ui.1.ts
@@ -1,30 +1,32 @@
 import Services from './extension/service'
 
 try {
-    const old = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'src')!
+    if (process.env.architecture === 'app' && process.env.engine === 'safari') {
+        const old = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, 'src')!
 
-    const originalToBlob = new Map<string, Promise<string> | string>()
-    const blobToOriginal = new Map<string, string>()
-    Object.defineProperty(HTMLImageElement.prototype, 'src', {
-        configurable: true,
-        enumerable: old.enumerable,
-        get() {
-            const orig = old.get!.call(this)
-            return blobToOriginal.get(orig) || orig
-        },
-        set(value) {
-            value = String(value)
-            if (value.startsWith('http')) {
-                if (!originalToBlob.has(value)) {
-                    originalToBlob.set(value, Services.Helper.fetch(value).then(URL.createObjectURL))
-                }
-                Promise.resolve(originalToBlob.get(value))
-                    .catch(() => value)
-                    .then((url) => {
-                        old.set!.call(this, url)
-                        blobToOriginal.set(value, url)
-                    })
-            } else old.set!.call(this, value)
-        },
-    })
+        const originalToBlob = new Map<string, Promise<string> | string>()
+        const blobToOriginal = new Map<string, string>()
+        Object.defineProperty(HTMLImageElement.prototype, 'src', {
+            configurable: true,
+            enumerable: old.enumerable,
+            get() {
+                const orig = old.get!.call(this)
+                return blobToOriginal.get(orig) || orig
+            },
+            set(value) {
+                value = String(value)
+                if (value.startsWith('http')) {
+                    if (!originalToBlob.has(value)) {
+                        originalToBlob.set(value, Services.Helper.fetch(value).then(URL.createObjectURL))
+                    }
+                    Promise.resolve(originalToBlob.get(value))
+                        .catch(() => value)
+                        .then((url) => {
+                            old.set!.call(this, url)
+                            blobToOriginal.set(value, url)
+                        })
+                } else old.set!.call(this, value)
+            },
+        })
+    }
 } catch {}

--- a/packages/mask/src/setup.ui.ts
+++ b/packages/mask/src/setup.ui.ts
@@ -1,5 +1,6 @@
 // Start SNS adaptor
 import './setup.ui.0'
+import './setup.ui.1'
 import './social-network-adaptor'
 import { activateSocialNetworkUI } from './social-network/define'
 export const status = activateSocialNetworkUI()


### PR DESCRIPTION
## Description

Add HTMLImage.prototype.src hack to bypass CSP on iOS.

## Type of change

<!-- Please remove options that are not relevant. -->

-   [ ] Documentation
-   [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must
        upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

-   [ ] My code follows the style guidelines of this project.
-   [ ] I have performed a self-review of my own code.
    -   [ ] I have removed all in development `console.log`s
    -   [ ] I have removed all commented code.
-   [ ] I have commented on my code, particularly in hard-to-understand areas.
-   [ ] I have read
        [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved
        text fields to the i18n JSON file.

If this PR depends on external APIs:

-   [ ] I have configured those APIs with CORS headers to let extension requests get passed.
        <!-- If you don't have permission to modify the server, please let us know it. -->
    -   chrome extension: `chrome-extension://[id]`
    -   firefox extension: `moz-extension://[id]`
-   [ ] I have delegated all web requests to the background service via the internal RPC bridge.
