### PR TITLE
fix(facebook): on mobile, facebook can't detect user's account

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -208,6 +208,7 @@
         "rhonin",
         "rica",
         "rindexed",
+        "rootcontainer",
         "rpid",
         "rpids",
         "sablier",

--- a/packages/mask/src/social-network-adaptor/facebook.com/collecting/identity.ts
+++ b/packages/mask/src/social-network-adaptor/facebook.com/collecting/identity.ts
@@ -50,7 +50,6 @@ function resolveCurrentVisitingIdentityInner(
         const bio = getBioDescription()
         const handle = getFacebookId()
         const homepage = getPersonalHomepage()
-
         const avatar = getAvatar()
 
         ref.value = {

--- a/packages/mask/src/social-network-adaptor/facebook.com/utils/selector.ts
+++ b/packages/mask/src/social-network-adaptor/facebook.com/utils/selector.ts
@@ -22,18 +22,24 @@ export const searchAvatarSelector: () => LiveSelector<HTMLImageElement, true> = 
 export const searchNickNameSelector: () => LiveSelector<HTMLHeadingElement, true> = () =>
     querySelector<HTMLHeadingElement>('span[dir="auto"] div h1')
 
-export const searchNickNameSelectorOnMobile: () => LiveSelector<E, true> = () => querySelector<E>('#cover-name-root h3')
-
+// export const searchNickNameSelectorOnMobile: () => LiveSelector<E, true> = () => querySelector<E>('#cover-name-root h3')
+export const searchNickNameSelectorOnMobile: () => LiveSelector<E, true> = () => querySelector<E>('#screen-root h1')
+export const searchNickNameSelectorOnMobileBig: () => LiveSelector<E, true> = () =>
+    querySelector<E>('#rootcontainer h3')
 export const bioDescriptionSelector = () =>
     querySelector('span[dir="auto"] div h1').closest(7).querySelector<HTMLSpanElement>('span[dir="auto"] > span')
 
-export const bioDescriptionSelectorOnMobile: () => LiveSelector<HTMLDivElement, true> = () => querySelector('#bio div')
+// export const bioDescriptionSelectorOnMobile: () => LiveSelector<HTMLDivElement, true> = () => querySelector('#bio div')
+export const bioDescriptionSelectorOnMobile: () => LiveSelector<HTMLDivElement, true> = () =>
+    querySelector('#screen-root > div > :nth-child(2) > :nth-child(3) > :nth-child(3) > :nth-child(2) div[dir="auto"]')
 
 export const searchUserIdSelector: () => LiveSelector<HTMLAnchorElement, true> = () =>
     querySelector<HTMLAnchorElement>('div[data-pagelet="ProfileTabs"] a[role="tab"]')
 
-export const searchUserIdSelectorOnMobile: () => LiveSelector<HTMLAnchorElement, true> = () =>
-    querySelector<HTMLAnchorElement>('#tlFeed div[data-sigil="scroll-area"] a:last-child')
+export const searchUserIdSelectorOnMobile = () => {
+    const matched = location.pathname.match(/\d+/)
+    return matched?.[0] ?? ''
+}
 
 // #endregion facebook nft avatar
 
@@ -47,9 +53,11 @@ export const searchFacebookAvatarMobileListSelector = () => querySelector('#nuxC
 export const searchFacebookAvatarSelector = () =>
     querySelector('[role="main"] [role="button"] svg[role="img"],[role="main"] [role="link"] svg[role="img"]')
 
-export const searchFacebookAvatarOnMobileSelector = () =>
-    querySelector('[data-sigil="timeline-cover"] i[aria-label$="picture"]')
+// export const searchFacebookAvatarOnMobileSelector = () =>
+//    querySelector('[data-sigil="timeline-cover"] i[aria-label$="picture"]')
 
+export const searchFacebookAvatarOnMobileSelector = () =>
+    querySelector('#screen-root > div > :nth-child(2) > :nth-child(3) > :nth-child(8) > :nth-child(2) img')
 export const searchFaceBookPostAvatarSelector = () =>
     new LiveSelector<SVGElement, false>().querySelectorAll<SVGElement>(
         '[type="nested/pressable"] > a > div > svg, ul div[role="article"] a > div > svg[role="none"]',
@@ -115,7 +123,7 @@ export const profileSectionSelector: () => LiveSelector<E, true> = () =>
     querySelector<E>('[data-pagelet="ProfileAppSection_0"], [data-pagelet="ProfileTimeline"]').querySelector('[style]')
 
 export const searchIntroSectionSelector: () => LiveSelector<E, true> = () =>
-    querySelector<E>('[data-pagelet="ProfileTilesFeed_0"]')
+    querySelector<E>('[data-pagelet="ProfileAppSection_0"]')
 
 export const searchBioSelector: () => LiveSelector<HTMLSpanElement, true> = () =>
     querySelector<HTMLSpanElement>(
@@ -125,4 +133,4 @@ export const searchBioSelector: () => LiveSelector<HTMLSpanElement, true> = () =
 export const searchResultHeadingSelector = () => querySelector('[role="article"]')
 
 export const searchHomepageSelector: () => LiveSelector<HTMLSpanElement, true> = () =>
-    querySelector<HTMLSpanElement>('[data-pagelet="ProfileTilesFeed_0"] ul a span[dir="auto"]')
+    querySelector<HTMLSpanElement>('[data-pagelet="ProfileAppSection_0"] ul a')

--- a/packages/mask/src/social-network-adaptor/facebook.com/utils/user.ts
+++ b/packages/mask/src/social-network-adaptor/facebook.com/utils/user.ts
@@ -8,6 +8,7 @@ import {
     searchIntroSectionSelector,
     searchNickNameSelector,
     searchNickNameSelectorOnMobile,
+    searchNickNameSelectorOnMobileBig,
     searchUserIdSelector,
     searchUserIdSelectorOnMobile,
 } from './selector'
@@ -16,7 +17,9 @@ import { isMobileFacebook } from './isMobile'
 import { bioDescription, personalHomepage } from '../../../settings/settings'
 
 export const getNickName = () => {
-    const node = isMobileFacebook ? searchNickNameSelectorOnMobile().evaluate() : searchNickNameSelector().evaluate()
+    const node = isMobileFacebook
+        ? searchNickNameSelectorOnMobile().evaluate() || searchNickNameSelectorOnMobileBig().evaluate()
+        : searchNickNameSelector().evaluate()
     if (!node) return ''
 
     return collectNodeText(node)
@@ -28,31 +31,29 @@ export const getAvatar = () => {
         : searchAvatarSelector().evaluate()
     if (!node) return
 
-    const imageURL =
-        (isMobileFacebook
-            ? node.style.background.match(/\(["']?(.*?)["']?\)/)?.[1]
-            : node.getAttribute('xlink:href')) ?? ''
+    const imageURL = (isMobileFacebook ? node.getAttribute('src') : node.getAttribute('xlink:href')) ?? ''
 
     return imageURL.trim()
 }
 
 export const getBioDescription = () => {
-    const intro = searchIntroSectionSelector().evaluate()
     const node = isMobileFacebook ? bioDescriptionSelectorOnMobile().evaluate() : searchBioSelector().evaluate()
-
-    if (intro && node) {
+    if (node) {
         const text = collectNodeText(node)
         bioDescription[EnhanceableSite.Facebook].value = text
-    } else if (intro) {
-        bioDescription[EnhanceableSite.Facebook].value = ''
+    } else {
+        const intro = searchIntroSectionSelector().evaluate()
+        if (!isMobileFacebook && !intro) {
+            bioDescription[EnhanceableSite.Facebook].value = ''
+        }
     }
 
     return bioDescription[EnhanceableSite.Facebook].value
 }
 
 export const getFacebookId = () => {
-    const node = isMobileFacebook ? searchUserIdSelectorOnMobile().evaluate() : searchUserIdSelector().evaluate()
-
+    if (isMobileFacebook) return searchUserIdSelectorOnMobile()
+    const node = searchUserIdSelector().evaluate()
     if (!node) return ''
     const url = new URL(node.href)
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # mf-251

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
