### PR TITLE
fix(solana): pubkey length varies from 32 to 44 characters

### DIFF
--- a/packages/web3-shared/solana/utils/address.ts
+++ b/packages/web3-shared/solana/utils/address.ts
@@ -24,8 +24,10 @@ export function formatTokenId(id: string) {
     return id
 }
 export function isValidAddress(address?: string) {
+    const length = address?.length
+    if (!length) return false
     try {
-        return address?.length === 44 && Web3.PublicKey.isOnCurve(bs58.decode(address))
+        return length >= 32 && length <= 44 && Web3.PublicKey.isOnCurve(bs58.decode(address))
     } catch {
         return false
     }


### PR DESCRIPTION
> The public key is a long string of base58 characters. Its length varies
from 32 to 44 characters.

https://docs.solana.com/cli/transfer-tokens#receive-tokens
