### PR TITLE
fix(sandboxed-plugin): builder gives wrong origin for modules

### DIFF
--- a/packages/mask/public/module-loader.js
+++ b/packages/mask/public/module-loader.js
@@ -30,7 +30,7 @@
         } else {
             // pathname is started "//"
             await import('/sandboxed-modules' + spec.pathname.slice(1))
-            if (modules.has(spec)) return modules.get(spec)
+            if (modules.has(spec.href)) return modules.get(spec.href)
             throw new SyntaxError(`Module ${specifier} is not a valid module.`)
         }
     }

--- a/packages/sandboxed-plugins/plugins.json
+++ b/packages/sandboxed-plugins/plugins.json
@@ -15,4 +15,4 @@
 //     The sandbox plugin from npm should be installed in ./package.json.
 //     The sandbox plugin should has a valid <package-name>/mask-manifest.json available.
 //     If a local folder points outside of this repo, it must be in the plugins-local.json
-["file:./example/"]
+[]

--- a/packages/sandboxed-plugins/plugins.json
+++ b/packages/sandboxed-plugins/plugins.json
@@ -15,4 +15,4 @@
 //     The sandbox plugin from npm should be installed in ./package.json.
 //     The sandbox plugin should has a valid <package-name>/mask-manifest.json available.
 //     If a local folder points outside of this repo, it must be in the plugins-local.json
-[]
+["file:./example/"]

--- a/packages/scripts/src/projects/sandboxed-plugins.ts
+++ b/packages/scripts/src/projects/sandboxed-plugins.ts
@@ -137,7 +137,7 @@ function createBuilder({ id, manifestRoot, distPath, onJS, origin }: BuilderOpti
             since: lastRun(compile),
             cwd: manifestRoot,
         })
-            .pipe(new TransformStream(id, onJS))
+            .pipe(new TransformStream(origin, onJS))
             .pipe(dest(origin, { cwd: distPath }))
     }
     return compile

--- a/packages/scripts/src/projects/sandboxed-plugins.ts
+++ b/packages/scripts/src/projects/sandboxed-plugins.ts
@@ -54,7 +54,7 @@ export async function buildSandboxedPluginConfigurable(distPath: string, isProdu
                 id: json.id,
                 manifestRoot: manifestPath.slice(0, -'/mask-manifest.json'.length),
                 distPath,
-                prefix: 'plugin-',
+                origin: 'plugin-' + json.id,
                 onJS: (id, relative) => mv3PreloadList.add(removeMJSSuffix(`${id}/${relative}`)),
             }),
         )
@@ -74,7 +74,7 @@ export async function buildSandboxedPluginConfigurable(distPath: string, isProdu
             createBuilder({
                 id: json.id,
                 manifestRoot: manifestPath.slice(0, -'/mask-manifest.json'.length),
-                prefix: 'local-plugin-',
+                origin: 'local-plugin-' + json.id,
                 distPath,
                 onJS: (id, relative) => mv3PreloadList.add(removeMJSSuffix(`local-${id}/${relative}`)),
             }),
@@ -126,11 +126,11 @@ watchTask(buildSandboxedPlugin, watchSandboxedPlugin, 'sbp', 'Build sandboxed pl
 interface BuilderOptions {
     id: string
     manifestRoot: string
-    prefix: string
+    origin: string
     distPath: string
     onJS(id: string, relative: string): void
 }
-function createBuilder({ id, manifestRoot, prefix, distPath, onJS }: BuilderOptions) {
+function createBuilder({ id, manifestRoot, distPath, onJS, origin }: BuilderOptions) {
     if (id.includes('..') || id.includes('/')) throw new TypeError(`Invalid plugin: ${id}`)
     function compile() {
         return src(['./**/*'], {
@@ -138,7 +138,7 @@ function createBuilder({ id, manifestRoot, prefix, distPath, onJS }: BuilderOpti
             cwd: manifestRoot,
         })
             .pipe(new TransformStream(id, onJS))
-            .pipe(dest(prefix + id, { cwd: distPath }))
+            .pipe(dest(origin, { cwd: distPath }))
     }
     return compile
 }
@@ -183,7 +183,7 @@ function resolveManifestPath(spec: string) {
     }
 }
 class TransformStream extends Transform {
-    constructor(public id: string, public onJS: (id: string, relative: string) => void) {
+    constructor(public origin: string, public onJS: (id: string, relative: string) => void) {
         super({ objectMode: true, defaultEncoding: 'utf-8' })
     }
     wasm = require.resolve('@masknet/static-module-record-swc')
@@ -196,8 +196,8 @@ class TransformStream extends Transform {
             return callback(null, file)
         }
         const relative = file.relative.replace(/\\/g, '/')
-        this.onJS(this.id, file.relative)
-        const sandboxedPath = 'mask-modules://' + this.id + '/' + relative
+        this.onJS(this.origin, file.relative)
+        const sandboxedPath = 'mask-modules://' + this.origin + '/' + relative
         const options = {
             template: {
                 type: 'callback',


### PR DESCRIPTION
- fix: module loader does not handle origin correctly
- fix: sandbox module origin error

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
