### PR TITLE
refactor: flooding queryOwnedPersonaInformation(true)

### DIFF
--- a/packages/mask/background/services/settings/old-settings-accessor.ts
+++ b/packages/mask/background/services/settings/old-settings-accessor.ts
@@ -32,7 +32,7 @@ export async function getCurrentPersonaIdentifier(): Promise<PersonaIdentifier |
         .sort((a, b) => (a.createdAt > b.createdAt ? 1 : 0))
         .map((x) => x.identifier)
     const newVal = ECKeyIdentifier.from(currentPersonaIdentifier.value).unwrapOr(head(personas))
-    if (!newVal) return undefined
+    if (!newVal) return
     if (personas.find((x) => x === newVal)) return newVal
     if (personas[0]) currentPersonaIdentifier.value = personas[0].toText()
     return personas[0]

--- a/packages/mask/src/components/DataSource/useMyPersonas.ts
+++ b/packages/mask/src/components/DataSource/useMyPersonas.ts
@@ -1,7 +1,7 @@
-import Services from '../../extension/service'
-import { MaskMessages } from '../../utils/messages'
-import { createSubscriptionFromAsyncSuspense } from '@masknet/shared-base'
 import { useSubscription } from 'use-subscription'
+import Services from '../../extension/service'
+import { createSubscriptionFromAsyncSuspense } from '@masknet/shared-base'
+import { MaskMessages } from '../../utils/messages'
 
 const personas = createSubscriptionFromAsyncSuspense(
     () => Services.Identity.queryOwnedPersonaInformation(true),

--- a/packages/mask/src/components/DataSource/usePersonaAgainstSNSConnectStatus.ts
+++ b/packages/mask/src/components/DataSource/usePersonaAgainstSNSConnectStatus.ts
@@ -30,5 +30,5 @@ export function usePersonaAgainstSNSConnectStatus() {
             currentPersonaPublicKey: currentPersona?.identifier.rawPublicKey,
             currentSNSConnectedPersonaPublicKey: currentSNSConnectedPersona?.identifier.rawPublicKey,
         }
-    }, [platform, username, ui, personas])
+    }, [platform, username, personas.map((x) => x.identifier.toText()).join()])
 }

--- a/packages/mask/src/social-network/ui.ts
+++ b/packages/mask/src/social-network/ui.ts
@@ -111,26 +111,30 @@ export async function activateSocialNetworkUIInner(ui_deferred: SocialNetworkUI.
         }
     })
 
+    const allPersonaSub = createSubscriptionFromAsync(
+        () => {
+            console.log('DEBUG: currentPersonaIdentifier')
+            return Services.Identity.queryOwnedPersonaInformation(true)
+        },
+        [],
+        MaskMessages.events.currentPersonaIdentifier.on,
+        signal,
+    )
+    const empty = new ValueRef<IdentityResolved | undefined>(undefined)
+    const lastRecognizedSub = createSubscriptionFromValueRef(
+        ui.collecting.identityProvider?.recognized || empty,
+        signal,
+    )
+    const currentVisitingSub = createSubscriptionFromValueRef(
+        ui.collecting.currentVisitingIdentityProvider?.recognized || empty,
+        signal,
+    )
+
     startPluginSNSAdaptor(
         getCurrentSNSNetwork(ui.networkIdentifier),
         createPluginHost(
             signal,
             (pluginID, signal): Plugin.SNSAdaptor.SNSAdaptorContext => {
-                const empty = new ValueRef<IdentityResolved | undefined>(undefined)
-                const lastRecognizedSub = createSubscriptionFromValueRef(
-                    ui.collecting.identityProvider?.recognized || empty,
-                    signal,
-                )
-                const currentVisitingSub = createSubscriptionFromValueRef(
-                    ui.collecting.currentVisitingIdentityProvider?.recognized || empty,
-                    signal,
-                )
-                const allPersonaSub = createSubscriptionFromAsync(
-                    () => Services.Identity.queryOwnedPersonaInformation(true),
-                    [],
-                    MaskMessages.events.currentPersonaIdentifier.on,
-                    signal,
-                )
                 return {
                     ...createPartialSharedUIContext(pluginID, signal),
                     ...RestPartOfPluginUIContextShared,


### PR DESCRIPTION
## Description

After the plugin starts, too many requests flood the background services.

![image](https://user-images.githubusercontent.com/52657989/180798965-2ed19bbe-f581-4238-b357-d438dfc13e80.png)


Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [x] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)
