### PR TITLE
fix: kill the image compose pre text

### DIFF
--- a/packages/mask/shared-ui/locales/en-US.json
+++ b/packages/mask/shared-ui/locales/en-US.json
@@ -66,7 +66,7 @@
     "additional_post_box__encrypted_post_pre_ito": "$t(promote_ito) {{encrypted}}",
     "additional_post_box__encrypted_post_pre_file_service_twitter_official_account": "$t(promote_file_service)\n {{encrypted}}",
     "additional_post_box__encrypted_post_pre_file_service": "$t(promote_file_service) {{encrypted}}",
-    "additional_post_box__steganography_post_pre": "This image is encrypted with #mask_io.\n{{random}}\n$t(promote)",
+    "additional_post_box__steganography_post_pre": "$t(promote)",
     "auto_paste_failed_dialog_title": "Paste manually",
     "auto_paste_failed_dialog_content": "Please copy the following text and image (if there is any) and publish it.",
     "auto_paste_failed_dialog_image_caption": "Open in a new tab",

--- a/packages/mask/src/components/CompositionDialog/useSubmit.ts
+++ b/packages/mask/src/components/CompositionDialog/useSubmit.ts
@@ -35,9 +35,7 @@ export function useSubmit(onClose: () => void, reason: 'timeline' | 'popup' | 'r
             const [imageTemplateType, decoratedText] = decorateEncryptedText(encrypted, t, content.meta)
 
             if (encode === 'image') {
-                const defaultText = t('additional_post_box__steganography_post_pre', {
-                    random: new Date().toLocaleString(),
-                })
+                const defaultText = t('additional_post_box__steganography_post_pre')
                 if (decoratedText) {
                     await pasteImage(decoratedText.replace(encrypted, ''), encrypted, imageTemplateType, reason)
                 } else {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-1364

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
