### PR TITLE
feat: add useAccountName

### DIFF
--- a/packages/mask/src/plugins/Collectible/SNSAdaptor/OpenSea/ActionBar.tsx
+++ b/packages/mask/src/plugins/Collectible/SNSAdaptor/OpenSea/ActionBar.tsx
@@ -54,7 +54,7 @@ export function ActionBar(props: ActionBarProps) {
     const isOwner = isSameAddress(asset.value.owner?.address, account)
     return (
         <Box className={classes.root} sx={{ padding: 1.5 }} display="flex" justifyContent="center">
-            <ChainBoundary expectedPluginID={NetworkPluginID.PLUGIN_EVM} expectedChainId={chainId}>
+            <ChainBoundary expectedPluginID={NetworkPluginID.PLUGIN_EVM} expectedChainId={chainId} renderInTimeline>
                 {!isOwner && asset.value.auction ? (
                     <ActionButton
                         className={classes.button}

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/ConfirmDialog.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/ConfirmDialog.tsx
@@ -125,11 +125,12 @@ export interface ConfirmDialogUIProps extends withClasses<never> {
     onConfirm: () => void
     onClose?: () => void
     wallet?: Wallet | null
+    account?: string
 }
 
 export function ConfirmDialogUI(props: ConfirmDialogUIProps) {
     const { t } = useI18N()
-    const { open, trade, wallet, inputToken, outputToken, onConfirm, onClose, gas, gasPrice } = props
+    const { open, trade, wallet, inputToken, outputToken, onConfirm, onClose, gas, gasPrice, account } = props
 
     const [cacheTrade, setCacheTrade] = useState<TradeComputed | undefined>()
     const [priceUpdated, setPriceUpdated] = useState(false)
@@ -220,7 +221,11 @@ export function ConfirmDialogUI(props: ConfirmDialogUIProps) {
                     <Box className={classes.section}>
                         <Typography>{t('plugin_red_packet_nft_account_name')}</Typography>
                         <Typography>
-                            ({wallet?.name})
+                            {wallet?.name ? (
+                                `(${wallet.name})`
+                            ) : (
+                                <FormattedAddress address={account} size={10} formatter={formatEthereumAddress} />
+                            )}
                             <FormattedAddress
                                 address={wallet?.address ?? ''}
                                 size={4}

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
@@ -100,7 +100,6 @@ const useStyles = makeStyles<{ isDashboard: boolean; isPopup: boolean }>()((them
             fontSize: 18,
             lineHeight: '22px',
             fontWeight: 600,
-            borderRadius: isDashboard ? 8 : 24,
             height: 'auto',
             padding: '13px 0',
             marginTop: '0 !important',
@@ -110,7 +109,6 @@ const useStyles = makeStyles<{ isDashboard: boolean; isPopup: boolean }>()((them
             lineHeight: '22px',
             fontWeight: 600,
             padding: '13px 0',
-            borderRadius: isDashboard ? 8 : 24,
             height: 'auto',
         },
         selectedTokenChip: {
@@ -476,6 +474,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                                     withChildren
                                     ActionButtonProps={{
                                         color: 'primary',
+                                        variant: 'roundedContained',
                                     }}
                                     infiniteUnlockContent={
                                         <Box component="span" display="flex" alignItems="center">
@@ -510,7 +509,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                                             <ActionButton
                                                 fullWidth
                                                 loading={isSwapping}
-                                                variant="contained"
+                                                variant="roundedContained"
                                                 color="error"
                                                 disabled={
                                                     focusedTrade?.loading ||
@@ -528,7 +527,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                                             <ActionButton
                                                 fullWidth
                                                 loading={isSwapping}
-                                                variant="contained"
+                                                variant="roundedContained"
                                                 disabled={
                                                     focusedTrade?.loading ||
                                                     !focusedTrade?.value ||

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
@@ -100,6 +100,7 @@ const useStyles = makeStyles<{ isDashboard: boolean; isPopup: boolean }>()((them
             fontSize: 18,
             lineHeight: '22px',
             fontWeight: 600,
+            borderRadius: isDashboard ? 8 : 24,
             height: 'auto',
             padding: '13px 0',
             marginTop: '0 !important',
@@ -109,6 +110,7 @@ const useStyles = makeStyles<{ isDashboard: boolean; isPopup: boolean }>()((them
             lineHeight: '22px',
             fontWeight: 600,
             padding: '13px 0',
+            borderRadius: isDashboard ? 8 : 24,
             height: 'auto',
         },
         selectedTokenChip: {
@@ -474,7 +476,6 @@ export const TradeForm = memo<AllTradeFormProps>(
                                     withChildren
                                     ActionButtonProps={{
                                         color: 'primary',
-                                        variant: 'roundedContained',
                                     }}
                                     infiniteUnlockContent={
                                         <Box component="span" display="flex" alignItems="center">
@@ -509,7 +510,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                                             <ActionButton
                                                 fullWidth
                                                 loading={isSwapping}
-                                                variant="roundedContained"
+                                                variant="contained"
                                                 color="error"
                                                 disabled={
                                                     focusedTrade?.loading ||
@@ -527,7 +528,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                                             <ActionButton
                                                 fullWidth
                                                 loading={isSwapping}
-                                                variant="roundedContained"
+                                                variant="contained"
                                                 disabled={
                                                     focusedTrade?.loading ||
                                                     !focusedTrade?.value ||

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
@@ -5,14 +5,7 @@ import { InputTokenPanel } from './InputTokenPanel'
 import { Box, chipClasses, Collapse, IconButton, Tooltip, Typography } from '@mui/material'
 import { useRemoteControlledDialog } from '@masknet/shared-base-ui'
 import { ChainId, formatPercentage, SchemaType } from '@masknet/web3-shared-evm'
-import {
-    FungibleToken,
-    isLessThan,
-    formatBalance,
-    NetworkPluginID,
-    rightShift,
-    Wallet,
-} from '@masknet/web3-shared-base'
+import { FungibleToken, isLessThan, formatBalance, NetworkPluginID, rightShift } from '@masknet/web3-shared-base'
 import { TokenPanelType, TradeInfo } from '../../types'
 import BigNumber from 'bignumber.js'
 import { first, noop } from 'lodash-unified'
@@ -180,7 +173,7 @@ const useStyles = makeStyles<{ isDashboard: boolean; isPopup: boolean }>()((them
 })
 
 export interface AllTradeFormProps {
-    wallet?: Wallet | null
+    account?: string | null
     inputAmount: string
     inputToken?: FungibleToken<ChainId, SchemaType>
     outputToken?: FungibleToken<ChainId, SchemaType>
@@ -199,7 +192,7 @@ export interface AllTradeFormProps {
 
 export const TradeForm = memo<AllTradeFormProps>(
     ({
-        wallet,
+        account,
         trades,
         inputAmount,
         inputToken,
@@ -456,7 +449,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                             </IconButton>
                         </div>
                     </Box>
-                    {wallet ? (
+                    {account ? (
                         <Box className={classes.section}>
                             <ChainBoundary
                                 expectedPluginID={NetworkPluginID.PLUGIN_EVM}

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
@@ -476,6 +476,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                                     withChildren
                                     ActionButtonProps={{
                                         color: 'primary',
+                                        style: { borderRadius: isDashboard ? 8 : 24 },
                                     }}
                                     infiniteUnlockContent={
                                         <Box component="span" display="flex" alignItems="center">

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/Trader.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/Trader.tsx
@@ -28,7 +28,7 @@ import { ConfirmDialog } from './ConfirmDialog'
 import { useGasConfig } from './hooks/useGasConfig'
 import { useSortedTrades } from './hooks/useSortedTrades'
 import { useUpdateBalance } from './hooks/useUpdateBalance'
-import { useChainId, useChainIdValid, useFungibleTokenBalance, useWallet } from '@masknet/plugin-infra/web3'
+import { useChainId, useChainIdValid, useFungibleTokenBalance, useWallet, useAccount } from '@masknet/plugin-infra/web3'
 import { SettingsDialog } from './SettingsDialog'
 import { TradeForm } from './TradeForm'
 
@@ -52,6 +52,7 @@ export function Trader(props: TraderProps) {
     const { defaultOutputCoin, coin, chainId: targetChainId, defaultInputCoin } = props
     const [focusedTrade, setFocusTrade] = useState<TradeInfo>()
     const wallet = useWallet(NetworkPluginID.PLUGIN_EVM)
+    const account = useAccount(NetworkPluginID.PLUGIN_EVM)
     const currentChainId = useChainId(NetworkPluginID.PLUGIN_EVM)
     const chainId = targetChainId ?? currentChainId
     const chainIdValid = useChainIdValid(NetworkPluginID.PLUGIN_EVM)
@@ -356,7 +357,7 @@ export function Trader(props: TraderProps) {
     return (
         <div className={classes.root}>
             <TradeForm
-                wallet={wallet}
+                account={account}
                 trades={sortedAllTradeComputed}
                 inputToken={inputToken}
                 outputToken={outputToken}
@@ -373,6 +374,7 @@ export function Trader(props: TraderProps) {
             />
             {focusedTrade?.value && !isNativeTokenWrapper(focusedTrade.value) && inputToken && outputToken ? (
                 <ConfirmDialog
+                    account={account}
                     wallet={wallet}
                     open={openConfirmDialog}
                     trade={focusedTrade.value}

--- a/packages/mask/src/web3/UI/ChainBoundary.tsx
+++ b/packages/mask/src/web3/UI/ChainBoundary.tsx
@@ -156,6 +156,7 @@ export function ChainBoundary<T extends NetworkPluginID>(props: ChainBoundaryPro
             <>
                 {!props.hiddenConnectButton ? (
                     <ActionButton
+                        fullWidth
                         startIcon={<PluginWalletConnectIcon />}
                         variant="contained"
                         size={props.ActionButtonPromiseProps?.size}

--- a/packages/mask/src/web3/UI/EthereumERC20TokenApprovedBoundary.tsx
+++ b/packages/mask/src/web3/UI/EthereumERC20TokenApprovedBoundary.tsx
@@ -80,6 +80,27 @@ export function EthereumERC20TokenApprovedBoundary(props: EthereumERC20TokenAppr
     // not a valid erc20 token, please given token as undefined
     if (!token) return <Grid container>{render ? (render(false) as any) : children}</Grid>
 
+    if (transactionState.loading || approveStateType === ApproveStateType.UPDATING)
+        return (
+            <Grid container>
+                <ActionButton
+                    className={classes.button}
+                    fullWidth
+                    variant="contained"
+                    size="large"
+                    disabled
+                    {...props.ActionButtonProps}>
+                    {transactionState.loading
+                        ? t('plugin_ito_unlocking_symbol', { symbol: token.symbol })
+                        : `Updating ${token.symbol}`}
+                    &hellip;
+                </ActionButton>
+                {withChildren ? (
+                    <Box className={classes.children}>{render ? (render(true) as any) : children}</Box>
+                ) : null}
+            </Grid>
+        )
+
     if (approveStateType === ApproveStateType.UNKNOWN)
         return (
             <Grid container>
@@ -150,23 +171,6 @@ export function EthereumERC20TokenApprovedBoundary(props: EthereumERC20TokenAppr
                     <Box className={classes.children}>{render ? (render(true) as any) : children}</Box>
                 ) : null}
             </Box>
-        )
-    if (transactionState.loading || approveStateType === ApproveStateType.UPDATING)
-        return (
-            <Grid container>
-                <ActionButton
-                    className={classes.button}
-                    fullWidth
-                    variant="contained"
-                    size="large"
-                    disabled
-                    {...props.ActionButtonProps}>
-                    {transactionState.loading
-                        ? t('plugin_ito_unlocking_symbol', { symbol: token.symbol })
-                        : `Updating ${token.symbol}`}
-                    &hellip;
-                </ActionButton>
-            </Grid>
         )
     if (approveStateType === ApproveStateType.APPROVED)
         return (

--- a/packages/plugin-infra/src/web3/EVM/useERC20TokenApproveCallback.ts
+++ b/packages/plugin-infra/src/web3/EVM/useERC20TokenApproveCallback.ts
@@ -116,7 +116,7 @@ export function useERC20TokenApproveCallback(address?: string, amount?: string, 
             spender,
             balance,
         },
-        state,
+        { ...state, loading: loadingAllowance || loadingBalance || state.loading },
         approveCallback,
         resetCallback,
     ] as const

--- a/packages/plugin-infra/src/web3/EVM/useERC20TokenApproveCallback.ts
+++ b/packages/plugin-infra/src/web3/EVM/useERC20TokenApproveCallback.ts
@@ -1,6 +1,5 @@
 import type { NonPayableTx } from '@masknet/web3-contracts/types/types'
 import { isLessThan, NetworkPluginID, toFixed } from '@masknet/web3-shared-base'
-import { once } from 'lodash-unified'
 import { useCallback, useMemo } from 'react'
 import { useAsyncFn } from 'react-use'
 import { useERC20TokenContract } from './useERC20TokenContract'
@@ -80,10 +79,10 @@ export function useERC20TokenApproveCallback(address?: string, amount?: string, 
 
             // send transaction and wait for hash
             return new Promise<string>(async (resolve, reject) => {
-                const revalidate = once(() => {
+                const revalidate = () => {
                     revalidateBalance()
                     revalidateAllowance()
-                })
+                }
                 erc20Contract.methods
                     .approve(spender, useExact ? amount : MaxUint256)
                     .send(config as NonPayableTx)

--- a/packages/plugin-infra/src/web3/index.ts
+++ b/packages/plugin-infra/src/web3/index.ts
@@ -1,6 +1,7 @@
 export * from './Context'
 
 export * from './useAccount'
+export * from './useAccountName'
 export * from './useAddressBook'
 export * from './useSocialAddressList'
 export * from './useSocialAddressListAll'

--- a/packages/plugin-infra/src/web3/useAccountName.ts
+++ b/packages/plugin-infra/src/web3/useAccountName.ts
@@ -15,7 +15,7 @@ export function useAccountName<T extends NetworkPluginID>(pluginID?: T, expected
     const wallets = useWallets(pluginID)
 
     return useMemo(() => {
-        // if the currently selected account is a mask wallet then use the wallet name as the account name
+        // if the currently selected account is a mask wallet, then use the wallet name as the account name
         const wallet = wallets.find((x) => isSameAddress(account, x.address))
         if (wallet?.name) return wallet.name
 

--- a/packages/plugin-infra/src/web3/useAccountName.ts
+++ b/packages/plugin-infra/src/web3/useAccountName.ts
@@ -11,7 +11,7 @@ export function useAccountName<T extends NetworkPluginID>(pluginID?: T, expected
 
     const { Others } = useWeb3State<void, T>(pluginID)
     const account = useAccount(pluginID, expectedAccount)
-    const proivderType = useProviderType(pluginID)
+    const providerType = useProviderType(pluginID)
     const wallets = useWallets(pluginID)
 
     return useMemo(() => {
@@ -20,6 +20,6 @@ export function useAccountName<T extends NetworkPluginID>(pluginID?: T, expected
         if (wallet?.name) return wallet.name
 
         // else use the provider name as the account name
-        return (Others?.providerResolver.providerName as ProviderName | undefined)?.(proivderType)
-    }, [account, proivderType, wallets.map((x) => x.address.toLowerCase()), Others])
+        return (Others?.providerResolver.providerName as ProviderName | undefined)?.(providerType)
+    }, [account, providerType, wallets.map((x) => x.address.toLowerCase()), Others])
 }

--- a/packages/plugin-infra/src/web3/useAccountName.ts
+++ b/packages/plugin-infra/src/web3/useAccountName.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react'
+import { isSameAddress, NetworkPluginID } from '@masknet/web3-shared-base'
+import { useWeb3State } from './useWeb3State'
+import { useAccount } from './useAccount'
+import { useWallets } from './useWallets'
+import { useProviderType } from './useProviderType'
+import type { Web3Helper } from '../web3-helpers'
+
+export function useAccountName<T extends NetworkPluginID>(pluginID?: T, expectedAccount?: string) {
+    type ProviderName = (providerType: Web3Helper.Definition[T]['ProviderType']) => string
+
+    const { Others } = useWeb3State<void, T>(pluginID)
+    const account = useAccount(pluginID, expectedAccount)
+    const proivderType = useProviderType(pluginID)
+    const wallets = useWallets(pluginID)
+
+    return useMemo(() => {
+        // if the currently selected account is a mask wallet then use the wallet name as the account name
+        const wallet = wallets.find((x) => isSameAddress(account, x.address))
+        if (wallet?.name) return wallet.name
+
+        // else use the provider name as the account name
+        return (Others?.providerResolver.providerName as ProviderName | undefined)?.(proivderType)
+    }, [account, proivderType, wallets.map((x) => x.address.toLowerCase()), Others])
+}

--- a/packages/plugins/EVM/src/state/Connection/translators/Base.ts
+++ b/packages/plugins/EVM/src/state/Connection/translators/Base.ts
@@ -13,9 +13,15 @@ export class Base implements Translator {
 
         // #region polyfill transaction config
         {
-            // add gas margin
-            if (config.gas)
-                config.gas = BigNumber.max(toHex(addGasMargin(config.gas as string).toFixed()), 21000).toFixed()
+            try {
+                // add gas margin
+                if (config.gas)
+                    config.gas = toHex(
+                        BigNumber.max(toHex(addGasMargin(config.gas as string).toFixed()), 21000).toFixed(),
+                    )
+            } catch (error) {
+                console.log(error)
+            }
 
             // add gas price
             const hub = await Web3StateSettings.value.Hub?.getHub?.({
@@ -52,7 +58,6 @@ export class Base implements Translator {
                     config.gasPrice = toHex(normalOption.suggestedMaxFeePerGas)
                 }
             }
-
             context.config = config
         }
         // #endregion

--- a/packages/plugins/EVM/src/state/Connection/translators/Base.ts
+++ b/packages/plugins/EVM/src/state/Connection/translators/Base.ts
@@ -31,7 +31,7 @@ export class Base implements Translator {
                     slowOption?.suggestedMaxFeePerGas &&
                     normalOption &&
                     isLessThan(
-                        config.maxFeePerGas ? formatWeiToGwei(config.maxFeePerGas as string) : 0,
+                        config.maxPriorityFeePerGas ? formatWeiToGwei(config.maxPriorityFeePerGas as string) : 0,
                         slowOption.suggestedMaxPriorityFeePerGas,
                     )
                 ) {

--- a/packages/plugins/EVM/src/state/TransactionFormatter/descriptors/ERC20.ts
+++ b/packages/plugins/EVM/src/state/TransactionFormatter/descriptors/ERC20.ts
@@ -12,7 +12,6 @@ export class ERC20Descriptor implements TransactionDescriptor {
             chainId: context.chainId,
         })
 
-        console.log(context)
         switch (context.name) {
             case 'approve':
                 return {

--- a/packages/plugins/EVM/src/state/TransactionFormatter/descriptors/ERC20.ts
+++ b/packages/plugins/EVM/src/state/TransactionFormatter/descriptors/ERC20.ts
@@ -12,6 +12,7 @@ export class ERC20Descriptor implements TransactionDescriptor {
             chainId: context.chainId,
         })
 
+        console.log(context)
         switch (context.name) {
             case 'approve':
                 return {
@@ -19,7 +20,7 @@ export class ERC20Descriptor implements TransactionDescriptor {
                     title: 'Approve',
                     description: `Approve spend ${getTokenAmountDescription(
                         context.parameters?.value,
-                        await connection?.getFungibleToken(context.parameters?.to ?? '', {
+                        await connection?.getFungibleToken(context.to ?? '', {
                             chainId: context.chainId,
                         }),
                     )}`,


### PR DESCRIPTION
## Description

In the new web3 infra, the wallet DB only serves for Mask wallets. We don't keep wallet records for external wallets anymore. In this PR, `useAccountName` is added for reading the name of external wallets.

1. If the currently selected account is a Mask Wallet, use the `name` in the wallet record.
2. Else, if an external wallet is used, the provider name will be the wallet name.

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)
