### PR TITLE
chore: add back conflux constants

### DIFF
--- a/packages/web3-constants/evm/coingecko.json
+++ b/packages/web3-constants/evm/coingecko.json
@@ -17,7 +17,8 @@
         "Celo": "celo",
         "Fantom": "fantom",
         "Aurora": "aurora",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "COIN_ID": {
         "Mainnet": "ethereum",
@@ -37,6 +38,7 @@
         "Celo": "celo",
         "Fantom": "fantom",
         "Aurora": "ethereum",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": "conflux-token"
     }
 }

--- a/packages/web3-constants/evm/coinmarketcap.json
+++ b/packages/web3-constants/evm/coinmarketcap.json
@@ -17,6 +17,7 @@
         "Celo": "5567",
         "Fantom": "3513",
         "Aurora": "1313161554",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     }
 }

--- a/packages/web3-constants/evm/debank.json
+++ b/packages/web3-constants/evm/debank.json
@@ -17,6 +17,7 @@
         "Celo": "celo",
         "Fantom": "ftm",
         "Aurora": "aurora",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     }
 }

--- a/packages/web3-constants/evm/ethereum.json
+++ b/packages/web3-constants/evm/ethereum.json
@@ -17,7 +17,8 @@
         "Celo": "0x8e28F1d64ceD52b9A09aB1AA3071Aa3c05802d1F",
         "Fantom": "0xc119574d5fb333f5ac018658d4d8b5035e16bf39",
         "Aurora": "0xC119574D5Fb333F5AC018658D4d8b5035E16bf39",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MULTICALL_ADDRESS": {
         "Mainnet": "0x1F98415757620B543A52E61c46B32eB19261F984",
@@ -37,7 +38,8 @@
         "Celo": "0x072453AdEC16cFC7FB6Af1517c3f25407180cccC",
         "Fantom": "0x913975af2Bb8a6Be4100D7dc5e9765B77F6A5d6c",
         "Aurora": "0x6cc1b1058F9153358278C35E0b2D382f1585854B",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": "0x19f179d7e0d7d9f9d5386afff64271d98a91615b"
     },
     "ENS_REGISTRAR_ADDRESS": {
         "Mainnet": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",

--- a/packages/web3-constants/evm/ito.json
+++ b/packages/web3-constants/evm/ito.json
@@ -57,7 +57,8 @@
         "Celo": "0xaA5bfd7355637eA7405CB194a55303e821c4c569",
         "Fantom": "0x981be454a930479d92C91a0092D204b64845A5D6",
         "Aurora": "0x2cf91AD8C175305EBe6970Bd8f81231585EFbd77",
-        "Aurora_Testnet": "0xdcA6F476EebCDE8FE8b072e3fC80dBC28dC209b3"
+        "Aurora_Testnet": "0xdcA6F476EebCDE8FE8b072e3fC80dBC28dC209b3",
+        "Conflux": "0x066804d9123bf2609ed4a4a40b1177a9c5a9ed51"
     },
     "ITO2_CONTRACT_CREATION_BLOCK_HEIGHT": {
         "Mainnet": 12766513,
@@ -77,7 +78,8 @@
         "Celo": 10278776,
         "Fantom": 25071597,
         "Aurora": 57350598,
-        "Aurora_Testnet": 77919102
+        "Aurora_Testnet": 77919102,
+        "Conflux": 37722805
     },
     "DEFAULT_QUALIFICATION_ADDRESS": {
         "Mainnet": "0x81b6ae377e360dcad63611846a2516f4ba8c88ac",
@@ -117,7 +119,8 @@
         "Celo": "0x2cB220F925E603A04BEE05F210252120deBA29d7",
         "Fantom": "0x83D6b366f21e413f214EB077D5378478e71a5eD2",
         "Aurora": "0x578a7Fee5f0D8CEc7d00578Bf37374C5b95C4b98",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": "0x05ee315e407c21a594f807d61d6cc11306d1f149"
     },
     "SUBGRAPH_URL": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/dimensiondev/mask-ito-mainnet",

--- a/packages/web3-constants/evm/nft-red-packet.json
+++ b/packages/web3-constants/evm/nft-red-packet.json
@@ -17,7 +17,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x05ee315E407C21a594f807D61d6CC11306D1F149",
-        "Aurora_Testnet": "0x97369fEE7db34E0BfE47861f2ec44b4378d13eB4"
+        "Aurora_Testnet": "0x97369fEE7db34E0BfE47861f2ec44b4378d13eB4",
+        "Conflux": "0x5b966f3a32db9c180843bcb40267a66b73e4f022"
     },
     "SUBGRAPH_URL": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/dimensiondev/mask-nft-red-packet-mainnet",
@@ -37,6 +38,7 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "https://api.thegraph.com/subgraphs/name/dimensiondev/mask-nft-red-packet-aurora",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     }
 }

--- a/packages/web3-constants/evm/red-packet.json
+++ b/packages/web3-constants/evm/red-packet.json
@@ -77,7 +77,8 @@
         "Celo": "0xAb7B1bE4233A04e5C43a810E75657ECED8E5463B",
         "Fantom": "0x578a7Fee5f0D8CEc7d00578Bf37374C5b95C4b98",
         "Aurora": "0x19f179D7e0D7d9F9d5386afFF64271D98A91615B",
-        "Aurora_Testnet": "0xdB93cCd481012bB5D1E2c8d0aF7C5f2940c00fdC"
+        "Aurora_Testnet": "0xdB93cCd481012bB5D1E2c8d0aF7C5f2940c00fdC",
+        "Conflux": "0x96c7d011cdfd467f551605f0f5fce279f86f4186"
     },
     "HAPPY_RED_PACKET_ADDRESS_V4_BLOCK_HEIGHT": {
         "Mainnet": 12939427,
@@ -97,7 +98,8 @@
         "Celo": 10413552,
         "Fantom": 25112473,
         "Aurora": 57552338,
-        "Aurora_Testnet": 77918765
+        "Aurora_Testnet": 77918765,
+        "Conflux": 37670572
     },
     "SUBGRAPH_URL": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/dimensiondev/mask-red-packet-mainnet",

--- a/packages/web3-constants/evm/rpc.json
+++ b/packages/web3-constants/evm/rpc.json
@@ -59,7 +59,8 @@
         "Celo": ["https://forno.celo.org"],
         "Fantom": ["https://rpc.ftm.tools/"],
         "Aurora": ["https://mainnet.aurora.dev"],
-        "Aurora_Testnet": ["https://testnet.aurora.dev"]
+        "Aurora_Testnet": ["https://testnet.aurora.dev"],
+        "Conflux": ["https://evm.confluxrpc.com"]
     },
     "RPC_WEIGHTS": {
         "Mainnet": [0, 1, 2, 3, 4],
@@ -79,6 +80,7 @@
         "Celo": [0, 0, 0, 0, 0],
         "Fantom": [0, 0, 0, 0, 0],
         "Aurora": [0, 0, 0, 0, 0],
-        "Aurora_Testnet": [0, 0, 0, 0, 0]
+        "Aurora_Testnet": [0, 0, 0, 0, 0],
+        "Conflux": [0, 0, 0, 0, 0]
     }
 }

--- a/packages/web3-constants/evm/token-asset-base-url.json
+++ b/packages/web3-constants/evm/token-asset-base-url.json
@@ -47,6 +47,7 @@
         "Celo": [],
         "Fantom": [],
         "Aurora": [],
-        "Aurora_Testnet": []
+        "Aurora_Testnet": [],
+        "Conflux": []
     }
 }

--- a/packages/web3-constants/evm/token-list.json
+++ b/packages/web3-constants/evm/token-list.json
@@ -17,6 +17,7 @@
         "Celo": ["https://tokens.r2d2.to/latest/42220/tokens.json"],
         "Fantom": ["https://tokens.r2d2.to/latest/250/tokens.json"],
         "Aurora": ["https://tokens.r2d2.to/latest/1313161554/tokens.json"],
-        "Aurora_Testnet": []
+        "Aurora_Testnet": [],
+        "Conflux": ["https://tokens.r2d2.to/latest/1030/tokens.json"]
     }
 }

--- a/packages/web3-constants/evm/token.json
+++ b/packages/web3-constants/evm/token.json
@@ -17,7 +17,8 @@
         "Celo": "0x471EcE3750Da237f93B8E339c536989b8978a438",
         "Fantom": "0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83",
         "Aurora": "0xC9BdeEd33CD01541e1eeD10f90519d2C06Fe3feB",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "LDO_stETH_ADDRESS": {
         "Mainnet": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
@@ -37,7 +38,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "USDC_ADDRESS": {
         "Mainnet": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -57,7 +59,8 @@
         "Celo": "0x2A3684e9Dc20B857375EA04235F2F7edBe818FA7",
         "Fantom": "0x04068da6c83afcfa0e13ba15a6696662335d5b75",
         "Aurora": "0xb12bfca5a55806aaf64e99521918a4bf0fc40802",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "USDT_ADDRESS": {
         "Mainnet": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
@@ -77,7 +80,8 @@
         "Celo": "0xb020d981420744f6b0fedd22bb67cd37ce18a1d5",
         "Fantom": "",
         "Aurora": "0x4988a896b1227218e4a686fde5eabdcabd91571f",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aUSDT_ADDRESS": {
         "Mainnet": "0x71fc860F7D3A592A4a98740e39dB31d25db65ae8",
@@ -97,7 +101,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "HUSD_ADDRESS": {
         "Mainnet": "0xdf574c24545e5ffecb9a659c229253d4111d87e1",
@@ -117,7 +122,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BUSD_ADDRESS": {
         "Mainnet": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -137,7 +143,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "COMP_ADDRESS": {
         "Mainnet": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
@@ -157,7 +164,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "EASY_ADDRESS": {
         "Mainnet": "",
@@ -177,7 +185,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MKR_ADDRESS": {
         "Mainnet": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
@@ -197,7 +206,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MASK_ADDRESS": {
         "Mainnet": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
@@ -217,7 +227,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MSKA_ADDRESS": {
         "Mainnet": "",
@@ -237,7 +248,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MSKB_ADDRESS": {
         "Mainnet": "",
@@ -257,7 +269,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MSKC_ADDRESS": {
         "Mainnet": "",
@@ -277,7 +290,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MSKD_ADDRESS": {
         "Mainnet": "",
@@ -297,7 +311,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MSKE_ADDRESS": {
         "Mainnet": "",
@@ -317,7 +332,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "DAI_ADDRESS": {
         "Mainnet": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
@@ -337,7 +353,8 @@
         "Celo": "",
         "Fantom": "0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E",
         "Aurora": "0xe3520349f477a5f6eb06107066048508498a291b",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "AMPL_ADDRESS": {
         "Mainnet": "0xD46bA6D942050d489DBd938a2C909A5d5039A161",
@@ -357,7 +374,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "OKB_ADDRESS": {
         "Mainnet": "0x75231F58b43240C9718Dd58B4967c5114342a86c",
@@ -377,7 +395,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UST_ADDRESS": {
         "Mainnet": "0xa47c8bf37f92aBed4A126BDA807A7b7498661acD",
@@ -397,7 +416,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "eUSDC_ADDRESS": {
         "Mainnet": "",
@@ -417,7 +437,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "eUSDT_ADDRESS": {
         "Mainnet": "",
@@ -437,7 +458,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "fUSDT_ADDRESS": {
         "Mainnet": "",
@@ -457,7 +479,8 @@
         "Celo": "",
         "Fantom": "0x049d68029688eAbF473097a2fC38ef61633A3C7A",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "eDAI_ADDRESS": {
         "Mainnet": "",
@@ -477,7 +500,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNITOKEN_ADDRESS": {
         "Mainnet": "",
@@ -497,7 +521,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TT01_ADDRESS": {
         "Mainnet": "",
@@ -517,7 +542,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TT02_ADDRESS": {
         "Mainnet": "",
@@ -537,7 +563,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "QUICK_ADDRESS": {
         "Mainnet": "",
@@ -557,7 +584,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "WANNA_ADDRESS": {
         "Mainnet": "",
@@ -577,7 +605,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x7faA64Faf54750a2E3eE621166635fEAF406Ab22",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "WBTC_ADDRESS": {
         "Mainnet": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
@@ -597,7 +626,8 @@
         "Celo": "0xBe50a3013A1c94768A1ABb78c3cB79AB28fc1aCE",
         "Fantom": "0x321162Cd933E2Be498Cd2267a90534A804051b11",
         "Aurora": "0xf4eb217ba2454613b15dbdea6e5f22276410e89e",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "IGG_ADDRESS": {
         "Mainnet": "",
@@ -617,7 +647,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "OM_ADDRESS": {
         "Mainnet": "",
@@ -637,7 +668,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SUSHI_ADDRESS": {
         "Mainnet": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
@@ -657,7 +689,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "YAM_ADDRESS": {
         "Mainnet": "0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16",
@@ -677,7 +710,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "RUNE_ADDRESS": {
         "Mainnet": "0x3155BA85D5F96b2d030a4966AF206230e46849cb",
@@ -697,7 +731,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "YFI_ADDRESS": {
         "Mainnet": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
@@ -717,7 +752,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "sUSD_ADDRESS": {
         "Mainnet": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -737,7 +773,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BTCB_ADDRESS": {
         "Mainnet": "",
@@ -757,7 +794,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "CAKE_ADDRESS": {
         "Mainnet": "",
@@ -777,7 +815,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "maUSDC_ADDRESS": {
         "Mainnet": "",
@@ -797,7 +836,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "stETH_ADDRESS": {
         "Mainnet": "0xDFe66B14D37C77F4E9b180cEb433d1b164f0281D",
@@ -817,7 +857,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "NFTX_ADDRESS": {
         "Mainnet": "0x87d73E916D7057945c9BcD8cdd94e42A6F47f776",
@@ -837,7 +878,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "cUSD_ADDRESS": {
         "Mainnet": "",
@@ -857,7 +899,8 @@
         "Celo": "0x765de816845861e75a25fca122bb6898b8b1282a",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "cEUR_ADDRESS": {
         "Mainnet": "",
@@ -877,7 +920,8 @@
         "Celo": "0x765de816845861e75a25fca122bb6898b8b1282a",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "xTRI_ADDRESS": {
         "Mainnet": "",
@@ -897,7 +941,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x802119e4e253D5C19aA06A5d567C5a41596D6803",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "JOE_ADDRESS": {
         "Mainnet": "",
@@ -917,7 +962,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PNG_ADDRESS": {
         "Mainnet": "",
@@ -937,7 +983,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "ETHER_ADDRESS": {
         "Mainnet": "",
@@ -957,7 +1004,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "NATIVE_TOKEN_ADDRESS": {
         "Mainnet": "0x0000000000000000000000000000000000000000",
@@ -977,7 +1025,8 @@
         "Celo": "0x471ece3750da237f93b8e339c536989b8978a438",
         "Fantom": "0x0000000000000000000000000000000000000000",
         "Aurora": "0x0000000000000000000000000000000000000000",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": "0x0000000000000000000000000000000000000000"
     },
     "WETH_ADDRESS": {
         "Mainnet": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
@@ -997,7 +1046,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aWETH_ADDRESS": {
         "Mainnet": "0x030bA81f1c18d280636F32af80b9AAd02Cf0854e",
@@ -1017,7 +1067,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "ZRX_ADDRESS": {
         "Mainnet": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
@@ -1037,7 +1088,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aZRX_ADDRESS": {
         "Mainnet": "0xDf7FF54aAcAcbFf42dfe29DD6144A69b629f8C9e",
@@ -1057,7 +1109,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNI_ADDRESS": {
         "Mainnet": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
@@ -1077,7 +1130,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aUNI_ADDRESS": {
         "Mainnet": "0xB9D7CB55f463405CDfBe4E90a6D2Df01C2B92BF1",
@@ -1097,7 +1151,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "LIDO_ADDRESS": {
         "Mainnet": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
@@ -1117,7 +1172,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "AAVE_ADDRESS": {
         "Mainnet": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
@@ -1137,7 +1193,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aAAVE_ADDRESS": {
         "Mainnet": "0xFFC97d72E13E01096502Cb8Eb52dEe56f74DAD7B",
@@ -1157,7 +1214,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BAT_ADDRESS": {
         "Mainnet": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
@@ -1177,7 +1235,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aBAT_ADDRESS": {
         "Mainnet": "0x05Ec93c0365baAeAbF7AefFb0972ea7ECdD39CF1",
@@ -1197,7 +1256,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "ENJ_ADDRESS": {
         "Mainnet": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
@@ -1217,7 +1277,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aENJ_ADDRESS": {
         "Mainnet": "0xaC6Df26a590F08dcC95D5a4705ae8abbc88509Ef",
@@ -1237,7 +1298,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "KNC_ADDRESS": {
         "Mainnet": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
@@ -1257,7 +1319,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aKNC_ADDRESS": {
         "Mainnet": "0x39C6b3e42d6A679d7D776778Fe880BC9487C2EDA",
@@ -1277,7 +1340,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "LINK_ADDRESS": {
         "Mainnet": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
@@ -1297,7 +1361,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aLINK_ADDRESS": {
         "Mainnet": "0xa06bC25B5805d5F8d82847D191Cb4Af5A3e873E0",
@@ -1317,7 +1382,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MANA_ADDRESS": {
         "Mainnet": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
@@ -1337,7 +1403,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aMANA_ADDRESS": {
         "Mainnet": "0xa685a61171bb30d4072B338c80Cb7b2c865c873E",
@@ -1357,7 +1424,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "REN_ADDRESS": {
         "Mainnet": "0x408e41876cCCDC0F92210600ef50372656052a38",
@@ -1377,7 +1445,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aREN_ADDRESS": {
         "Mainnet": "0xCC12AbE4ff81c9378D670De1b57F8e0Dd228D77a",
@@ -1397,7 +1466,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SNX_ADDRESS": {
         "Mainnet": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
@@ -1417,7 +1487,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aSNX_ADDRESS": {
         "Mainnet": "0x35f6B052C598d933D69A4EEC4D04c73A191fE6c2",
@@ -1437,7 +1508,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TUSD_ADDRESS": {
         "Mainnet": "0x0000000000085d4780B73119b644AE5ecd22b376",
@@ -1457,7 +1529,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aTUSD_ADDRESS": {
         "Mainnet": "0x101cc05f4A51C0319f570d5E146a8C625198e636",
@@ -1477,7 +1550,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "CRV_ADDRESS": {
         "Mainnet": "0xD533a949740bb3306d119CC777fa900bA034cd52",
@@ -1497,7 +1571,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aCRV_ADDRESS": {
         "Mainnet": "0x8dAE6Cb04688C62d939ed9B68d32Bc62e49970b1",
@@ -1517,7 +1592,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "GUSD_ADDRESS": {
         "Mainnet": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
@@ -1537,7 +1613,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aGUSD_ADDRESS": {
         "Mainnet": "0xD37EE7e4f452C6638c96536e68090De8cBcdb583",
@@ -1557,7 +1634,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BAL_ADDRESS": {
         "Mainnet": "0xba100000625a3754423978a60c9317c58a424e3D",
@@ -1577,7 +1655,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aBAL_ADDRESS": {
         "Mainnet": "0x272F97b7a56a387aE942350bBC7Df5700f8a4576",
@@ -1597,7 +1676,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "xSUSHI_ADDRESS": {
         "Mainnet": "0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272",
@@ -1617,7 +1697,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aXSUSHI_ADDRESS": {
         "Mainnet": "0xF256CC7847E919FAc9B808cC216cAc87CCF2f47a",
@@ -1637,7 +1718,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "renFIL_ADDRESS": {
         "Mainnet": "0xD5147bc8e386d91Cc5DBE72099DAC6C9b99276F5",
@@ -1657,7 +1739,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aRENFIL_ADDRESS": {
         "Mainnet": "0x514cd6756CCBe28772d4Cb81bC3156BA9d1744aa",
@@ -1677,7 +1760,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "RAI_ADDRESS": {
         "Mainnet": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
@@ -1697,7 +1781,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aRAI_ADDRESS": {
         "Mainnet": "0xc9BC48c72154ef3e5425641a3c747242112a46AF",
@@ -1717,7 +1802,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "USDP_ADDRESS": {
         "Mainnet": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
@@ -1737,7 +1823,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aUSDP_ADDRESS": {
         "Mainnet": "0x2e8F4bdbE3d47d7d7DE490437AeA9915D930F1A3",
@@ -1757,7 +1844,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "DPI_ADDRESS": {
         "Mainnet": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
@@ -1777,7 +1865,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aDPI_ADDRESS": {
         "Mainnet": "0x6F634c6135D2EBD550000ac92F494F9CB8183dAe",
@@ -1797,7 +1886,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "FRAX_ADDRESS": {
         "Mainnet": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
@@ -1817,7 +1907,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aFRAX_ADDRESS": {
         "Mainnet": "0xd4937682df3C8aEF4FE912A96A74121C0829E664",
@@ -1837,7 +1928,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "FEI_ADDRESS": {
         "Mainnet": "0x956F47F50A910163D8BF957Cf5846D573E7f87CA",
@@ -1857,7 +1949,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aFEI_ADDRESS": {
         "Mainnet": "0x683923dB55Fead99A79Fa01A27EeC3cB19679cC3",
@@ -1877,7 +1970,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aWBTC_ADDRESS": {
         "Mainnet": "0x9ff58f4fFB29fA2266Ab25e75e2A8b3503311656",
@@ -1897,7 +1991,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aYFI_ADDRESS": {
         "Mainnet": "0x5165d24277cD063F5ac44Efd447B27025e888f37",
@@ -1917,7 +2012,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aBUSD_ADDRESS": {
         "Mainnet": "0xA361718326c15715591c299427c62086F69923D9",
@@ -1937,7 +2033,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aDAI_ADDRESS": {
         "Mainnet": "0x028171bCA77440897B824Ca71D1c56caC55b68A3",
@@ -1957,7 +2054,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aMKR_ADDRESS": {
         "Mainnet": "0xc713e5E149D5D0715DcD1c156a020976e7E56B88",
@@ -1977,7 +2075,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aSUSD_ADDRESS": {
         "Mainnet": "0x6C5024Cd4F8A59110119C56f8933403A539555EB",
@@ -1997,7 +2096,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aUSDC_ADDRESS": {
         "Mainnet": "0xBcca60bB61934080951369a648Fb03DF4F96263C",
@@ -2017,7 +2117,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "aAMPL_ADDRESS": {
         "Mainnet": "0x1E6bb68Acec8fefBD87D192bE09bb274170a0548",
@@ -2037,6 +2138,7 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": "0x0000000000000000000000000000000000000000"
     }
 }

--- a/packages/web3-constants/evm/trader.json
+++ b/packages/web3-constants/evm/trader.json
@@ -17,7 +17,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_V2_FACTORY_ADDRESS": {
         "Mainnet": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
@@ -37,7 +38,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_V2_THEGRAPH": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
@@ -57,7 +59,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_V2_INIT_CODE_HASH": {
         "Mainnet": "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
@@ -77,7 +80,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_SWAP_ROUTER_ADDRESS": {
         "Mainnet": "0xe592427a0aece92de3edee1f18e0157c05861564",
@@ -97,7 +101,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_V3_FACTORY_ADDRESS": {
         "Mainnet": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
@@ -117,7 +122,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_V3_QUOTER_ADDRESS": {
         "Mainnet": "0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6",
@@ -137,7 +143,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_V3_THEGRAPH": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3",
@@ -157,7 +164,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "UNISWAP_V3_INIT_CODE_HASH": {
         "Mainnet": "0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54",
@@ -177,7 +185,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SUSHISWAP_ROUTER_ADDRESS": {
         "Mainnet": "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F",
@@ -197,7 +206,8 @@
         "Celo": "0x1421bDe4B10e8dd459b3BCb598810B1337D56842",
         "Fantom": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506",
         "Aurora": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SUSHISWAP_FACTORY_ADDRESS": {
         "Mainnet": "0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac",
@@ -217,7 +227,8 @@
         "Celo": "0xc35DADB65012eC5796536bD9864eD8773aBc74C4",
         "Fantom": "0xc35DADB65012eC5796536bD9864eD8773aBc74C4",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SUSHISWAP_THEGRAPH": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/zippoxer/sushiswap-subgraph-fork",
@@ -237,7 +248,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SUSHISWAP_INIT_CODE_HASH": {
         "Mainnet": "0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303",
@@ -257,7 +269,8 @@
         "Celo": "0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303",
         "Fantom": "0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SASHIMISWAP_ROUTER_ADDRESS": {
         "Mainnet": "0xe4fe6a45f354e845f954cddee6084603cedb9410",
@@ -277,7 +290,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SASHIMISWAP_FACTORY_ADDRESS": {
         "Mainnet": "0xF028F723ED1D0fE01cC59973C49298AA95c57472",
@@ -297,7 +311,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SASHIMISWAP_THEGRAPH": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/sashimiproject/sashimi",
@@ -317,7 +332,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "SASHIMISWAP_INIT_CODE_HASH": {
         "Mainnet": "0xb465bbe4edb8c9b0da8ff0b2b36ce0065de9fcd5a33f32c6856ea821779c8b72",
@@ -337,7 +353,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "QUICKSWAP_ROUTER_ADDRESS": {
         "Mainnet": "",
@@ -357,7 +374,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "QUICKSWAP_FACTORY_ADDRESS": {
         "Mainnet": "",
@@ -377,7 +395,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "QUICKSWAP_THEGRAPH": {
         "Mainnet": "",
@@ -397,7 +416,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "QUICKSWAP_INIT_CODE_HASH": {
         "Mainnet": "",
@@ -417,7 +437,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANCAKESWAP_ROUTER_ADDRESS": {
         "Mainnet": "",
@@ -437,7 +458,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANCAKESWAP_FACTORY_ADDRESS": {
         "Mainnet": "",
@@ -457,7 +479,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANCAKESWAP_THEGRAPH": {
         "Mainnet": "",
@@ -477,7 +500,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANCAKESWAP_INIT_CODE_HASH": {
         "Mainnet": "",
@@ -497,7 +521,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BALANCER_ETH_ADDRESS": {
         "Mainnet": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -517,7 +542,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BALANCER_EXCHANGE_PROXY_ADDRESS": {
         "Mainnet": "0x3E66B66Fd1d0b02fDa6C811Da9E0547970DB2f21",
@@ -537,7 +563,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BALANCER_POOLS_URL": {
         "Mainnet": "https://ipfs.fleek.co/ipns/balancer-bucket.storage.fleek.co/balancer-exchange/pools",
@@ -557,7 +584,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "DODO_ETH_ADDRESS": {
         "Mainnet": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -577,7 +605,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "DODO_EXCHANGE_PROXY_ADDRESS": {
         "Mainnet": "0xCB859eA579b28e02B87A1FDE08d087ab9dbE5149",
@@ -597,7 +626,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x335aC99bb3E51BDbF22025f092Ebc1Cf2c5cC619",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BANCOR_ETH_ADDRESS": {
         "Mainnet": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -617,7 +647,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "BANCOR_EXCHANGE_PROXY_ADDRESS": {
         "Mainnet": "0x2F9EC37d6CcFFf1caB21733BdaDEdE11c823cCB0",
@@ -637,7 +668,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRADERJOE_ROUTER_ADDRESS": {
         "Mainnet": "",
@@ -657,7 +689,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRADERJOE_FACTORY_ADDRESS": {
         "Mainnet": "",
@@ -677,7 +710,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRADERJOE_THEGRAPH": {
         "Mainnet": "https://api.thegraph.com/subgraphs/name/traderjoe-xyz/exchange",
@@ -697,7 +731,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRADERJOE_INIT_CODE_HASH": {
         "Mainnet": "",
@@ -717,7 +752,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "OPENOCEAN_ETH_ADDRESS": {
         "Mainnet": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
@@ -737,7 +773,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "OPENOCEAN_EXCHANGE_PROXY_ADDRESS": {
         "Mainnet": "0x6352a56caadC4F1E25CD6c75970Fa768A3304e64",
@@ -757,7 +794,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANGOLIN_ROUTER_ADDRESS": {
         "Mainnet": "",
@@ -777,7 +815,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANGOLIN_FACTORY_ADDRESS": {
         "Mainnet": "",
@@ -797,7 +836,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANGOLIN_THEGRAPH": {
         "Mainnet": "",
@@ -817,7 +857,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "PANGOLIN_INIT_CODE_HASH": {
         "Mainnet": "",
@@ -837,7 +878,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "WANNASWAP_ROUTER_V2_ADDRESS": {
         "Mainnet": "",
@@ -857,7 +899,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0xa3a1eF5Ae6561572023363862e238aFA84C72ef5",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "WANNASWAP_ROUTER_ADDRESS": {
         "Mainnet": "",
@@ -877,7 +920,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x8f1E0Cf0f9f269Bc977C38635E560aa5b0E63323",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "WANNASWAP_FACTORY_ADDRESS": {
         "Mainnet": "",
@@ -897,7 +941,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x7928D4FeA7b2c90C732c10aFF59cf403f0C38246",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "WANNASWAP_THEGRAPH": {
         "Mainnet": "",
@@ -917,7 +962,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "WANNASWAP_INIT_CODE_HASH": {
         "Mainnet": "",
@@ -937,7 +983,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0xa06b8b0642cf6a9298322d0c8ac3c68c291ca24dc66245cf23aa2abc33b57e21",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRISOLARIS_ROUTER_ADDRESS": {
         "Mainnet": "",
@@ -957,7 +1004,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x2CB45Edb4517d5947aFdE3BEAbF95A582506858B",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRISOLARIS_FACTORY_ADDRESS": {
         "Mainnet": "",
@@ -977,7 +1025,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0xc66F594268041dB60507F00703b152492fb176E7",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRISOLARIS_THEGRAPH": {
         "Mainnet": "",
@@ -997,7 +1046,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRISOLARIS_INIT_CODE_HASH": {
         "Mainnet": "",
@@ -1017,7 +1067,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "0x754e1d90e536e4c1df81b7f030f47b4ca80c87120e145c294f098c83a6cb5ace",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MDEX_ROUTER_ADDRESS": {
         "Mainnet": "0x74119c3bca85bEA0538A62319a79b4a372590B47",
@@ -1037,7 +1088,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MDEX_FACTORY_ADDRESS": {
         "Mainnet": "0x7DAe51BD3E3376B8c7c4900E9107f12Be3AF1bA8",
@@ -1057,7 +1109,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MDEX_THEGRAPH": {
         "Mainnet": "",
@@ -1077,7 +1130,8 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "MDEX_INIT_CODE_HASH": {
         "Mainnet": "0x8ecc069c645df696f2ca5116ab459c5c2889f299e73c1b208aaa3cdd7d110b16",
@@ -1097,6 +1151,7 @@
         "Celo": "",
         "Fantom": "",
         "Aurora": "",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     }
 }

--- a/packages/web3-constants/evm/zerion.json
+++ b/packages/web3-constants/evm/zerion.json
@@ -17,7 +17,8 @@
         "Celo": "celo-assets",
         "Fantom": "fantom-assets",
         "Aurora": "aurora-assets",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     },
     "TRANSACTIONS_SCOPE_NAME": {
         "Mainnet": "transactions",
@@ -37,6 +38,7 @@
         "Celo": "celo-transactions",
         "Fantom": "fantom-transactions",
         "Aurora": "aurora-transactions",
-        "Aurora_Testnet": ""
+        "Aurora_Testnet": "",
+        "Conflux": ""
     }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
