### PR TITLE
chore: update node minimal version requirement to 18.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mask-network",
   "packageManager": "pnpm@7.7.0",
   "engines": {
-    "node": ">=17.0.0",
+    "node": ">=18.7.0",
     "pnpm": ">=7.7.0",
     "yarn": ">=999.0.0",
     "npm": ">=999.0.0"


### PR DESCRIPTION
to support 'node:util'

fixup! 57d9097
