### PR TITLE
fix: should unwrap date value when generate backup file

### DIFF
--- a/packages/backup-format/src/version-2/index.ts
+++ b/packages/backup-format/src/version-2/index.ts
@@ -178,10 +178,11 @@ export async function normalizeBackupVersion2(item: BackupJSONFileVersion2): Pro
 }
 
 export function generateBackupVersion2(item: NormalizedBackup.Data): BackupJSONFileVersion2 {
+    const now = new Date()
     const result: BackupJSONFileVersion2 = {
         _meta_: {
             maskbookVersion: item.meta.maskVersion.unwrapOr('>=2.5.0'),
-            createdAt: Number(item.meta.createdAt),
+            createdAt: Number(item.meta.createdAt.unwrapOr(now)),
             type: 'maskbook-backup',
             version: 2,
         },
@@ -197,8 +198,8 @@ export function generateBackupVersion2(item: NormalizedBackup.Data): BackupJSONF
     for (const [id, data] of item.personas) {
         result.personas.push({
             identifier: id.toText(),
-            createdAt: Number(data.createdAt),
-            updatedAt: Number(data.updatedAt),
+            createdAt: Number(data.createdAt.unwrapOr(now)),
+            updatedAt: Number(data.updatedAt.unwrapOr(now)),
             nickname: data.nickname.unwrapOr(undefined),
             linkedProfiles: [...data.linkedProfiles.keys()].map((id) => [
                 id.toText(),
@@ -219,8 +220,8 @@ export function generateBackupVersion2(item: NormalizedBackup.Data): BackupJSONF
     for (const [id, data] of item.profiles) {
         result.profiles.push({
             identifier: id.toText(),
-            createdAt: Number(data.createdAt),
-            updatedAt: Number(data.updatedAt),
+            createdAt: Number(data.createdAt.unwrapOr(now)),
+            updatedAt: Number(data.updatedAt.unwrapOr(now)),
             nickname: data.nickname.unwrapOr(undefined),
             linkedPersona: data.linkedPersona.unwrapOr(undefined)?.toText(),
             localKey: data.localKey.unwrapOr(undefined),


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
