### PR TITLE
refactor: move conditional text logic into i18n layer

### DIFF
--- a/packages/mask/src/utils/i18n-next-ui.ts
+++ b/packages/mask/src/utils/i18n-next-ui.ts
@@ -3,11 +3,17 @@ import type en from '../../shared-ui/locales/en-US.json'
 import type { i18NextInstance, TranslateOptions } from '@masknet/shared-base'
 import { SupportedLanguages } from '@masknet/public-api'
 
-export type I18NFunction = <TKeys extends keyof typeof en>(
+type PluralsSuffix = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other'
+
+type LocaleKeys = keyof typeof en
+type ExtendBaseKeys<K> = K extends `${infer B}$${string}` ? B | K : K extends `${infer B}_${PluralsSuffix}` ? B | K : K
+type AvailableLocaleKeys = ExtendBaseKeys<LocaleKeys>
+
+export type I18NFunction = <TKeys extends AvailableLocaleKeys>(
     key: TKeys | TKeys[],
     // defaultValue?: string,
     options?: TranslateOptions | string,
-) => typeof en[TKeys]
+) => string
 
 /**
  * Enhanced version of useTranslation

--- a/packages/shared-base/src/i18n/instance.ts
+++ b/packages/shared-base/src/i18n/instance.ts
@@ -15,6 +15,7 @@ if (!i18n.isInitialized) {
     i18n.use(Detector).init({
         keySeparator: false,
         interpolation: { escapeValue: false },
+        contextSeparator: '$',
         fallbackLng: {
             'zh-CN': ['zh-TW', 'en'],
             'zh-TW': ['zh-CN', 'en'],


### PR DESCRIPTION
Set `contextSeparator` to `$`

https://mask.atlassian.net/browse/MF-773

- [ ] Would rewrite some usage which as following screenshot shows

![image](https://user-images.githubusercontent.com/1141198/169451357-12c4e237-5a81-4b6d-b5a5-632892079262.png)
