### PR TITLE
fix: some release bugs new

### DIFF
--- a/packages/mask/src/components/DataSource/useConnectedPersonas.ts
+++ b/packages/mask/src/components/DataSource/useConnectedPersonas.ts
@@ -1,13 +1,15 @@
 import { EMPTY_LIST, NextIDPlatform } from '@masknet/shared-base'
 import { NextIDProof } from '@masknet/web3-providers'
-import { useAsync } from 'react-use'
+import { useAsyncRetry } from 'react-use'
 import Services from '../../extension/service'
 import { usePersonasFromDB } from './usePersonasFromDB'
+import { useEffect } from 'react'
+import { MaskMessages } from '../../utils'
 
 export function useConnectedPersonas() {
     const personasInDB = usePersonasFromDB()
 
-    return useAsync(async () => {
+    const result = useAsyncRetry(async () => {
         const allPersonaPublicKeys = personasInDB.map((x) => x.identifier.publicKeyAsHex)
         const allPersonaIdentifiers = personasInDB.map((x) => x.identifier)
 
@@ -28,4 +30,8 @@ export function useConnectedPersonas() {
             }
         })
     }, [personasInDB.length])
+
+    useEffect(() => MaskMessages.events.ownProofChanged.on(result.retry), [result.retry])
+
+    return result
 }

--- a/packages/mask/src/components/shared/ApplicationBoardDialog.tsx
+++ b/packages/mask/src/components/shared/ApplicationBoardDialog.tsx
@@ -42,9 +42,7 @@ export function ApplicationBoardDialog() {
         WalletMessages.events.ApplicationDialogUpdated,
     )
 
-    const { open: openPersonaListDialog, closeDialog: _closePersonaListDialog } = useRemoteControlledDialog(
-        PluginNextIDMessages.PersonaListDialogUpdated,
-    )
+    const { open: openPersonaListDialog } = useRemoteControlledDialog(PluginNextIDMessages.PersonaListDialogUpdated)
 
     const closeDialog = useCallback(() => {
         _closeDialog()
@@ -87,7 +85,7 @@ export function ApplicationBoardDialog() {
                     ) : (
                         <ApplicationBoard closeDialog={closeDialog} />
                     )}
-                    <PersonaListDialog />
+                    {openPersonaListDialog && <PersonaListDialog />}
                 </DialogContent>
             </InjectedDialog>
         </TabContext>

--- a/packages/mask/src/components/shared/PersonaListDialog.tsx
+++ b/packages/mask/src/components/shared/PersonaListDialog.tsx
@@ -16,7 +16,7 @@ import Services from '../../extension/service'
 import { InjectedDialog } from '@masknet/shared'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNextIDVerify } from '../DataSource/useNextIDVerify'
-import { useI18N } from '../../utils'
+import { MaskMessages, useI18N } from '../../utils'
 import { WalletMessages } from '../../plugins/Wallet/messages'
 import { useRemoteControlledDialog } from '@masknet/shared-base-ui'
 import { LoadingBase, makeStyles, useCustomSnackbar } from '@masknet/theme'
@@ -102,21 +102,23 @@ export const PersonaListDialog = () => {
         [],
     )
 
-    const gotoSetup = async () => {
-        await Services.Helper.openDashboard(DashboardRoutes.Setup)
+    const { setDialog: setCreatePersonaConfirmDialog } = useRemoteControlledDialog(MaskMessages.events.openPageConfirm)
+
+    useEffect(() => {
+        if (personas.length) return
+
         closeDialog()
-    }
+        setCreatePersonaConfirmDialog({
+            open: true,
+            target: 'dashboard',
+            url: DashboardRoutes.Setup,
+            text: t('applications_create_persona_hint'),
+            title: t('applications_create_persona_title'),
+            actionHint: t('applications_create_persona_action'),
+        })
+    }, [personas.length])
 
     const actionButton = useMemo(() => {
-        console.log(personas)
-        if (!personas.length)
-            return (
-                <ActionContent
-                    onClick={gotoSetup}
-                    buttonText={t('applications_create_persona_action')}
-                    hint={t('applications_create_persona_hint')}
-                />
-            )
         let isConnected = true
         let isVerified = true
 

--- a/packages/mask/src/components/shared/PersonaListDialog.tsx
+++ b/packages/mask/src/components/shared/PersonaListDialog.tsx
@@ -107,7 +107,7 @@ export const PersonaListDialog = () => {
     const { setDialog: setCreatePersonaConfirmDialog } = useRemoteControlledDialog(MaskMessages.events.openPageConfirm)
 
     useEffect(() => {
-        if (personas.length) return
+        if (personas.length || !finishTarget) return
 
         closeDialog()
         setCreatePersonaConfirmDialog({
@@ -118,7 +118,7 @@ export const PersonaListDialog = () => {
             title: t('applications_create_persona_title'),
             actionHint: t('applications_create_persona_action'),
         })
-    }, [personas.length])
+    }, [personas.length, finishTarget])
 
     const actionButton = useMemo(() => {
         let isConnected = true

--- a/packages/mask/src/components/shared/PersonaListDialog.tsx
+++ b/packages/mask/src/components/shared/PersonaListDialog.tsx
@@ -193,7 +193,7 @@ export const PersonaListDialog = () => {
                         }),
                     }
                 return {
-                    hint: t('applications_persona_verify_hint', {
+                    buttonText: t('applications_persona_connect', {
                         nickname: selectedPersona?.persona.nickname,
                     }),
                 }

--- a/packages/mask/src/components/shared/PersonaListDialog.tsx
+++ b/packages/mask/src/components/shared/PersonaListDialog.tsx
@@ -88,7 +88,9 @@ export const PersonaListDialog = () => {
             setSelectedPersona(personas[0])
             return
         }
-        setSelectedPersona(personas.find((x) => isSamePersona(x.persona, currentPersonaIdentifier)))
+
+        const persona = personas.find((x) => isSamePersona(x.persona, currentPersonaIdentifier))
+        setSelectedPersona(persona ?? personas[0])
     }, [currentPersonaIdentifier?.toText(), personas.length])
 
     const [, connect] = useAsyncFn(
@@ -200,7 +202,7 @@ export const PersonaListDialog = () => {
         }
 
         return <ActionContent {...actionProps} />
-    }, [currentPersonaIdentifier, currentProfileIdentify, selectedPersona, personas.length])
+    }, [currentPersonaIdentifier, currentProfileIdentify, selectedPersona])
 
     const onSelectPersona = useCallback((x: PersonaNextIDMixture) => {
         setSelectedPersona(x)

--- a/packages/mask/src/plugins/Savings/SNSAdaptor/SavingsDialog.tsx
+++ b/packages/mask/src/plugins/Savings/SNSAdaptor/SavingsDialog.tsx
@@ -17,7 +17,6 @@ import { InjectedDialog } from '@masknet/shared'
 import { AllProviderTradeContext } from '../../Trader/trader/useAllProviderTradeContext'
 import { TargetChainIdContext } from '@masknet/plugin-infra/web3-evm'
 import { NetworkTab } from '../../../components/shared/NetworkTab'
-import { WalletRPC } from '../../Wallet/messages'
 import { SavingsProtocol, TabType } from '../types'
 import { useStyles } from './SavingsDialogStyles'
 import { SavingsTable } from './SavingsTable'
@@ -50,9 +49,10 @@ export function SavingsDialog({ open, onClose }: SavingsDialogProps) {
     const [tab, setTab] = useState<TabType>(TabType.Deposit)
     const [selectedProtocol, setSelectedProtocol] = useState<SavingsProtocol | null>(null)
 
-    const { value: chains = EMPTY_LIST } = useAsync(async () => {
-        const networks = await WalletRPC.getSupportedNetworks()
-        return networks.map((network: NetworkType) => networkResolver.networkChainId(network))
+    const chains = useMemo(() => {
+        return [NetworkType.Ethereum, NetworkType.Polygon].map((network: NetworkType) =>
+            networkResolver.networkChainId(network),
+        )
     }, [])
 
     const { value: aaveTokens } = useAsync(async () => {

--- a/packages/mask/src/plugins/Savings/SNSAdaptor/SavingsTable.tsx
+++ b/packages/mask/src/plugins/Savings/SNSAdaptor/SavingsTable.tsx
@@ -3,14 +3,14 @@ import { makeStyles } from '@masknet/theme'
 import { Box, Button, Grid, Typography } from '@mui/material'
 import { FormattedBalance, TokenIcon } from '@masknet/shared'
 import { Icons } from '@masknet/icons'
-import { isZero, rightShift, formatBalance, isSameAddress, NetworkPluginID, TokenType } from '@masknet/web3-shared-base'
+import { formatBalance, isSameAddress, isZero, NetworkPluginID, rightShift, TokenType } from '@masknet/web3-shared-base'
 import type { ChainId, Web3 } from '@masknet/web3-shared-evm'
 import { ProviderIconURLs } from './IconURL'
 import { useI18N } from '../../../utils'
 import { ProtocolType, SavingsProtocol, TabType } from '../types'
-import { useAccount, useWeb3, useFungibleAssets } from '@masknet/plugin-infra/web3'
+import { useAccount, useFungibleAssets, useWeb3 } from '@masknet/plugin-infra/web3'
 import { useRemoteControlledDialog } from '@masknet/shared-base-ui'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { PluginTraderMessages } from '../../Trader/messages'
 import { LDO_PAIRS } from '../constants'
 
@@ -143,6 +143,12 @@ export function SavingsTable({ chainId, tab, protocols, setTab, setSelectedProto
             },
         })
     }, [openSwapDialog])
+
+    const renderProtocols = useMemo(() => {
+        if (tab === TabType.Deposit) return protocols
+        return protocols.filter((x) => !x.balance.isZero())
+    }, [tab, protocols])
+
     return (
         <Box className={classes.containerWrap}>
             <Grid container spacing={0} className={classes.tableHeader}>
@@ -167,69 +173,67 @@ export function SavingsTable({ chainId, tab, protocols, setTab, setSelectedProto
                     <Icons.CircleLoading size={36} className={classes.animated} />
                     <Typography className={classes.loading}>{t('popups_loading')}</Typography>
                 </div>
-            ) : protocols.filter((x) => !x.balance.isZero()).length ? (
+            ) : renderProtocols.length ? (
                 <div className={classes.tableContainer}>
-                    {protocols
-                        .filter((x) => !x.balance.isZero())
-                        .map((protocol, index) => (
-                            <Grid container spacing={0} className={classes.tableRow} key={index}>
-                                <Grid item xs={4} className={classes.tableCell}>
-                                    <div className={classes.logoWrap}>
-                                        <TokenIcon
-                                            name={protocol.bareToken.name}
-                                            address={protocol.bareToken.address}
-                                            classes={{ icon: classes.logo }}
-                                            chainId={chainId}
-                                        />
-                                        <img src={ProviderIconURLs[protocol.type]} className={classes.logoMini} />
-                                    </div>
-                                    <div>
-                                        <Typography variant="body1" className={classes.protocolLabel}>
-                                            {protocol.bareToken.symbol}
-                                        </Typography>
-                                    </div>
-                                </Grid>
-                                {tab === TabType.Deposit ? (
-                                    <Grid item xs={2} className={classes.tableCell}>
-                                        <Typography variant="body1">{protocol.apr}%</Typography>
-                                    </Grid>
-                                ) : null}
-                                <Grid xs={tab === TabType.Deposit ? 3 : 5} className={classes.tableCell}>
-                                    <Typography variant="body1">
-                                        <FormattedBalance
-                                            value={
-                                                tab === TabType.Deposit
-                                                    ? assets!.find((x) =>
-                                                          isSameAddress(x.address, protocol.bareToken.address),
-                                                      )?.balance
-                                                    : protocol.balance
-                                            }
-                                            decimals={protocol.bareToken.decimals}
-                                            significant={6}
-                                            minimumBalance={rightShift(10, protocol.bareToken.decimals - 6)}
-                                            formatter={formatBalance}
-                                        />
+                    {renderProtocols.map((protocol, index) => (
+                        <Grid container spacing={0} className={classes.tableRow} key={index}>
+                            <Grid item xs={4} className={classes.tableCell}>
+                                <div className={classes.logoWrap}>
+                                    <TokenIcon
+                                        name={protocol.bareToken.name}
+                                        address={protocol.bareToken.address}
+                                        classes={{ icon: classes.logo }}
+                                        chainId={chainId}
+                                    />
+                                    <img src={ProviderIconURLs[protocol.type]} className={classes.logoMini} />
+                                </div>
+                                <div>
+                                    <Typography variant="body1" className={classes.protocolLabel}>
+                                        {protocol.bareToken.symbol}
                                     </Typography>
-                                </Grid>
-                                <Grid item xs={3} className={classes.tableCell}>
-                                    <Button
-                                        color="primary"
-                                        disabled={tab === TabType.Withdraw ? isZero(protocol.balance) : false}
-                                        onClick={() => {
-                                            if (tab === TabType.Withdraw && protocol.type === ProtocolType.Lido) {
-                                                onConvertClick()
-                                                return
-                                            }
-                                            setTab(tab)
-                                            setSelectedProtocol(protocol)
-                                        }}>
-                                        {tab === TabType.Deposit
-                                            ? t('plugin_savings_deposit')
-                                            : t('plugin_savings_withdraw')}
-                                    </Button>
-                                </Grid>
+                                </div>
                             </Grid>
-                        ))}
+                            {tab === TabType.Deposit ? (
+                                <Grid item xs={2} className={classes.tableCell}>
+                                    <Typography variant="body1">{protocol.apr}%</Typography>
+                                </Grid>
+                            ) : null}
+                            <Grid item xs={tab === TabType.Deposit ? 3 : 5} className={classes.tableCell}>
+                                <Typography variant="body1">
+                                    <FormattedBalance
+                                        value={
+                                            tab === TabType.Deposit
+                                                ? assets!.find((x) =>
+                                                      isSameAddress(x.address, protocol.bareToken.address),
+                                                  )?.balance
+                                                : protocol.balance
+                                        }
+                                        decimals={protocol.bareToken.decimals}
+                                        significant={6}
+                                        minimumBalance={rightShift(10, protocol.bareToken.decimals - 6)}
+                                        formatter={formatBalance}
+                                    />
+                                </Typography>
+                            </Grid>
+                            <Grid item xs={3} className={classes.tableCell}>
+                                <Button
+                                    color="primary"
+                                    disabled={tab === TabType.Withdraw ? isZero(protocol.balance) : false}
+                                    onClick={() => {
+                                        if (tab === TabType.Withdraw && protocol.type === ProtocolType.Lido) {
+                                            onConvertClick()
+                                            return
+                                        }
+                                        setTab(tab)
+                                        setSelectedProtocol(protocol)
+                                    }}>
+                                    {tab === TabType.Deposit
+                                        ? t('plugin_savings_deposit')
+                                        : t('plugin_savings_withdraw')}
+                                </Button>
+                            </Grid>
+                        </Grid>
+                    ))}
                 </div>
             ) : (
                 <div className={classes.placeholder}>

--- a/packages/shared/src/UI/components/FungibleTokenList/index.tsx
+++ b/packages/shared/src/UI/components/FungibleTokenList/index.tsx
@@ -223,7 +223,6 @@ export const FungibleTokenList = forwardRef(
                 setSearchError(undefined)
                 return
             }
-            if (mode === TokenListMode.Manage) return ''
 
             if (
                 (keyword.startsWith('0x') || keyword.startsWith('0X')) &&
@@ -233,6 +232,8 @@ export const FungibleTokenList = forwardRef(
                 setSearchError(t.erc20_search_wrong_address())
                 return
             }
+
+            if (mode === TokenListMode.Manage) return ''
 
             return Others?.isValidAddress(keyword) &&
                 !sortedFungibleTokens.some((x) => isSameAddress(x.address, keyword))

--- a/packages/shared/src/locales/en-US.json
+++ b/packages/shared/src/locales/en-US.json
@@ -7,7 +7,7 @@
     "erc20_token_list_placeholder": "Name or Contract address e.g., USDC or 0x234...",
     "erc20_token_list_loading": "Loading token lists...",
     "erc20_search_token_loading": "Loading token...",
-    "erc20_token_add_by_user": "Added By user",
+    "erc20_token_add_by_user": "Added by user",
     "erc20_search_not_token_found": "No results or contract address does not meet the query criteria.",
     "erc20_search_empty_result": "No results",
     "erc20_search_wrong_address": "Enter valid token address",

--- a/packages/theme/src/Components/SearchableList/SearchableList.tsx
+++ b/packages/theme/src/Components/SearchableList/SearchableList.tsx
@@ -94,6 +94,18 @@ export function SearchableList<T extends {}>({
         onSearch?.(inputValue)
     }
 
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.currentTarget.value
+        setInputValue(value)
+        if (!value) handleClear()
+    }
+
+    const handleClear = () => {
+        setKeyword('')
+        setInputValue('')
+        onSearch?.('')
+    }
+
     const windowHeight = !!textFieldPropsRest.error && typeof height === 'number' ? height - 28 : height
 
     return (
@@ -113,13 +125,7 @@ export function SearchableList<T extends {}>({
                                 </InputAdornment>
                             ),
                             endAdornment: inputValue ? (
-                                <InputAdornment
-                                    position="end"
-                                    className={classes.closeIcon}
-                                    onClick={() => {
-                                        setKeyword('')
-                                        setInputValue('')
-                                    }}>
+                                <InputAdornment position="end" className={classes.closeIcon} onClick={handleClear}>
                                     <Icons.Clear size={18} />
                                 </InputAdornment>
                             ) : null,
@@ -129,7 +135,7 @@ export function SearchableList<T extends {}>({
                         onKeyDown={(ev) => {
                             if (ev.key === 'Enter') handleSearch()
                         }}
-                        onChange={(e) => setInputValue(e.currentTarget.value)}
+                        onChange={handleChange}
                         {...textFieldPropsRest}
                     />
                 </Box>


### PR DESCRIPTION
- chore: bump version to 2.12.0
- fix: web3 tab page style (#7035)
- fix: improve assets display (#7029)
- fix: nft image style (#7036)
- fix: css style for trade (#7039)
- fix: rp tx description (#7037)
- fix: web3 tab display (#7034)
- fix: cannot select persona (#7038)
- feat: should open confirm dialog when persona is zero
- feat: should select default persona when message async inconsistency
- feat: should not show create persona when not have finish target
- feat: saving only support eth and polygon
- feat: should show all protocols when tab is deposit
- fix: typo
- fix: search in manage mode
- fix: action display
- fix: should re-fetch personas when proof disconnect

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
