### PR TITLE
fix: show image at web3 tab

### DIFF
--- a/packages/mask/src/components/InjectedComponents/ProfileTabContent.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileTabContent.tsx
@@ -69,7 +69,7 @@ export function ProfileTabContent(props: ProfileTabContentProps) {
         return plugins
             .flatMap((x) => x.ProfileTabs?.map((y) => ({ ...y, pluginID: x.ID })) ?? EMPTY_LIST)
             .filter((x) => {
-                const shouldDisplay = x.Utils?.shouldDisplay?.(currentVisitingIdentity, selectedAddress) ?? true
+                const shouldDisplay = x.Utils?.shouldDisplay?.(currentVisitingIdentity, socialAddressList) ?? true
                 return x.pluginID !== PluginId.NextID && shouldDisplay
             })
             .sort((a, z) => {

--- a/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectionIcon.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectionIcon.tsx
@@ -1,8 +1,7 @@
 import { memo } from 'react'
 import { Box, Tooltip } from '@mui/material'
-import { Image } from '../../../../components/shared/Image'
 import { makeStyles } from '@masknet/theme'
-import { TokenIcon } from '@masknet/shared'
+import { TokenIcon, Image } from '@masknet/shared'
 import classNames from 'classnames'
 import { isSameAddress, NonFungibleTokenCollection } from '@masknet/web3-shared-base'
 import type { Web3Helper } from '@masknet/plugin-infra/src/entry-web3'
@@ -58,13 +57,7 @@ export const CollectionIcon = memo<CollectionIconProps>(({ collection, onClick, 
                 )}
                 onClick={onClick}>
                 {collection?.iconURL ? (
-                    <Image
-                        width={24}
-                        height={24}
-                        component="img"
-                        className={classes.collectionImg}
-                        src={collection?.iconURL}
-                    />
+                    <Image width={24} height={24} className={classes.collectionImg} src={collection?.iconURL} />
                 ) : (
                     <TokenIcon
                         classes={{ icon: classes.collectionImg }}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes mf-1578

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
