### PR TITLE
fix: scale10 returns the wrong value

### DIFF
--- a/packages/web3-shared/base/src/utils/number.ts
+++ b/packages/web3-shared/base/src/utils/number.ts
@@ -51,7 +51,7 @@ export function pow10(n: BigNumber.Value) {
 
 /** scale 10 ** n * m */
 export function scale10(m: BigNumber.Value, n = 1) {
-    const x = new BigNumber(10).shiftedBy(n)
+    const x = new BigNumber(1).shiftedBy(n)
     return n === 1 ? x : x.multipliedBy(m)
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I found a bug of scale10. We are using it with expectations like `pow10`. E.g, `pow(5).multipledBy(5)` is not equal to `scale10(5, 5)`.


Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)
