### PR TITLE
fix: alway force user to connect a wallet

### DIFF
--- a/packages/plugins/EVM/src/state/Connection/provider.ts
+++ b/packages/plugins/EVM/src/state/Connection/provider.ts
@@ -1,9 +1,9 @@
 import { ProviderType } from '@masknet/web3-shared-evm'
+import { BaseProvider } from './providers/Base'
 import { CustomNetworkProvider } from './providers/CustomNetwork'
 import { MaskWalletProvider } from './providers/MaskWallet'
 import { MetaMaskProvider } from './providers/MetaMask'
 import WalletConnectProvider from './providers/WalletConnect'
-import type { BaseProvider } from './providers/Base'
 import { WalletLinkProvider } from './providers/WalletLink'
 import { Coin98Provider } from './providers/Coin98'
 import { MathWalletProvider } from './providers/MathWallet'
@@ -14,6 +14,7 @@ import TorusProvider from './providers/Torus'
  * Register all supported providers
  */
 export const Providers: Record<ProviderType, BaseProvider> = {
+    [ProviderType.None]: new BaseProvider(),
     [ProviderType.MaskWallet]: new MaskWalletProvider(),
     [ProviderType.MetaMask]: new MetaMaskProvider(),
     [ProviderType.WalletConnect]: new WalletConnectProvider(),

--- a/packages/plugins/EVM/src/state/Provider.ts
+++ b/packages/plugins/EVM/src/state/Provider.ts
@@ -21,7 +21,7 @@ export class Provider extends ProviderState<ChainId, ProviderType, NetworkType, 
             isValidChainId,
             getDefaultChainId: () => ChainId.Mainnet,
             getDefaultNetworkType: () => NetworkType.Ethereum,
-            getDefaultProviderType: () => ProviderType.MaskWallet,
+            getDefaultProviderType: () => ProviderType.None,
             getNetworkTypeFromChainId: (chainId: ChainId) =>
                 chainResolver.chainNetworkType(chainId) ?? NetworkType.Ethereum,
         })

--- a/packages/plugins/Flow/src/state/Connection/provider.ts
+++ b/packages/plugins/Flow/src/state/Connection/provider.ts
@@ -1,10 +1,11 @@
 import { ProviderType } from '@masknet/web3-shared-flow'
-import type { BaseProvider } from './providers/Base'
+import { BaseProvider } from './providers/Base'
 import { BloctoProvider } from './providers/Blocto'
 import { DapperProvider } from './providers/Dapper'
 import { LedgerProvider } from './providers/Ledger'
 
 export const Providers: Record<ProviderType, BaseProvider> = {
+    [ProviderType.None]: new BaseProvider(),
     [ProviderType.Blocto]: new BloctoProvider(),
     [ProviderType.Dapper]: new DapperProvider(),
     [ProviderType.Ledger]: new LedgerProvider(),

--- a/packages/plugins/Flow/src/state/Provider.ts
+++ b/packages/plugins/Flow/src/state/Provider.ts
@@ -20,7 +20,7 @@ export class Provider extends ProviderState<ChainId, ProviderType, NetworkType, 
             isValidChainId,
             isValidAddress,
             getDefaultChainId: () => ChainId.Mainnet,
-            getDefaultProviderType: () => ProviderType.Blocto,
+            getDefaultProviderType: () => ProviderType.None,
             getDefaultNetworkType: () => NetworkType.Flow,
             getNetworkTypeFromChainId: (chainId: ChainId) =>
                 chainResolver.chainNetworkType(chainId) ?? NetworkType.Flow,

--- a/packages/plugins/Solana/src/state/Connection/provider.ts
+++ b/packages/plugins/Solana/src/state/Connection/provider.ts
@@ -1,11 +1,12 @@
 import { ProviderType } from '@masknet/web3-shared-solana'
-import type { BaseProvider } from './providers/Base'
+import { BaseProvider } from './providers/Base'
 import { Coin98Provider } from './providers/Coin98'
 import { PhantomProvider } from './providers/Phantom'
 import { SolflareProvider } from './providers/SolflareProvider'
 import { SolletProvider } from './providers/Sollet'
 
 export const Providers: Record<ProviderType, BaseProvider> = {
+    [ProviderType.None]: new BaseProvider(),
     [ProviderType.Phantom]: new PhantomProvider(),
     [ProviderType.Solflare]: new SolflareProvider(),
     [ProviderType.Sollet]: new SolletProvider(),

--- a/packages/plugins/Solana/src/state/Provider.ts
+++ b/packages/plugins/Solana/src/state/Provider.ts
@@ -20,7 +20,7 @@ export class Provider extends ProviderState<ChainId, ProviderType, NetworkType, 
             isValidChainId,
             isValidAddress,
             getDefaultChainId: () => ChainId.Mainnet,
-            getDefaultProviderType: () => ProviderType.Phantom,
+            getDefaultProviderType: () => ProviderType.None,
             getDefaultNetworkType: () => NetworkType.Solana,
             getNetworkTypeFromChainId: (chainId: ChainId) =>
                 chainResolver.chainNetworkType(chainId) ?? NetworkType.Solana,

--- a/packages/web3-shared/evm/types/index.ts
+++ b/packages/web3-shared/evm/types/index.ts
@@ -262,6 +262,7 @@ export enum NetworkType {
 }
 
 export enum ProviderType {
+    None = 'None',
     MaskWallet = 'Maskbook',
     MetaMask = 'MetaMask',
     WalletConnect = 'WalletConnect',

--- a/packages/web3-shared/flow/types.ts
+++ b/packages/web3-shared/flow/types.ts
@@ -17,6 +17,7 @@ export enum NetworkType {
 }
 
 export enum ProviderType {
+    None = 'None',
     Blocto = 'Blocto',
     Dapper = 'Dapper',
     Ledger = 'Ledger',

--- a/packages/web3-shared/solana/types.ts
+++ b/packages/web3-shared/solana/types.ts
@@ -17,6 +17,7 @@ export enum NetworkType {
 }
 
 export enum ProviderType {
+    None = 'None',
     Phantom = 'Phantom',
     Solflare = 'Solflare',
     Sollet = 'Sollet',


### PR DESCRIPTION
## Description

All networks should have a default none wallet provider. It would be the default value if we didn't select any wallet.

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)
