### PR TITLE
feat: raise syntax target to es2022

### DIFF
--- a/packages/mask/.webpack/config.ts
+++ b/packages/mask/.webpack/config.ts
@@ -37,7 +37,7 @@ export function createConfiguration(rawFlags: BuildFlags): Configuration {
         name: 'mask',
         mode,
         devtool: sourceMapKind,
-        target: ['web', 'es2021'],
+        target: ['web', 'es2022'],
         entry: {},
         experiments: { backCompat: false, asyncWebAssembly: true },
         cache: {
@@ -118,7 +118,7 @@ export function createConfiguration(rawFlags: BuildFlags): Configuration {
                                 dynamicImport: true,
                                 tsx: true,
                             },
-                            target: 'es2021',
+                            target: 'es2022',
                             externalHelpers: true,
                             transform: {
                                 react: {

--- a/packages/mask/background/tsconfig.json
+++ b/packages/mask/background/tsconfig.json
@@ -7,7 +7,7 @@
     "emitDeclarationOnly": true,
     // MV3 = WebWorker, MV2 = DOM
     // but we cannot build the same code in two env
-    "lib": ["ES2021", "WebWorker"]
+    "lib": ["ES2022", "WebWorker"]
   },
   "include": ["./"],
   "references": [

--- a/packages/mask/shared-ui/tsconfig.json
+++ b/packages/mask/shared-ui/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "../dist/shared-ui/",
     "tsBuildInfoFile": "../dist/shared-ui.tsbuildinfo",
     "emitDeclarationOnly": true,
-    "lib": ["ES2021"]
+    "lib": ["ES2022"]
   },
   "include": ["./", "./**/*.json"],
   "references": [

--- a/packages/mask/shared/tsconfig.json
+++ b/packages/mask/shared/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "../dist/shared/",
     "tsBuildInfoFile": "../dist/shared.tsbuildinfo",
     "emitDeclarationOnly": true,
-    "lib": ["ES2021"]
+    "lib": ["ES2022"]
   },
   "include": ["./"],
   "exclude": ["./plugin-infra/register.js"],

--- a/packages/mask/src/tsconfig.json
+++ b/packages/mask/src/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "../dist/src/",
     "tsBuildInfoFile": "../dist/legacy.tsbuildinfo",
     "emitDeclarationOnly": true,
-    "lib": ["ES2021"]
+    "lib": ["ES2022"]
   },
   "include": ["./", "./**/*.json"],
 

--- a/packages/mask/utils-pure/tsconfig.json
+++ b/packages/mask/utils-pure/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "../dist/utils-pure/",
     "tsBuildInfoFile": "../dist/utils-pure.tsbuildinfo",
     "emitDeclarationOnly": true,
-    "lib": ["ES2021"]
+    "lib": ["ES2022"]
   },
   "include": ["./"],
   "references": [{ "path": "../../shared-base" }]

--- a/packages/mask/utils-ui/tsconfig.json
+++ b/packages/mask/utils-ui/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "../dist/utils-ui/",
     "tsBuildInfoFile": "../dist/utils-ui.tsbuildinfo",
     "emitDeclarationOnly": true,
-    "lib": ["ES2021"]
+    "lib": ["ES2022"]
   },
   "include": ["./"],
   "references": []

--- a/packages/polyfills/README.md
+++ b/packages/polyfills/README.md
@@ -9,18 +9,17 @@
 Extra:
 
 - Intl: `dist/intl.js` provides polyfill for ES Intl API.
-- Secp256k1 support in WebCrypto: `dist/secp256k1.js`
 
 ## Supporting browsers
 
-- Safari 14+ (Released on Sept 2020)
+- Safari 14.5+ (Released on Sept 2020)
 - Chrome Last 2 versions (about 3 months)
 - Firefox Last 2 versions (about 3 months)
 - GeckoView 99 (last updated at 4/5/2022).
 
 ## Targeting ES Syntax and APIs
 
-- Syntax: ES2021
+- Syntax: ES2022
 - Library: ES2022 (with [core-js](https://github.com/zloirock/core-js)).
 
 ### Caution
@@ -35,7 +34,6 @@ Those features are not easy to polyfill.
   - DataView.prototype.getBigInt64 (requires Safari 15)
   - DataView.prototype.getBigUint64 (requires Safari 15)
 - ES2022:
-  - ⭐ C l a s s ⭐ F i e l d s ⭐ (requires Safari 14.5)
   - Class initialization block (Safari not supported)
 
 ## Web APIs and Intl APIs

--- a/packages/scripts/src/codegen/icon-codegen.ts
+++ b/packages/scripts/src/codegen/icon-codegen.ts
@@ -169,7 +169,7 @@ async function generateIcons() {
             jsc: {
                 parser: { jsx: true, syntax: 'ecmascript' },
                 transform: { react: { useBuiltins: true, runtime: 'automatic' } },
-                target: 'es2021',
+                target: 'es2022',
             },
         }).then(({ code }) => writeFile(CODE_FILE + '-jsx.js', code)),
         writeFile(CODE_FILE + '-jsx.d.ts', asJSX.dts.join('\n')),

--- a/packages/storybook-shared/patch-webpack.cjs
+++ b/packages/storybook-shared/patch-webpack.cjs
@@ -11,7 +11,7 @@ module.exports = async function (config) {
                     dynamicImport: true,
                     tsx: true,
                 },
-                target: 'es2021',
+                target: 'es2022',
                 transform: {
                     react: {
                         runtime: 'automatic',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -149,7 +149,7 @@
     // Language and Environment
     "jsx": "react-jsx",
     "lib": ["ES2022"], // don't add "DOM", we use @types/web
-    "target": "ES2021",
+    "target": "ES2022",
     "useDefineForClassFields": true,
 
     // Projects


### PR DESCRIPTION
New syntax

+ Public/private fields.

The following syntaxes ARE NOT available on Safari so please don't use them!

- `#priv in expr` private field check
- class static initialization block
- RegExp /d flag