### PR TITLE
perf: reduce settings changing notification for nextid

### DIFF
--- a/packages/mask/src/settings/createSettings.ts
+++ b/packages/mask/src/settings/createSettings.ts
@@ -2,6 +2,7 @@ import { ValueRef, isEnvironment, Environment } from '@dimensiondev/holoflows-ki
 import Services from '../extension/service'
 import { MaskMessages } from '../utils/messages'
 import { defer } from '@dimensiondev/kit'
+import { isEqual } from 'lodash-unified'
 
 export interface SettingsTexts {
     primary: () => string
@@ -49,7 +50,7 @@ MaskMessages.events.createInternalSettingsUpdated.on(async (payload) => {
 export function createInternalSettings<T extends browser.storage.StorageValue>(
     key: string,
     value: T,
-    comparer: (a: T, b: T) => boolean = (a, b) => a === b,
+    comparer: (a: T, b: T) => boolean = isEqual,
 ) {
     const settings = new ValueRef(value, comparer) as InternalSettings<T>
     const [readyPromise, resolve, reject] = defer<T>()
@@ -93,7 +94,7 @@ export function createGlobalSettings<T extends browser.storage.StorageValue>(
     key: string,
     value: T,
     UITexts: SettingsTexts,
-    comparer: (a: T, b: T) => boolean = (a, b) => a === b,
+    comparer: (a: T, b: T) => boolean = isEqual,
 ) {
     const settings = createInternalSettings(`settings+${key}`, value, comparer)
     return settings

--- a/packages/mask/src/settings/createSettings.ts
+++ b/packages/mask/src/settings/createSettings.ts
@@ -2,7 +2,6 @@ import { ValueRef, isEnvironment, Environment } from '@dimensiondev/holoflows-ki
 import Services from '../extension/service'
 import { MaskMessages } from '../utils/messages'
 import { defer } from '@dimensiondev/kit'
-import { isEqual } from 'lodash-unified'
 
 export interface SettingsTexts {
     primary: () => string
@@ -15,6 +14,8 @@ export type InternalSettings<T> = ValueRef<T> & {
     readonly resolve: (value: T) => void
     readonly reject: (e: Error) => void
 }
+type ValueComparer<T> = (a: T, b: T) => boolean
+const defaultValueComparer = (a: any, b: any) => a === b
 
 const cached: Map<string, InternalSettings<any>> = new Map()
 const lastEventId: Map<string, number> = new Map()
@@ -50,7 +51,7 @@ MaskMessages.events.createInternalSettingsUpdated.on(async (payload) => {
 export function createInternalSettings<T extends browser.storage.StorageValue>(
     key: string,
     value: T,
-    comparer: (a: T, b: T) => boolean = isEqual,
+    comparer: ValueComparer<T> = defaultValueComparer,
 ) {
     const settings = new ValueRef(value, comparer) as InternalSettings<T>
     const [readyPromise, resolve, reject] = defer<T>()
@@ -94,7 +95,7 @@ export function createGlobalSettings<T extends browser.storage.StorageValue>(
     key: string,
     value: T,
     UITexts: SettingsTexts,
-    comparer: (a: T, b: T) => boolean = isEqual,
+    comparer: ValueComparer<T> = defaultValueComparer,
 ) {
     const settings = createInternalSettings(`settings+${key}`, value, comparer)
     return settings
@@ -104,17 +105,21 @@ export interface NetworkSettings<T> {
     [networkKey: string]: ValueRef<T> & { ready: boolean; readyPromise: Promise<T> }
 }
 
-export function createNetworkSettings<T extends browser.storage.StorageValue>(settingsKey: string, defaultValue: T) {
+export function createNetworkSettings<T extends browser.storage.StorageValue>(
+    settingsKey: string,
+    defaultValue: T,
+    comparer: ValueComparer<T> = defaultValueComparer,
+) {
     const cached: NetworkSettings<T> = {}
     MaskMessages.events.createNetworkSettingsReady.on((networkKey) => {
         if (networkKey.startsWith('plugin:') || settingsKey === 'pluginsEnabled') return
         if (!(networkKey in cached))
-            cached[networkKey] = createInternalSettings(`${networkKey}+${settingsKey}`, defaultValue)
+            cached[networkKey] = createInternalSettings(`${networkKey}+${settingsKey}`, defaultValue, comparer)
     })
     return new Proxy(cached, {
         get(target, networkKey: string) {
             if (!(networkKey in target)) {
-                const settings = createInternalSettings(`${networkKey}+${settingsKey}`, defaultValue)
+                const settings = createInternalSettings(`${networkKey}+${settingsKey}`, defaultValue, comparer)
                 target[networkKey] = settings
                 settings.readyPromise.then(() => MaskMessages.events.createNetworkSettingsReady.sendToAll(networkKey))
             }

--- a/packages/mask/src/settings/settings.ts
+++ b/packages/mask/src/settings/settings.ts
@@ -5,6 +5,7 @@ import { Appearance } from '@masknet/theme'
 import { LanguageOptions } from '@masknet/public-api'
 import { Identifier, ProfileIdentifier } from '@masknet/shared-base'
 import { PLUGIN_ID } from '../plugins/EVM/constants'
+import { isEqual } from 'lodash-unified'
 
 /**
  * Does the debug mode on
@@ -64,6 +65,7 @@ export const dismissPinExtensionTip = createGlobalSettings<boolean>('dismissPinE
 export const dismissVerifyNextID: NetworkSettings<{ [key in string]: boolean }> = createNetworkSettings(
     'dismissVerifyNextID',
     {},
+    isEqual,
 )
 export const bioDescription: NetworkSettings<string> = createNetworkSettings('bioDescription', '')
 export const personalHomepage: NetworkSettings<string> = createNetworkSettings('personalHomepage', '')


### PR DESCRIPTION
`dismissVerifyNextID` is not a  primitive type, every time it changes, it trigger the notification.
https://github.com/DimensionDev/Maskbook/blob/31561fc4e6af2549837f42775ffb3a5d9717382a/packages/mask/src/settings/settings.ts#L64-L67

| before | after |
| -- | -- |
| <img width="2148" alt="image" src="https://user-images.githubusercontent.com/1141198/156873399-8d6f190e-fb2c-4996-af9d-af219d40a98d.png">  |  <img width="2148" alt="image" src="https://user-images.githubusercontent.com/1141198/156873438-87dc3b4a-6dc8-4510-a7f2-c868a551a065.png"> |
| <img width="580" alt="image" src="https://user-images.githubusercontent.com/1141198/156872998-65414f53-0c94-40e9-af31-11fb7a1d5600.png"> | no more repeats |
