### PR TITLE
fix: fill public when wallet backup only have private key

### DIFF
--- a/packages/backup-format/package.json
+++ b/packages/backup-format/package.json
@@ -11,6 +11,8 @@
   "type": "module",
   "dependencies": {
     "@masknet/shared-base": "workspace:*",
-    "@msgpack/msgpack": "^2.7.2"
+    "@msgpack/msgpack": "^2.7.2",
+    "elliptic": "^6.5.3",
+    "pvtsutils": "^1.2.2"
   }
 }

--- a/packages/backup-format/src/utils/hex2buffer.ts
+++ b/packages/backup-format/src/utils/hex2buffer.ts
@@ -1,0 +1,36 @@
+/** @internal */
+export function hex2buffer(hexString: string, padded?: boolean) {
+    if (hexString.length % 2) {
+        hexString = '0' + hexString
+    }
+    let res = new Uint8Array(hexString.length / 2)
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < hexString.length; i++) {
+        // eslint-disable-next-line no-plusplus
+        const c = hexString.slice(i, ++i + 1)
+        res[(i - 1) / 2] = Number.parseInt(c, 16)
+    }
+    // BN padding
+    if (padded) {
+        let len = res.length
+        len = len > 32 ? (len > 48 ? 66 : 48) : 32
+        if (res.length < len) {
+            res = concat(new Uint8Array(len - res.length), res)
+        }
+    }
+    return res
+}
+
+/** @internal */
+function concat(...buf: (Uint8Array | number[])[]) {
+    const res = new Uint8Array(buf.map((item) => item.length).reduce((prev, cur) => prev + cur))
+    let offset = 0
+    buf.forEach((item, index) => {
+        // eslint-disable-next-line no-plusplus
+        for (let i = 0; i < item.length; i++) {
+            res[offset + i] = item[i]
+        }
+        offset += item.length
+    })
+    return res
+}

--- a/packages/backup-format/src/version-2/index.ts
+++ b/packages/backup-format/src/version-2/index.ts
@@ -10,10 +10,13 @@ import {
     ProfileIdentifier,
     RelationFavor,
 } from '@masknet/shared-base'
+import __ from 'elliptic'
+import { Convert } from 'pvtsutils'
 import { decode, encode } from '@msgpack/msgpack'
 import { Err, None, Some } from 'ts-results'
 import { createEmptyNormalizedBackup } from '../normalize'
 import type { NormalizedBackup } from '../normalize/type'
+import { hex2buffer } from '../utils/hex2buffer'
 
 export function isBackupVersion2(item: unknown): item is BackupJSONFileVersion2 {
     try {
@@ -146,6 +149,16 @@ export function normalizeBackupVersion2(item: BackupJSONFileVersion2): Normalize
     }
 
     for (const wallet of wallets || []) {
+        if (wallet.privateKey?.d && !wallet.publicKey) {
+            // @ts-ignore
+            const ec = new (__.ec || __.default.ec)('secp256k1') as __.ec
+            const key = ec.keyFromPrivate(wallet.privateKey.d)
+            const hexPub = key.getPublic('hex').slice(2)
+            const hexX = hexPub.slice(0, hexPub.length / 2)
+            const hexY = hexPub.slice(hexPub.length / 2, hexPub.length)
+            wallet.privateKey.x = Convert.ToBase64Url(hex2buffer(hexX))
+            wallet.privateKey.y = Convert.ToBase64Url(hex2buffer(hexY))
+        }
         const normalizedWallet: NormalizedBackup.WalletBackup = {
             address: wallet.address,
             name: wallet.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,13 @@ importers:
     specifiers:
       '@masknet/shared-base': workspace:*
       '@msgpack/msgpack': ^2.7.2
+      elliptic: ^6.5.3
+      pvtsutils: ^1.2.2
     dependencies:
       '@masknet/shared-base': link:../shared-base
       '@msgpack/msgpack': 2.7.2
+      elliptic: 6.5.4
+      pvtsutils: 1.2.2
 
   packages/configuration:
     specifiers:


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
