### PR TITLE
fix: nft card fallback image size

### DIFF
--- a/packages/dashboard/src/pages/Wallets/components/CollectibleCard/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/CollectibleCard/index.tsx
@@ -67,7 +67,7 @@ const useStyles = makeStyles()((theme) => ({
     tipArrow: {
         color: '#111432',
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         transform: 'translateY(10px)',
@@ -143,7 +143,7 @@ export const CollectibleCard = memo<CollectibleCardProps>(({ asset, onSend, rend
                             url={asset.metadata?.imageURL || asset.metadata?.mediaURL}
                             tokenId={asset.tokenId}
                             classes={{
-                                loadingFailImage: classes.loadingFailImage,
+                                fallbackImage: classes.fallbackImage,
                                 wrapper: classes.wrapper,
                             }}
                         />

--- a/packages/dashboard/src/pages/Wallets/components/Transfer/NFTCard.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Transfer/NFTCard.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles()({
         width: '140px !important',
         height: '186px !important',
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         transform: 'translateY(10px)',
@@ -110,7 +110,7 @@ export const NFTCard = memo<NFTCardProps>(({ token, selectedTokenId, onSelect, r
                 setERC721TokenName={setName}
                 renderOrder={renderOrder}
                 classes={{
-                    loadingFailImage: classes.loadingFailImage,
+                    fallbackImage: classes.fallbackImage,
                     loadingPlaceholder: classes.loadingPlaceholder,
                     wrapper: classes.wrapper,
                 }}

--- a/packages/mask/src/components/shared/NFTCard/NFTBasicInfo.tsx
+++ b/packages/mask/src/components/shared/NFTCard/NFTBasicInfo.tsx
@@ -91,7 +91,7 @@ const useStyles = makeStyles()((theme) => ({
     providerIcon: {
         cursor: 'pointer',
     },
-    loadingFailImage: {
+    fallbackImage: {
         position: 'absolute',
     },
 }))
@@ -131,7 +131,7 @@ export function NFTBasicInfo(props: NFTBasicInfoProps) {
                         wrapper: classes.wrapper,
                         imgWrapper: classes.imgWrapper,
                         loadingPlaceholder: classes.loadingPlaceholder,
-                        loadingFailImage: classes.loadingFailImage,
+                        fallbackImage: classes.fallbackImage,
                     }}
                     isImageOnly={false}
                 />

--- a/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectibleCard.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectibleCard.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles()((theme) => ({
         height: 64,
         opacity: 0.1,
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         width: 30,
@@ -94,7 +94,7 @@ export function CollectibleCard(props: CollectibleCardProps) {
                     tokenId={asset.tokenId}
                     address={address}
                     classes={{
-                        loadingFailImage: classes.loadingFailImage,
+                        fallbackImage: classes.fallbackImage,
                         wrapper: classes.wrapper,
                         imgWrapper: classes.wrapper,
                     }}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftList.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftList.tsx
@@ -82,7 +82,7 @@ const useStyles = makeStyles()((theme) => {
             padding: '2px 2px 6px',
             color: MaskColorVar.textSecondary,
         },
-        loadingFailImage: {
+        fallbackImage: {
             minHeight: '0 !important',
             maxWidth: 'none',
             transform: 'translateY(-10px)',
@@ -108,7 +108,7 @@ export const NftItem: FC<NftItemProps> = ({ contract, tokenId, className, claime
         <div className={classnames(className, classes.nft)} {...rest}>
             <NFTCardStyledAssetPlayer
                 classes={{
-                    loadingFailImage: classes.loadingFailImage,
+                    fallbackImage: classes.fallbackImage,
                 }}
                 tokenId={tokenId}
                 renderOrder={renderOrder}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC721Form.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC721Form.tsx
@@ -144,7 +144,7 @@ const useStyles = makeStyles()((theme) => {
             cursor: 'pointer',
             color: 'rgba(255, 95, 95, 1)',
         },
-        loadingFailImage: {
+        fallbackImage: {
             minHeight: '0 !important',
             maxWidth: 'none',
             transform: 'translateY(10px)',
@@ -450,7 +450,7 @@ function NFTCard(props: NFTCardProps) {
                 renderOrder={renderOrder}
                 setERC721TokenName={setName}
                 classes={{
-                    loadingFailImage: classes.loadingFailImage,
+                    fallbackImage: classes.fallbackImage,
                     iframe: classes.iframe,
                     imgWrapper: classes.assetImgWrapper,
                 }}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketNft.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketNft.tsx
@@ -240,7 +240,7 @@ const useStyles = makeStyles()((theme) => ({
     assetPlayerVideoIframe: {
         minWidth: 'fit-content',
     },
-    loadingFailImage: {
+    fallbackImage: {
         height: 160,
         width: 120,
     },
@@ -366,7 +366,7 @@ export function RedPacketNft({ payload }: RedPacketNftProps) {
                                     sourceType === 'video' ? classes.assetPlayerVideoIframe : '',
                                 ),
                                 imgWrapper: classes.imgWrapper,
-                                loadingFailImage: classes.loadingFailImage,
+                                fallbackImage: classes.fallbackImage,
                             }}
                             fallbackImage={new URL('./assets/nft-preview.png', import.meta.url)}
                         />

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketNftConfirmDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketNftConfirmDialog.tsx
@@ -133,7 +133,7 @@ const useStyles = makeStyles()((theme) => ({
         alignItems: 'center',
         transform: 'translateY(1px)',
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         transform: 'translateY(10px)',
@@ -359,7 +359,7 @@ function NFTCard(props: NFTCardProps) {
                 renderOrder={renderOrder}
                 setERC721TokenName={setName}
                 classes={{
-                    loadingFailImage: classes.loadingFailImage,
+                    fallbackImage: classes.fallbackImage,
                     iframe: classes.iframe,
                 }}
             />

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/SelectNftTokenDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/SelectNftTokenDialog.tsx
@@ -214,7 +214,7 @@ const useStyles = makeStyles<StyleProps>()((theme, props) => ({
         height: 15,
         color: '#1C68F3',
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         transform: 'translateY(10px)',
@@ -723,7 +723,7 @@ function NFTCard(props: NFTCardProps) {
                 renderOrder={renderOrder}
                 chainId={token.contract?.chainId}
                 classes={{
-                    loadingFailImage: classes.loadingFailImage,
+                    fallbackImage: classes.fallbackImage,
                     iframe: classes.iframe,
                     imgWrapper: classes.assetImgWrapper,
                 }}

--- a/packages/mask/src/plugins/Tips/components/NFTSection/NFTList.tsx
+++ b/packages/mask/src/plugins/Tips/components/NFTSection/NFTList.tsx
@@ -65,7 +65,7 @@ const useStyles = makeStyles()((theme) => ({
     unselected: {
         opacity: 0.5,
     },
-    loadingFailImage: {
+    fallbackImage: {
         width: 64,
         height: 64,
     },
@@ -104,7 +104,7 @@ export const NFTItem: FC<NFTItemProps> = ({ token }) => {
             url={token.metadata?.imageURL ?? token.metadata?.mediaURL}
             tokenId={token.tokenId}
             classes={{
-                loadingFailImage: classes.loadingFailImage,
+                fallbackImage: classes.fallbackImage,
                 iframe: classes.assetPlayerIframe,
                 wrapper: classes.wrapper,
                 imgWrapper: classes.imgWrapper,

--- a/packages/mask/src/plugins/Tips/components/TipDialog.tsx
+++ b/packages/mask/src/plugins/Tips/components/TipDialog.tsx
@@ -77,7 +77,7 @@ const useStyles = makeStyles()((theme) => ({
         marginTop: theme.spacing(3),
         lineHeight: '30px',
     },
-    loadingFailImage: {
+    fallbackImage: {
         width: 64,
         height: 64,
     },

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/DonationCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/DonationCard.tsx
@@ -68,7 +68,7 @@ const useStyles = makeStyles()((theme) => ({
         borderRadius: '8px',
         objectFit: 'cover',
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         width: 64,
@@ -95,7 +95,7 @@ export const DonationCard = ({ donation, socialAddress, onSelect, className, ...
                     <NFTCardStyledAssetPlayer
                         url={donation.imageURL || RSS3_DEFAULT_IMAGE}
                         classes={{
-                            loadingFailImage: classes.loadingFailImage,
+                            fallbackImage: classes.fallbackImage,
                             wrapper: classes.img,
                             iframe: classes.img,
                         }}

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles()((theme) => ({
         alignItems: 'center',
         borderRadius: 12,
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         width: 64,
@@ -173,7 +173,7 @@ export function FeedCard({ feed, address, onSelect }: FeedCardProps) {
                         )}
                         tokenId={feed.metadata?.token_id}
                         classes={{
-                            loadingFailImage: classes.loadingFailImage,
+                            fallbackImage: classes.fallbackImage,
                             wrapper: classes.img,
                             iframe: classes.img,
                         }}

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FootprintCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FootprintCard.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles()((theme) => ({
         borderRadius: '8px',
         objectFit: 'cover',
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         width: 64,
@@ -69,7 +69,7 @@ export const FootprintCard = ({ footprint, onSelect }: FootprintProps) => {
                     <NFTCardStyledAssetPlayer
                         url={footprint.imageURL || RSS3_DEFAULT_IMAGE}
                         classes={{
-                            loadingFailImage: classes.loadingFailImage,
+                            fallbackImage: classes.fallbackImage,
                             wrapper: classes.img,
                             iframe: classes.img,
                         }}

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/WalletAssets.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/WalletAssets.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles()((theme) => {
             color: theme.palette.maskColor.second,
             cursor: 'pointer',
         },
-        loadingFailImage: {
+        fallbackImage: {
             minHeight: '0 !important',
             maxWidth: '126px',
             transform: 'translateY(10px)',

--- a/packages/shared/src/UI/components/AssetPlayer/index.tsx
+++ b/packages/shared/src/UI/components/AssetPlayer/index.tsx
@@ -18,7 +18,7 @@ interface ERC721TokenQuery {
 
 interface AssetPlayerProps
     extends withClasses<
-        'errorPlaceholder' | 'errorIcon' | 'loadingPlaceholder' | 'loadingIcon' | 'loadingFailImage' | 'iframe'
+        'errorPlaceholder' | 'errorIcon' | 'loadingPlaceholder' | 'loadingIcon' | 'fallbackImage' | 'iframe'
     > {
     url?: string
     type?: string
@@ -209,13 +209,13 @@ export const AssetPlayer = memo<AssetPlayerProps>((props) => {
                 {playerState === AssetPlayerState.ERROR
                     ? props.fallbackResourceLoader ??
                       (props.fallbackImage ? (
-                          <img className={classes.loadingFailImage} src={props.fallbackImage.toString()} />
+                          <img className={classes.fallbackImage} src={props.fallbackImage.toString()} />
                       ) : (
                           <Icons.MaskPlaceholder className={classes.errorIcon} {...iconProps} />
                       ))
                     : props.loadingIcon ??
                       (props.fallbackImage && (
-                          <img className={classes.loadingFailImage} src={props.fallbackImage.toString()} />
+                          <img className={classes.fallbackImage} src={props.fallbackImage.toString()} />
                       )) ?? <Icons.AssetLoading className={classes.loadingIcon} />}
             </Box>
             {IframeResizerMemo}

--- a/packages/shared/src/UI/components/CollectionDetailCard/index.tsx
+++ b/packages/shared/src/UI/components/CollectionDetailCard/index.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles()((theme) => ({
         borderRadius: 8,
         objectFit: 'cover',
     },
-    loadingFailImage: {
+    fallbackImage: {
         minHeight: '0 !important',
         maxWidth: 'none',
         width: 300,
@@ -194,7 +194,7 @@ export const CollectionDetailCard = memo<CollectionDetailCardProps>(
                                 url={img}
                                 tokenId={metadata?.token_id}
                                 classes={{
-                                    loadingFailImage: classes.loadingFailImage,
+                                    fallbackImage: classes.fallbackImage,
                                     wrapper: classes.img,
                                     iframe: classes.img,
                                 }}

--- a/packages/shared/src/UI/components/Image/index.tsx
+++ b/packages/shared/src/UI/components/Image/index.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()((theme) => ({
 
 interface ImageProps
     extends ImgHTMLAttributes<HTMLImageElement>,
-        withClasses<'loadingFailImage' | 'imageLoading' | 'imageLoadingBox'> {
+        withClasses<'fallbackImage' | 'imageLoading' | 'imageLoadingBox'> {
     fallbackImage?: URL
 }
 
@@ -73,7 +73,7 @@ export function Image({ fallbackImage, ...rest }: ImageProps) {
             <img
                 {...rest}
                 src={fallbackImageURL.toString()}
-                className={classNames(classes.failImage, classes.loadingFailImage)}
+                className={classNames(classes.failImage, classes.fallbackImage)}
             />
         </Box>
     )

--- a/packages/shared/src/UI/components/NFTCardStyledAssetPlayer/index.tsx
+++ b/packages/shared/src/UI/components/NFTCardStyledAssetPlayer/index.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles()((theme) => ({
         height: 160,
         width: 120,
     },
-    loadingFailImage: {
+    fallbackImage: {
         height: '64px !important',
         width: '64px !important',
     },
@@ -46,7 +46,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-interface Props extends withClasses<'loadingFailImage' | 'iframe' | 'wrapper' | 'loadingPlaceholder' | 'imgWrapper'> {
+interface Props extends withClasses<'fallbackImage' | 'iframe' | 'wrapper' | 'loadingPlaceholder' | 'imgWrapper'> {
     chainId?: Web3Helper.ChainIdAll
     tokenId?: string
     contractAddress?: string
@@ -110,7 +110,7 @@ export function NFTCardStyledAssetPlayer(props: Props) {
             <div className={classes.imgWrapper}>
                 <Image
                     classes={{
-                        loadingFailImage: classes.loadingFailImage,
+                        fallbackImage: classes.fallbackImage,
                     }}
                     width="100%"
                     height="100%"
@@ -145,9 +145,9 @@ export function NFTCardStyledAssetPlayer(props: Props) {
                 iframe: classNames(classes.wrapper, classes.iframe),
                 errorPlaceholder: classes.wrapper,
                 loadingPlaceholder: classes.wrapper,
-                loadingFailImage: classes.loadingFailImage,
+                fallbackImage: classes.fallbackImage,
                 loadingIcon: classes.loadingIcon,
-                errorIcon: classes.loadingFailImage,
+                errorIcon: classes.fallbackImage,
             }}
             showNetwork={showNetwork}
             networkIcon={networkIcon}

--- a/packages/shared/src/UI/components/NFTCardStyledAssetPlayer/index.tsx
+++ b/packages/shared/src/UI/components/NFTCardStyledAssetPlayer/index.tsx
@@ -24,6 +24,10 @@ const useStyles = makeStyles()((theme) => ({
         height: 160,
         width: 120,
     },
+    loadingFailImage: {
+        height: '64px !important',
+        width: '64px !important',
+    },
     loadingIcon: {
         width: 30,
         height: 30,
@@ -104,7 +108,15 @@ export function NFTCardStyledAssetPlayer(props: Props) {
     if (isImageURL || isNative) {
         return (
             <div className={classes.imgWrapper}>
-                <Image width="100%" height="100%" style={{ objectFit: 'cover' }} src={urlComputed} />
+                <Image
+                    classes={{
+                        loadingFailImage: classes.loadingFailImage,
+                    }}
+                    width="100%"
+                    height="100%"
+                    style={{ objectFit: 'cover' }}
+                    src={urlComputed}
+                />
                 {showNetwork && <ImageIcon icon={networkIcon} size={20} classes={{ icon: classes.networkIcon }} />}
             </div>
         )

--- a/packages/shared/src/UI/components/NFTList/index.tsx
+++ b/packages/shared/src/UI/components/NFTList/index.tsx
@@ -89,7 +89,7 @@ const useStyles = makeStyles<{ columns?: number; gap?: number }>()((theme, { col
         inactive: {
             opacity: 0.5,
         },
-        loadingFailImage: {
+        fallbackImage: {
             width: 64,
             height: 64,
         },
@@ -135,7 +135,7 @@ export const NFTItem: FC<NFTItemProps> = ({ token }) => {
                 url={token.metadata?.imageURL ?? token.metadata?.imageURL}
                 tokenId={token.tokenId}
                 classes={{
-                    loadingFailImage: classes.loadingFailImage,
+                    fallbackImage: classes.fallbackImage,
                     iframe: classes.assetPlayerIframe,
                     imgWrapper: classes.imgWrapper,
                     wrapper: classes.wrapper,


### PR DESCRIPTION
## Description
<img width="387" alt="image" src="https://user-images.githubusercontent.com/63733714/185843016-4f50fbb6-50f6-4153-ab59-8f11e1347fb1.png">


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
