### PR TITLE
fix: remove duplicate profile in linked profile when restore

### DIFF
--- a/packages/mask/background/database/persona/web.ts
+++ b/packages/mask/background/database/persona/web.ts
@@ -454,13 +454,28 @@ export async function updateProfileDB(
     if (!old) throw new Error('Updating a non exists record')
 
     if (old.linkedPersona && updating.linkedPersona && old.linkedPersona !== updating.linkedPersona) {
-        const ide = Identifier.fromString(old.identifier, ProfileIdentifier).unwrap()
-        const oldLinkedPersona = await queryPersonaByProfileDB(ide, t)
+        const oldIdentifier = Identifier.fromString(old.identifier, ProfileIdentifier).unwrap()
+        const oldLinkedPersona = await queryPersonaByProfileDB(oldIdentifier, t)
 
         if (oldLinkedPersona) {
-            oldLinkedPersona.linkedProfiles.delete(ide)
+            oldLinkedPersona.linkedProfiles.delete(oldIdentifier)
             await updatePersonaDB(
                 oldLinkedPersona,
+                {
+                    linkedProfiles: 'replace',
+                    explicitUndefinedField: 'ignore',
+                },
+                t,
+            )
+        }
+    }
+
+    if (updating.linkedPersona && old.linkedPersona !== updating.linkedPersona) {
+        const linkedPersona = await queryPersonaDB(updating.linkedPersona, t)
+        if (linkedPersona) {
+            linkedPersona.linkedProfiles.set(updating.identifier, { connectionConfirmState: 'confirmed' })
+            await updatePersonaDB(
+                linkedPersona,
                 {
                     linkedProfiles: 'replace',
                     explicitUndefinedField: 'ignore',


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
