### PR TITLE
fix: reset token url

### DIFF
--- a/packages/plugins/FileService/src/SNSAdaptor/components/Prepare.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/Prepare.tsx
@@ -78,11 +78,6 @@ export const Prepare: React.FC = () => {
 
     const onFile = useCallback(
         async (file: File) => {
-            console.log('DEBUG: onFile')
-            console.log({
-                file,
-            })
-
             const key = encrypted ? makeFileKey() : undefined
             const block = new Uint8Array(await file.arrayBuffer())
             const checksum = encodeArrayBuffer(await Attachment.checksum(block))

--- a/packages/plugins/FileService/src/SNSAdaptor/components/Prepare.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/Prepare.tsx
@@ -78,7 +78,7 @@ export const Prepare: React.FC = () => {
 
     const onFile = useCallback(
         async (file: File) => {
-            console.log('DEBUG: onfile')
+            console.log('DEBUG: onFile')
             console.log({
                 file,
             })

--- a/packages/shared/src/hooks/useImageBase64.ts
+++ b/packages/shared/src/hooks/useImageBase64.ts
@@ -51,6 +51,7 @@ export function useAccessibleUrl(
         const response = await fetchingTask
         if (!response.ok) {
             cache.delete(key)
+            setAvailableUrl('')
             return
         }
 


### PR DESCRIPTION
fix: reset token url after fetch failed

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-1791

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
