### PR TITLE
fix: devtools cannot see response of some requests

### DIFF
--- a/packages/polyfills/builder.mjs
+++ b/packages/polyfills/builder.mjs
@@ -1,6 +1,5 @@
 import { fileURLToPath } from 'node:url'
 import { readFile, writeFile } from 'node:fs/promises'
-import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { createRequire } from 'node:module'
 import builder from 'core-js-builder'
@@ -21,7 +20,7 @@ let polyfillVersion = '__'
     const lockfile = await readFile(lockfilePath)
     const hash = createHash('sha256')
     hash.update(lockfile)
-    polyfillVersion = 'v1' + hash.digest('hex')
+    polyfillVersion = 'v2' + hash.digest('hex')
 }
 
 const versionFilePath = fileURLToPath(new URL('./dist/version.txt', import.meta.url))

--- a/packages/polyfills/web-apis/implementation/Response.blob.ts
+++ b/packages/polyfills/web-apis/implementation/Response.blob.ts
@@ -1,0 +1,9 @@
+try {
+    // See: https://bugs.chromium.org/p/chromium/issues/detail?id=1355770
+    Response.prototype.blob = async function (this: Response) {
+        return new Blob([await this.arrayBuffer()], {
+            type: this.headers.get('Content-Type')?.split(';')[0],
+        })
+    }
+} catch {}
+export {}

--- a/packages/polyfills/web-apis/worker.ts
+++ b/packages/polyfills/web-apis/worker.ts
@@ -1,3 +1,4 @@
 import './implementation/EventTarget-abortSignal'
 import './implementation/AbortController.abortReason'
 import './implementation/AbortSignal.throwIfAborted'
+import './implementation/Response.blob'


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
