### PR TITLE
fix(tip): adjust size of the badge of WalletIcon

### DIFF
--- a/packages/mask/src/plugins/NextID/components/Tip/TipDialog.tsx
+++ b/packages/mask/src/plugins/NextID/components/Tip/TipDialog.tsx
@@ -36,6 +36,7 @@ import { TipForm } from './TipForm'
 const useStyles = makeStyles()((theme) => ({
     dialog: {
         width: 600,
+        backgroundImage: 'none',
     },
     dialogTitle: {
         height: 60,
@@ -257,7 +258,12 @@ export function TipDialog({ open = false, onClose }: TipDialogProps) {
 
     const walletChip = account ? (
         <div className={classes.walletChip}>
-            <WalletIcon size={30} networkIcon={providerDescriptor?.icon} providerIcon={networkDescriptor?.icon} />
+            <WalletIcon
+                size={30}
+                badgeSize={12}
+                networkIcon={providerDescriptor?.icon}
+                providerIcon={networkDescriptor?.icon}
+            />
             <div className={classes.wallet}>
                 <Typography ml={1} className={classes.walletTitle}>
                     {walletTitle}


### PR DESCRIPTION
fix background color in dark mode by the way

https://mask.atlassian.net/browse/MF-380


## before
![image](https://user-images.githubusercontent.com/1141198/162185711-906ca371-82bf-42dd-bee7-5e57e31713ea.png)

## after


![image](https://user-images.githubusercontent.com/1141198/162185723-681a8f7c-118b-4f6e-afba-04d4f21ac6c6.png)
