### PR TITLE
fix: trigger locationchange on replacestate

### DIFF
--- a/packages/injected-script/main/locationChange.ts
+++ b/packages/injected-script/main/locationChange.ts
@@ -21,6 +21,7 @@ function setupChromium() {
             if (currentLocationHref !== window.location.href) {
                 currentLocationHref = window.location.href
                 $Content.dispatchEvent(window, new $Content.Event('replacestate'))
+                $Content.dispatchEvent(window, new $Content.Event('locationchange'))
             }
             return val
         },

--- a/packages/mask/src/plugins/Trader/trending/useSearchedKeyword.ts
+++ b/packages/mask/src/plugins/Trader/trending/useSearchedKeyword.ts
@@ -12,10 +12,8 @@ export function useSearchedKeyword() {
         }
         onLocationChange()
         window.addEventListener('locationchange', onLocationChange)
-        window.addEventListener('replacestate', onLocationChange)
         return () => {
             window.removeEventListener('locationchange', onLocationChange)
-            window.removeEventListener('replacestate', onLocationChange)
         }
     }, [])
     return keyword


### PR DESCRIPTION
Resolves failing to detect current visiting identity after Twitter gets updated.