### PR TITLE
fix: check if node is destroyed to avoid annoying access errors

### DIFF
--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/PostReplacer.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/PostReplacer.tsx
@@ -14,7 +14,7 @@ export function injectPostReplacerAtTwitter(signal: AbortSignal, current: PostIn
             if (langNode) langNode.style.display = 'none'
         },
         unzipPost(node) {
-            if (!node.current) return
+            if (node.destroyed || !node.current) return
             const langNode = resolveLangNode(node.current)
             if (langNode) langNode.style.display = 'unset'
         },


### PR DESCRIPTION
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1141198/184092900-3de53f98-e955-4551-b08d-b3a864f851c6.png">
