### PR TITLE
fix: send icon fill missing

### DIFF
--- a/packages/dashboard/src/pages/Wallets/components/Balance/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Balance/index.tsx
@@ -122,10 +122,13 @@ export const Balance = memo<BalanceCardProps>(
                 </Box>
                 {showOperations && (
                     <ButtonGroup>
-                        <Button size="small" onClick={onSend} endIcon={<SendIcon fontSize="inherit" />}>
+                        <Button
+                            size="small"
+                            onClick={onSend}
+                            endIcon={<SendIcon style={{ fill: '#fff' }} fontSize="inherit" />}>
                             {t.wallets_balance_Send()}
                         </Button>
-                        <Button size="small" onClick={onBuy} endIcon={<CardIcon fill="none" fontSize="inherit" />}>
+                        <Button size="small" onClick={onBuy} endIcon={<CardIcon fontSize="inherit" />}>
                             {t.wallets_balance_Buy()}
                         </Button>
                         <Button size="small" onClick={onSwap} endIcon={<SwapIcon fontSize="inherit" />}>

--- a/packages/mask/src/components/CompositionDialog/CompositionUI.tsx
+++ b/packages/mask/src/components/CompositionDialog/CompositionUI.tsx
@@ -78,6 +78,11 @@ const useStyles = makeStyles()((theme) => ({
         boxSizing: 'border-box',
         borderRadius: 8,
     },
+    sendIcon: {
+        width: 18,
+        height: 18,
+        fill: theme.palette.text.buttonText,
+    },
 }))
 
 export interface LazyRecipients {
@@ -239,7 +244,7 @@ export const CompositionDialogUI = forwardRef<CompositionRef, CompositionProps>(
                     loadingPosition="start"
                     variant="roundedContained"
                     onClick={onSubmit}
-                    startIcon={<SendIcon style={{ width: 18, height: 18 }} />}>
+                    startIcon={<SendIcon className={classes.sendIcon} />}>
                     {t('post_dialog__button')}
                 </LoadingButton>
             </div>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-765

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
