### PR TITLE
feat: add v37 support for developers

### DIFF
--- a/packages/encryption/src/encryption/DecryptionTypes.ts
+++ b/packages/encryption/src/encryption/DecryptionTypes.ts
@@ -89,8 +89,6 @@ export interface DecryptStaticECDH_PostKey {
 export interface DecryptEphemeralECDH_PostKey {
     encryptedPostKey: Uint8Array
     /** For the first time encryption, it might be included in the post payload. */
-    postKeyIV?: Uint8Array
-    /** For the first time encryption, it might be included in the post payload. */
     ephemeralPublicKey?: EC_Public_CryptoKey
     ephemeralPublicKeySignature?: Uint8Array
 }

--- a/packages/encryption/src/encryption/utils.ts
+++ b/packages/encryption/src/encryption/utils.ts
@@ -31,9 +31,6 @@ async function generateEC_KeyPair(io: Pick<EncryptIO, 'getRandomECKey'>, kind: E
     const namedCurve: Record<EC_KeyCurveEnum, string> = {
         [EC_KeyCurveEnum.secp256p1]: 'P-256',
         [EC_KeyCurveEnum.secp256k1]: 'K-256',
-        get [EC_KeyCurveEnum.ed25519](): string {
-            throw new Error('TODO: support ED25519')
-        },
     }
     const { privateKey, publicKey } = await crypto.subtle.generateKey(
         { name: 'ECDH', namedCurve: namedCurve[kind] },

--- a/packages/encryption/src/index.ts
+++ b/packages/encryption/src/index.ts
@@ -60,4 +60,4 @@ export {
 } from './image-steganography'
 
 // TODO: remove them in the future
-export { importEC_Key, importAES as importAESFromJWK } from './utils'
+export { importEC_Key, getEcKeyCurve, importAES as importAESFromJWK } from './utils'

--- a/packages/encryption/src/payload/types.ts
+++ b/packages/encryption/src/payload/types.ts
@@ -101,7 +101,8 @@ export interface EC_Key<K extends EC_CryptoKey = EC_CryptoKey> {
     readonly key: K
 }
 export enum EC_KeyCurveEnum {
-    ed25519 = 0,
+    // ed25519 = 0, Ed25519 is not supported by WebCrypto. Don't have a standard name, but maybe "Ed25519"
+    // https://github.com/tQsW/webcrypto-curve25519/blob/master/explainer.md
     secp256p1 = 1, // P-256
     secp256k1 = 2, // K-256
 }

--- a/packages/encryption/src/social-network-encode-decode/index.ts
+++ b/packages/encryption/src/social-network-encode-decode/index.ts
@@ -1,17 +1,30 @@
 import { SocialNetworkEnum } from '../payload/types'
+import { sharedDecoder, sharedEncoder } from './shared'
 import { TwitterDecoder, __TwitterEncoder } from './twitter'
 
-export function socialNetworkDecoder(network: SocialNetworkEnum, content: string): string[] {
-    if (network === SocialNetworkEnum.Twitter)
+export function socialNetworkDecoder(network: SocialNetworkEnum, content: string): Array<string | Uint8Array> {
+    if (network === SocialNetworkEnum.Twitter) {
         return TwitterDecoder(content)
             .map((x) => [x])
             .unwrapOr([])
-    const all = content.match(/(\u{1F3BC}[\w+/=|]+:\|\|)/giu)
-    if (all) return all
+    }
+    const newVersion = sharedDecoder(content)
+    if (newVersion.some) return [newVersion.val]
+
+    const v38 = content.match(/(\u{1F3BC}[\w+/=|]+:\|\|)/giu)
+    if (v38) return v38
     return []
 }
-export function socialNetworkEncoder(network: SocialNetworkEnum, content: string) {
+export function socialNetworkEncoder(network: SocialNetworkEnum, content: string | Uint8Array): string {
+    // v38
+    if (typeof content === 'string') {
+        if (network === SocialNetworkEnum.Twitter) return __TwitterEncoder(content)
+        return content
+    }
+
+    // v37
     if (network === SocialNetworkEnum.Twitter) return __TwitterEncoder(content)
-    return content
+    return sharedEncoder(content)
 }
+
 export * from './twitter'

--- a/packages/encryption/src/social-network-encode-decode/shared.ts
+++ b/packages/encryption/src/social-network-encode-decode/shared.ts
@@ -1,0 +1,17 @@
+import { decodeArrayBuffer, encodeArrayBuffer } from '@dimensiondev/kit'
+import { None, Option, Some } from 'ts-results'
+/** @internal */
+export function sharedEncoder(input: Uint8Array): string {
+    return `\u{1F3BC}6/8|${encodeArrayBuffer(input)}:||`
+}
+
+/** @internal */
+export function sharedDecoder(input: string): Option<Uint8Array> {
+    const [, payload] = input.match(/\u{1F3BC}6\/8\|(\w+):\|\|/giu) || []
+    if (!payload) return None
+    try {
+        return Some(new Uint8Array(decodeArrayBuffer(payload)))
+    } catch {
+        return None
+    }
+}

--- a/packages/mask/background/network/gun/encryption/queryPostKey.ts
+++ b/packages/mask/background/network/gun/encryption/queryPostKey.ts
@@ -1,5 +1,13 @@
 import { decodeArrayBuffer, encodeArrayBuffer, isNonNull, unreachable } from '@dimensiondev/kit'
-import { type DecryptStaticECDH_PostKey, type EncryptionResultE2EMap, SocialNetworkEnum } from '@masknet/encryption'
+import {
+    type DecryptStaticECDH_PostKey,
+    type DecryptEphemeralECDH_PostKey,
+    type EncryptionResultE2EMap,
+    SocialNetworkEnum,
+    EC_KeyCurveEnum,
+    importEC_Key,
+    getEcKeyCurve,
+} from '@masknet/encryption'
 import type { EC_Public_CryptoKey, EC_Public_JsonWebKey } from '@masknet/shared-base'
 import { CryptoKeyToJsonWebKey } from '../../../../utils-pure'
 import { getGunData, pushToGunDataArray, subscribeGunMapData } from '@masknet/gun-utils'
@@ -74,7 +82,7 @@ namespace Version38Or39 {
             ]).then(() => queue.stop())
 
             async function main(keyProvider: AsyncGenerator<unknown>) {
-                for await (const data of keyProvider) emit(data)
+                for await (const data of keyProvider) Promise.resolve(data).then(emit, noop)
             }
             function emit(result: unknown) {
                 if (abortSignal.aborted) return
@@ -88,11 +96,6 @@ namespace Version38Or39 {
         yield* iter
     }
 
-    export type PublishedAESKeyRecord = {
-        aesKey: { encryptedKey: string; salt: string }
-        receiverKey: EC_Public_JsonWebKey
-    }
-
     /**
      * Publish post keys on the gun
      * @param version current payload
@@ -103,36 +106,27 @@ namespace Version38Or39 {
         version: -39 | -38,
         postIV: Uint8Array,
         network: SocialNetworkEnum,
-        receiversKeys: PublishedAESKeyRecord[] | EncryptionResultE2EMap,
+        receiversKeys: EncryptionResultE2EMap,
     ) {
         const [postHash] = await hashIV(network, postIV)
-        if (Array.isArray(receiversKeys)) {
-            // Store AES key to gun
-            receiversKeys.forEach(async ({ aesKey, receiverKey }) => {
-                const keyHash = await (version === -38 ? hashKey38 : hashKey39)(receiverKey)
-                console.log(`gun[${postHash}][${keyHash}].push(`, aesKey, ')')
-                pushToGunDataArray([postHash, keyHash], aesKey)
-            })
-        } else {
-            if (version === -39) throw new Error('unreachable')
-            for (const result of receiversKeys.values()) {
-                try {
-                    if (result.status === 'rejected') continue
-                    const { encryptedPostKey, target, ivToBePublished } = result.value
-                    if (!ivToBePublished) throw new Error('Missing salt')
-                    const pub = await queryPublicKey(target)
-                    if (!pub) throw new Error('missing key')
-                    const jwk = await CryptoKeyToJsonWebKey(pub)
-                    const keyHash = await hashKey38(jwk)
-                    const post: PublishedAESKeyRecord['aesKey'] = {
-                        encryptedKey: encodeArrayBuffer(encryptedPostKey),
-                        salt: encodeArrayBuffer(ivToBePublished),
-                    }
-                    console.log(`gun[${postHash}][${keyHash}].push(`, post, ')')
-                    pushToGunDataArray([postHash, keyHash], post)
-                } catch (error) {
-                    console.error('[@masknet/encryption] An error occurs when sending E2E keys', error)
+        if (version === -39) throw new Error('unreachable')
+        for (const result of receiversKeys.values()) {
+            try {
+                if (result.status === 'rejected') continue
+                const { encryptedPostKey, target, ivToBePublished } = result.value
+                if (!ivToBePublished) throw new Error('Missing salt')
+                const pub = await queryPublicKey(target)
+                if (!pub) throw new Error('missing key')
+                const jwk = await CryptoKeyToJsonWebKey(pub)
+                const keyHash = await hashKey38(jwk)
+                const post: DataOnGun = {
+                    encryptedKey: encodeArrayBuffer(encryptedPostKey),
+                    salt: encodeArrayBuffer(ivToBePublished),
                 }
+                console.log(`gun[${postHash}][${keyHash}].push(`, post, ')')
+                pushToGunDataArray([postHash, keyHash], post)
+            } catch (error) {
+                console.error('[@masknet/encryption] An error occurs when sending E2E keys', error)
             }
         }
     }
@@ -168,7 +162,7 @@ namespace Version38Or39 {
         const hashPair = '9283464d-ee4e-4e8d-a7f3-cf392a88133f'
         const N = 2
 
-        const hash = (await work(encodeArrayBuffer(iv), hashPair)).slice(0, N)
+        const hash = (await GUN_SEA_work(encodeArrayBuffer(iv), hashPair)).slice(0, N)
         const networkHint = getNetworkHint(network)
         return [`${networkHint}${hash}`, `${networkHint}-${hash}`]
     }
@@ -191,7 +185,7 @@ namespace Version38Or39 {
         const N = 2
 
         const jwk = JSON.stringify(key)
-        const hash = await work(jwk, hashPair)
+        const hash = await GUN_SEA_work(jwk, hashPair)
         return hash.slice(0, N)
     }
 
@@ -199,20 +193,158 @@ namespace Version38Or39 {
         const hashPair = '10198a2f-205f-45a6-9987-3488c80113d0'
         const N = 2
 
-        const hash = await work(jwk.x! + jwk.y!, hashPair)
+        const hash = await GUN_SEA_work(jwk.x! + jwk.y!, hashPair)
+        return hash.slice(0, N)
+    }
+}
+
+// This is a self contained Gun.SEA.work implementation that only contains code path we used.
+async function GUN_SEA_work(data: Uint8Array | string, salt: Uint8Array | string) {
+    if (typeof data === 'string') data = new TextEncoder().encode(data)
+    if (typeof salt === 'string') salt = new TextEncoder().encode(salt)
+    const key = await crypto.subtle.importKey('raw', data, { name: 'PBKDF2' }, false, ['deriveBits'])
+    const params: Pbkdf2Params = { name: 'PBKDF2', iterations: 100000, salt, hash: { name: 'SHA-256' } }
+    const derived = await crypto.subtle.deriveBits(params, key, 512)
+    return window.btoa(String.fromCharCode(...new Uint8Array(derived)))
+}
+
+namespace Version37 {
+    export async function* GUN_queryPostKey_version37(
+        iv: Uint8Array,
+        minePublicKey: EC_Public_CryptoKey,
+        network: SocialNetworkEnum,
+        abortSignal: AbortSignal,
+    ): AsyncGenerator<DecryptEphemeralECDH_PostKey, void, undefined> {
+        const minePublicKeyJWK = await CryptoKeyToJsonWebKey(minePublicKey)
+        const { keyHash, postHash, networkHint } = await calculatePostKeyPartition(network, iv, minePublicKeyJWK)
+
+        /* cspell:disable-next-line */
+        // ? In this step we get something like ["jzarhbyjtexiE7aB1DvQ", "jzarhuse6xlTAtblKRx9"]
+        const keyPartition = `${networkHint}-${postHash}-${keyHash}`
+        console.log(`[@masknet/encryption] Reading key partition [${keyPartition}]`)
+        const internalNodeNames = await getGunData(keyPartition).then((x) => {
+            if (!x) return []
+            if (typeof x !== 'object') return []
+            return Object.keys(x)
+        })
+        // ? In this step we get all keys in this category (gun2[keyPartition])
+        const resultPromise = internalNodeNames.map((key) => getGunData(key))
+
+        const iter = new EventIterator<DecryptEphemeralECDH_PostKey>((queue) => {
+            // immediate results
+            for (const result of resultPromise) result.then(emit, noop)
+
+            // future results
+            main(subscribeGunMapData([keyPartition], isValidData, abortSignal))
+
+            async function main(keyProvider: AsyncGenerator<unknown>) {
+                for await (const data of keyProvider) Promise.resolve(data).then(emit, noop)
+                queue.stop()
+            }
+            async function emit(result: unknown) {
+                if (abortSignal.aborted) return
+                if (!isValidData(result)) return
+
+                const data: DecryptEphemeralECDH_PostKey = {
+                    encryptedPostKey: new Uint8Array(decodeArrayBuffer(result.e)),
+                }
+                if (result.k && result.c) {
+                    data.ephemeralPublicKey = (
+                        await importEC_Key(new Uint8Array(decodeArrayBuffer(result.k)), result.c)
+                    ).unwrap()
+                }
+                queue.push(data)
+            }
+        })
+        yield* iter
+    }
+
+    /**
+     * Publish post keys on the gun
+     * @param postIV Post iv
+     * @param receiversKeys Keys needs to publish
+     */
+    export async function publishPostAESKey_version37(
+        postIV: Uint8Array,
+        network: SocialNetworkEnum,
+        receiversKeys: EncryptionResultE2EMap,
+    ) {
+        const networkPartition = getNetworkPartition(network)
+        const postHash = await hashIV(postIV)
+        for (const result of receiversKeys.values()) {
+            try {
+                if (result.status === 'rejected') continue
+                const { encryptedPostKey, target, ephemeralPublicKey } = result.value
+                const pub = await queryPublicKey(target)
+                if (!pub) throw new Error('missing key')
+                const jwk = await CryptoKeyToJsonWebKey(pub)
+                const keyPartition = `${networkPartition}-${postHash}-${await hashKey(jwk)}`
+                const post: DataOnGun = {
+                    e: encodeArrayBuffer(encryptedPostKey),
+                }
+                if (ephemeralPublicKey) {
+                    post.c = getEcKeyCurve(ephemeralPublicKey)
+                    post.k = encodeArrayBuffer(new Uint8Array(await crypto.subtle.exportKey('raw', ephemeralPublicKey)))
+                }
+                console.log(`[@masknet/encryption] gun[${keyPartition}].push(`, post, ')')
+                pushToGunDataArray([keyPartition], post)
+            } catch (error) {
+                console.error('[@masknet/encryption] An error occurs when sending E2E keys', error)
+            }
+        }
+    }
+
+    // we need to make it short, but looks like gun does not support storing Uint8Array?
+    type DataOnGun = {
+        /** encrypted key */
+        e: string
+        /** ephemeral public key chain */
+        c?: EC_KeyCurveEnum
+        /** ephemeral public key */
+        k?: string
+    }
+
+    function isValidData(data: unknown): data is DataOnGun {
+        if (!data) return false
+        if (typeof data !== 'object') return false
+        const { e, c, k } = data as DataOnGun
+        if (typeof e !== 'string') return false
+        if (![EC_KeyCurveEnum.secp256k1, EC_KeyCurveEnum.secp256p1, undefined].includes(c)) return false
+        if (typeof k !== 'string' && k !== undefined) return false
+        return true
+    }
+
+    async function calculatePostKeyPartition(network: SocialNetworkEnum, iv: Uint8Array, key: EC_Public_JsonWebKey) {
+        const postHash = await hashIV(iv)
+        const keyHash = await hashKey(key)
+        return { postHash, keyHash, networkHint: getNetworkPartition(network) }
+    }
+
+    async function hashIV(iv: Uint8Array): Promise<string> {
+        const hashPair = '9283464d-ee4e-4e8d-a7f3-cf392a88133f'
+        const N = 2
+
+        return (await GUN_SEA_work(encodeArrayBuffer(iv), hashPair)).slice(0, N)
+    }
+
+    async function hashKey(jwk: EC_Public_JsonWebKey) {
+        const hashPair = 'ace7ab0c-5507-4bdd-9d43-e4249a48e720'
+        const N = 2
+
+        const hash = await GUN_SEA_work(jwk.x! + jwk.y!, hashPair)
         return hash.slice(0, N)
     }
 
-    // This is a self contained Gun.SEA.work implementation that only contains code path we used.
-    async function work(data: Uint8Array | string, salt: Uint8Array | string) {
-        if (typeof data === 'string') data = new TextEncoder().encode(data)
-        if (typeof salt === 'string') salt = new TextEncoder().encode(salt)
-        const key = await crypto.subtle.importKey('raw', data, { name: 'PBKDF2' }, false, ['deriveBits'])
-        const params: Pbkdf2Params = { name: 'PBKDF2', iterations: 100000, salt, hash: { name: 'SHA-256' } }
-        const derived = await crypto.subtle.deriveBits(params, key, 512)
-        return window.btoa(String.fromCharCode(...new Uint8Array(derived)))
+    function getNetworkPartition(x: SocialNetworkEnum) {
+        if (x === SocialNetworkEnum.Facebook) return '37-fb'
+        if (x === SocialNetworkEnum.Twitter) return '37-tw'
+        if (x === SocialNetworkEnum.Minds) return '37-minds'
+        if (x === SocialNetworkEnum.Instagram) return '37-ins'
+        if (x === SocialNetworkEnum.Unknown)
+            throw new TypeError('[@masknet/encryption] Current SNS network is not correctly configured.')
+        unreachable(x)
     }
 }
 
 export const { GUN_queryPostKey_version39Or38, publishPostAESKey_version39Or38 } = Version38Or39
-export type PublishedAESKeyRecord_version39Or38 = Version38Or39.PublishedAESKeyRecord
+export const { GUN_queryPostKey_version37, publishPostAESKey_version37 } = Version37

--- a/packages/mask/background/services/crypto/appendEncryption.ts
+++ b/packages/mask/background/services/crypto/appendEncryption.ts
@@ -8,7 +8,7 @@ import {
 import type { EC_Public_CryptoKey, PostIVIdentifier, ProfileIdentifier } from '@masknet/shared-base'
 import { deriveAESByECDH, queryPublicKey } from '../../database/persona/helper'
 import { updatePostDB, queryPostDB } from '../../database/post'
-import { publishPostAESKey_version39Or38 } from '../../network/gun/encryption/queryPostKey'
+import { publishPostAESKey_version37, publishPostAESKey_version39Or38 } from '../../network/gun/encryption/queryPostKey'
 import { getPostKeyCache } from './decryption'
 
 export async function appendShareTarget(
@@ -30,7 +30,7 @@ export async function appendShareTarget(
             target,
             iv: post.toIV(),
             postAESKey: key,
-            version: -38,
+            version,
         },
         {
             async deriveAESKey(pub) {
@@ -45,7 +45,11 @@ export async function appendShareTarget(
         },
     )
 
-    publishPostAESKey_version39Or38(-38, post.toIV(), network, e2e)
+    if (version === -38) {
+        publishPostAESKey_version39Or38(-38, post.toIV(), network, e2e)
+    } else {
+        publishPostAESKey_version37(post.toIV(), network, e2e)
+    }
 
     updatePostDB(
         {

--- a/packages/mask/background/services/crypto/recipients.ts
+++ b/packages/mask/background/services/crypto/recipients.ts
@@ -21,7 +21,7 @@ export async function getRecipients(whoAmI: ProfileIdentifier): Promise<ProfileI
 export async function getIncompleteRecipientsOfPost(id: PostIVIdentifier): Promise<ProfileInformation[]> {
     const nameInDB = (await queryPostDB(id))?.recipients
     if (nameInDB === 'everyone') return []
-    if (!nameInDB) return []
+    if (!nameInDB?.size) return []
 
     const profiles = (
         await queryProfilesDB({

--- a/packages/mask/shared/flags.ts
+++ b/packages/mask/shared/flags.ts
@@ -47,6 +47,9 @@ export const Flags = {
     has_no_WebRTC: process.env.engine === 'safari' || !globalThis?.navigator?.permissions?.query,
     // #endregion
     using_emoji_flag: true,
+
+    // we still need to handle image encoding
+    v37PayloadDefaultEnabled: false, // new Date() > new Date('2022-07-01'),
 } as const
 
 if (process.env.NODE_ENV === 'development') {

--- a/packages/mask/src/components/CompositionDialog/Composition.tsx
+++ b/packages/mask/src/components/CompositionDialog/Composition.tsx
@@ -13,6 +13,7 @@ import { useSubmit } from './useSubmit'
 import { useAsync } from 'react-use'
 import { useCurrentIdentity } from '../DataSource/useActivatedUI'
 import { usePersonaConnectStatus } from '../DataSource/usePersonaConnectStatus'
+import { Flags } from '../../../shared'
 
 const useStyles = makeStyles()({
     dialogRoot: {
@@ -43,6 +44,7 @@ export function Composition({ type = 'timeline', requireClipboardPermission }: P
     )
 
     const [reason, setReason] = useState<'timeline' | 'popup' | 'reply'>('timeline')
+    const [version, setVersion] = useState<-38 | -37>(Flags.v37PayloadDefaultEnabled ? -37 : -38)
     // #region Open
     const [open, setOpen] = useState(false)
     const [isOpenFromApplicationBoard, setIsOpenFromApplicationBoard] = useState(false)
@@ -100,7 +102,7 @@ export function Composition({ type = 'timeline', requireClipboardPermission }: P
     const isE2E_Disabled = (() => {
         if (!connectStatus.currentConnectedPersona && !connectStatus.hasPersona) return E2EUnavailableReason.NoPersona
         if (!connectStatus.connected && connectStatus.hasPersona) return E2EUnavailableReason.NoConnection
-        if (!hasLocalKey) return E2EUnavailableReason.NoLocalKey
+        if (!hasLocalKey && version === -38) return E2EUnavailableReason.NoLocalKey
         return
     })()
 
@@ -114,6 +116,8 @@ export function Composition({ type = 'timeline', requireClipboardPermission }: P
                 title={t('post_dialog__title')}>
                 <DialogContent>
                     <CompositionDialogUI
+                        version={version}
+                        setVersion={setVersion}
                         onConnectPersona={() => {
                             if (connectStatus.action) connectStatus.action()
                             setOpen(false)
@@ -129,7 +133,7 @@ export function Composition({ type = 'timeline', requireClipboardPermission }: P
                         recipients={recipients}
                         maxLength={560}
                         onSubmit={onSubmit_}
-                        supportImageEncoding={networkSupport?.text ?? false}
+                        supportImageEncoding={version === -37 ? false : networkSupport?.text ?? false}
                         supportTextEncoding={networkSupport?.image ?? false}
                         e2eEncryptionDisabled={isE2E_Disabled}
                         isOpenFromApplicationBoard={isOpenFromApplicationBoard}

--- a/packages/mask/src/components/CompositionDialog/CompositionUI.tsx
+++ b/packages/mask/src/components/CompositionDialog/CompositionUI.tsx
@@ -246,7 +246,7 @@ export const CompositionDialogUI = forwardRef<CompositionRef, CompositionProps>(
                         onChange={setEncoding}
                     />
                 </div>
-                {process.env.NODE_ENV === 'development' ? (
+                {process.env.NODE_ENV === 'development' || process.env.channel !== 'stable' ? (
                     <div className={cx(classes.flex, classes.between)}>
                         <Typography component="label" htmlFor={id}>
                             Next generation payload

--- a/packages/mask/src/components/CompositionDialog/EncryptionMethodSelector.tsx
+++ b/packages/mask/src/components/CompositionDialog/EncryptionMethodSelector.tsx
@@ -27,6 +27,8 @@ const useStyles = makeStyles()((theme) => ({
 export interface EncryptionMethodSelectorProps extends PropsWithChildren<{}> {
     onChange(v: EncryptionMethodType): void
     method: EncryptionMethodType
+    textDisabled: boolean
+    imageDisabled: boolean
 }
 export enum EncryptionMethodType {
     Text = 'text',
@@ -54,12 +56,14 @@ export function EncryptionMethodSelector(props: EncryptionMethodSelectorProps) {
                     value={EncryptionMethodType.Text}
                     title={t('compose_encrypt_method_text')}
                     subTitle={t('compose_encrypt_method_text_sub_title')}
+                    disabled={props.textDisabled}
                 />
                 <div className={classes.divider} />
                 <PopoverListItem
                     value={EncryptionMethodType.Image}
                     title={t('compose_encrypt_method_image')}
                     subTitle={t('compose_encrypt_method_image_sub_title')}
+                    disabled={props.imageDisabled}
                 />
             </PopoverListTrigger>
         </>

--- a/packages/mask/src/components/CompositionDialog/useSubmit.ts
+++ b/packages/mask/src/components/CompositionDialog/useSubmit.ts
@@ -24,13 +24,14 @@ export function useSubmit(onClose: () => void, reason: 'timeline' | 'popup' | 'r
             const fallbackProfile: ProfileIdentifier | undefined = globalUIState.profiles.value[0]?.identifier
             if (encode === 'image' && !lastRecognizedIdentity) throw new Error('No Current Profile')
 
-            const _encrypted = await Services.Crypto.encryptTo(
+            const rawEncrypted = await Services.Crypto.encryptTo(
+                info.version,
                 content,
                 target,
                 lastRecognizedIdentity?.identifier ?? fallbackProfile,
                 activatedSocialNetworkUI.encryptionNetwork,
             )
-            const encrypted = socialNetworkEncoder(activatedSocialNetworkUI.encryptionNetwork, _encrypted)
+            const encrypted = socialNetworkEncoder(activatedSocialNetworkUI.encryptionNetwork, rawEncrypted)
             const [imageTemplateType, decoratedText] = decorateEncryptedText(encrypted, t, content.meta)
 
             if (encode === 'image') {

--- a/packages/mask/src/components/InjectedComponents/DecryptedPost/DecryptedPostSuccess.tsx
+++ b/packages/mask/src/components/InjectedComponents/DecryptedPost/DecryptedPostSuccess.tsx
@@ -34,7 +34,7 @@ function useCanAppendShareTarget(whoAmI: ProfileIdentifier | null): whoAmI is Pr
     const postAuthor = authorInPayload || currentPostBy
 
     if (sharedPublic) return false
-    if (version !== -38) return false
+    if (version !== -38 && version !== -37) return false
     if (!whoAmI) return false
     if (whoAmI !== postAuthor) return false
     return true

--- a/packages/mask/src/utils/type-transform/index.ts
+++ b/packages/mask/src/utils/type-transform/index.ts
@@ -1,4 +1,5 @@
 export * from './asyncIteratorHelpers'
-export function hasPayloadLike(text: string): boolean {
-    return text.includes('\u{1F3BC}') && text.includes(':||')
+export function hasPayloadLike(text: string | Uint8Array): boolean {
+    if (typeof text === 'string') return text.includes('\u{1F3BC}') && text.includes(':||')
+    return true
 }


### PR DESCRIPTION
A new option (only visible in development mode or beta/nightly channel) to use v-37 payload.

![image](https://user-images.githubusercontent.com/5390719/169979655-ebc37f77-1b54-40fc-ae7c-c5df35167327.png)

Notable changes:

- No image payload support yet.
- Now you can use **encrypt to self** with no local key (which is not possible in v-38).
- Payload is shorter.

V38 payload:

![image](https://user-images.githubusercontent.com/5390719/169980245-e1df2f00-0d9d-466a-a36c-0d95d3049c40.png)

V37 payload: 

![image](https://user-images.githubusercontent.com/5390719/169980314-0791f12f-bb34-40fd-b80c-6202c12c38db.png)
