### PR TITLE
fix: update reply area selector for mobile

### DIFF
--- a/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
@@ -122,7 +122,7 @@ export const postEditorDraftContentSelector = () => {
         )
     }
     if (isReplyPageSelector()) {
-        return querySelector<HTMLElement>('div[data-testid="tweetTextarea_0"]')
+        return querySelector<HTMLElement>('[data-testid="tweetTextarea_0"]')
     }
     return (isCompose() ? postEditorInPopupSelector() : postEditorInTimelineSelector()).querySelector<HTMLElement>(
         '.public-DraftEditor-content, [contenteditable][aria-label][spellcheck]',


### PR DESCRIPTION
Since Twitter has a different DOM tree structure of replying text area on mobile & desktop pages, we update the selector with only `data-testid` as the query factor to better compatibility.