### PR TITLE
fix: parse use identity by post

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mask-network",
   "packageManager": "pnpm@6.30.1",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/packages/mask/src/manifest.json
+++ b/packages/mask/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Mask Network",
-    "version": "2.5.2",
+    "version": "2.5.3",
     "manifest_version": 2,
     "permissions": ["storage", "downloads", "webNavigation", "activeTab"],
     "optional_permissions": ["<all_urls>", "notifications", "clipboardRead"],

--- a/packages/mask/src/social-network-adaptor/twitter.com/collecting/identity.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/collecting/identity.ts
@@ -47,7 +47,6 @@ function resolveCurrentVisitingIdentityInner(
         const nickname = getNickname()
         const handle = getTwitterId()
         const avatar = getAvatar()
-
         ref.value = {
             identifier: new ProfileIdentifier(twitterBase.networkIdentifier, handle),
             nickname,

--- a/packages/mask/src/social-network-adaptor/twitter.com/utils/fetch.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/utils/fetch.ts
@@ -1,6 +1,5 @@
 import { regexMatch } from '../../../utils/utils'
 import { defaultTo, flattenDeep } from 'lodash-unified'
-import { nthChild } from '../../../utils/dom'
 import { canonifyImgUrl } from './url'
 import {
     makeTypedMessageText,
@@ -52,20 +51,15 @@ export const postIdParser = (node: HTMLElement) => {
 
 export const postNameParser = (node: HTMLElement) => {
     const tweetElement = node.querySelector<HTMLElement>('[data-testid="tweet"]') ?? node
-    const nameElement = collectNodeText(tweetElement.querySelector<HTMLElement>('a[role] div[id]'))
+    const nameElement = collectNodeText(tweetElement.querySelector<HTMLElement>('div[id] a[role] div[dir="ltr"]'))
 
-    const nameElementInQuoted = nthChild(tweetElement, 0, 0, 0, 0, 0)
+    const nameElementInQuoted = tweetElement.querySelector<HTMLElement>('div[id] a[role] div[dir="auto"]')
     const nameInQuoteTweet = nameElementInQuoted ? collectNodeText(nameElementInQuoted) : ''
 
-    return (
-        [nameElement, nameInQuoteTweet]
-            .filter((x) => x?.includes('@'))
-            .map(parseNameArea)
-            .find((r) => r.name && r.handle) ?? {
-            name: '',
-            handle: '',
-        }
-    )
+    return {
+        name: nameInQuoteTweet || '',
+        handle: nameElement || '',
+    }
 }
 
 export const postAvatarParser = (node: HTMLElement) => {

--- a/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
@@ -47,8 +47,7 @@ export const searchNewTweetButtonSelector: () => LiveSelector<E, true> = () => {
     return querySelector<E>('[data-testid="SideNav_NewTweet_Button"]')
 }
 
-export const searchNickNameSelector: () => LiveSelector<E, true> = () =>
-    querySelector<E>('[data-testid="UserProfileHeader_Items"]')
+export const searchNickNameSelector: () => LiveSelector<E, true> = () => querySelector<E>('[data-testid="UserName"]')
 export const searchAvatarSelector = () =>
     querySelector<HTMLImageElement>('[data-testid="primaryColumn"] a[href$="/photo"] img[src*="profile_images"]')
 export const searchNFTAvatarSelector = () =>

--- a/packages/mask/src/social-network-adaptor/twitter.com/utils/user.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/utils/user.ts
@@ -23,22 +23,18 @@ export const usernameValidator: NonNullable<SocialNetwork.Utils['isValidUsername
 }
 
 export const getNickname = () => {
-    const node = searchNickNameSelector().evaluate()?.parentElement?.parentElement?.firstChild
-        ?.nextSibling as HTMLDivElement
+    const node = searchNickNameSelector().evaluate()?.querySelector('span span') as HTMLDivElement
     if (!node) return ''
 
-    const nicknameNode = node.querySelector<HTMLSpanElement>('div span')
-    if (!nicknameNode) return ''
-
-    return collectNodeText(nicknameNode)
+    return collectNodeText(node)
 }
 
 export const getTwitterId = () => {
-    const node = searchNickNameSelector().evaluate()?.parentElement?.parentElement?.firstChild?.nextSibling?.firstChild
-        ?.firstChild?.lastChild as HTMLDivElement
+    const node = searchNickNameSelector()
+        .evaluate()
+        ?.firstElementChild?.firstElementChild?.nextElementSibling?.querySelector('span') as HTMLDivElement
     if (node) {
-        const twitterIdNode = node.querySelector('div span')
-        if (twitterIdNode) return twitterIdNode.innerHTML.trim().replace('@', '')
+        return node.innerHTML.trim().replace('@', '')
     }
 
     const ele = searchAvatarSelector().evaluate()?.closest('a') || searchNFTAvatarSelector().evaluate()?.closest('a')


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
