### PR TITLE
refactor: remove provider switcher

### DIFF
--- a/packages/mask/shared-ui/locales/en-US.json
+++ b/packages/mask/shared-ui/locales/en-US.json
@@ -747,6 +747,7 @@
     "plugin_collectible_total": "Total",
     "plugin_collectible_subtotal": "Subtotal",
     "plugin_collectible_item": "Item",
+    "plugin_collectible_refresh": "Refresh",
     "plugin_collectible_approved_tips": "By checking this box, I acknowledge that this item has not been reviewed\n                                                or approved by OpenSea.",
     "plugin_collectible_agree_terms": "By checking this box, I agree to OpenSea's <terms>Terms of Service</terms>.",
     "plugin_collectible_convert_eth": "Convert ETH",

--- a/packages/mask/src/components/shared/NFTCard/NFTBasicInfo.tsx
+++ b/packages/mask/src/components/shared/NFTCard/NFTBasicInfo.tsx
@@ -2,11 +2,8 @@ import { NFTCardStyledAssetPlayer } from '@masknet/shared'
 import { makeStyles, MaskColorVar } from '@masknet/theme'
 import { Typography } from '@mui/material'
 import VerifiedUserIcon from '@mui/icons-material/VerifiedUser'
-import { SourceType } from '@masknet/web3-shared-base'
-import { CollectibleProviderIcon } from '../../../plugins/Collectible/SNSAdaptor/CollectibleProviderIcon'
 import type { Web3Helper } from '@masknet/plugin-infra/src/web3-helpers'
 import type { NetworkPluginID } from '@masknet/web3-shared-base'
-import { getEnumAsArray } from '@dimensiondev/kit'
 
 const useStyles = makeStyles()((theme) => ({
     layout: {
@@ -99,34 +96,21 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-interface NFTBasicInfoProps {
+export interface NFTBasicInfoProps {
     hideSubTitle?: boolean
     asset: Web3Helper.NonFungibleAssetScope<void, NetworkPluginID.PLUGIN_EVM>
-    onChangeProvider: (v: SourceType) => void
-    providers: SourceType[]
-    currentProvider: SourceType
     timeline?: boolean
 }
 
 export function NFTBasicInfo(props: NFTBasicInfoProps) {
-    const { asset, hideSubTitle, onChangeProvider, providers, currentProvider, timeline } = props
+    const { asset, hideSubTitle, timeline } = props
     const { classes, cx } = useStyles()
 
-    const collectibleProviderOptions = getEnumAsArray(SourceType).filter((x) => providers.includes(x.value))
     const fallbackImgURL = new URL('../assets/fallbackImg.svg', import.meta.url)
     const resourceUrl = asset.metadata?.imageURL ?? asset.metadata?.mediaURL
     return (
         <div className={classes.layout}>
             <div className={classes.body}>
-                <div className={classes.absoluteProvider}>
-                    {collectibleProviderOptions.map((x) => {
-                        return (
-                            <div className={classes.providerIcon} key={x.key} onClick={() => onChangeProvider(x.value)}>
-                                <CollectibleProviderIcon active={currentProvider === x.value} provider={x.value} />
-                            </div>
-                        )
-                    })}
-                </div>
                 <NFTCardStyledAssetPlayer
                     fallbackImage={fallbackImgURL}
                     url={resourceUrl}

--- a/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
+++ b/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
@@ -215,7 +215,7 @@ export function Collectible(props: CollectibleProps) {
                     }
                     title={
                         <Typography style={{ display: 'flex', alignItems: 'center' }}>
-                            <Typography className={classes.cardTitle}>{_asset.metadata?.name || '-'}</Typography>
+                            <span className={classes.cardTitle}>{_asset.metadata?.name || '-'}</span>
                             {_asset.collection?.verified ? <Icons.VerifiedCollection sx={{ marginLeft: 0.5 }} /> : null}
                         </Typography>
                     }

--- a/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
+++ b/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
@@ -1,6 +1,6 @@
 import { Icons } from '@masknet/icons'
 import { LoadingBase, makeStyles, MaskColorVar, MaskTabList, useTabs } from '@masknet/theme'
-import { resolveSourceName, SourceType } from '@masknet/web3-shared-base'
+import { resolveSourceName } from '@masknet/web3-shared-base'
 import { TabContext } from '@mui/lab'
 import { Box, Button, CardContent, CardHeader, Paper, Tab, Typography } from '@mui/material'
 import formatDateTime from 'date-fns/format'
@@ -8,6 +8,7 @@ import isAfter from 'date-fns/isAfter'
 import isValidDate from 'date-fns/isValid'
 import { useI18N, useSwitcher } from '../../../utils'
 import { Markdown } from '../../Snapshot/SNSAdaptor/Markdown'
+import { SupportedProvider } from '../constants'
 import { CollectibleState } from '../hooks/useCollectibleState'
 import { CollectiblePaper } from './CollectiblePaper'
 import { LinkingAvatar } from './LinkingAvatar'
@@ -136,17 +137,6 @@ const useStyles = makeStyles()((theme) => {
     }
 })
 
-const supportedProvider = [
-    // to add providers, temp hide some providers
-    SourceType.OpenSea,
-    SourceType.Gem,
-    SourceType.Rarible,
-    // SourceType.X2Y2,
-    // SourceType.NFTScan,
-    // SourceType.Zora,
-    // SourceType.LooksRare,
-]
-
 export interface CollectibleProps {}
 
 export function Collectible(props: CollectibleProps) {
@@ -155,7 +145,7 @@ export function Collectible(props: CollectibleProps) {
     const { asset, provider, setProvider } = CollectibleState.useContainer()
 
     // #region provider switcher
-    const CollectibleProviderSwitcher = useSwitcher(provider, setProvider, supportedProvider, resolveSourceName, true)
+    const CollectibleProviderSwitcher = useSwitcher(provider, setProvider, SupportedProvider, resolveSourceName, true)
     // #endregion
     const [currentTab, onChange, tabs] = useTabs('about', 'details', 'offers', 'activity')
     if (asset.loading)

--- a/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
+++ b/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
@@ -6,7 +6,6 @@ import { Box, Button, CardContent, CardHeader, Paper, Tab, Typography } from '@m
 import formatDateTime from 'date-fns/format'
 import isAfter from 'date-fns/isAfter'
 import isValidDate from 'date-fns/isValid'
-import { useCallback } from 'react'
 import { useI18N, useSwitcher } from '../../../utils'
 import { Markdown } from '../../Snapshot/SNSAdaptor/Markdown'
 import { CollectibleState } from '../hooks/useCollectibleState'
@@ -155,10 +154,6 @@ export function Collectible(props: CollectibleProps) {
     const { classes } = useStyles()
     const { asset, provider, setProvider } = CollectibleState.useContainer()
 
-    const onDataProviderChange = useCallback((v: SourceType) => {
-        setProvider(v)
-    }, [])
-
     // #region provider switcher
     const CollectibleProviderSwitcher = useSwitcher(provider, setProvider, supportedProvider, resolveSourceName, true)
     // #endregion
@@ -199,14 +194,7 @@ export function Collectible(props: CollectibleProps) {
     const endDate = _asset.auction?.endAt
     const renderTab = () => {
         const tabMap = {
-            [tabs.about]: (
-                <AboutTab
-                    currentProvider={provider}
-                    providers={supportedProvider}
-                    onChangeProvider={onDataProviderChange}
-                    asset={asset}
-                />
-            ),
+            [tabs.about]: <AboutTab asset={asset} />,
             [tabs.details]: <DetailTab asset={asset} />,
             [tabs.offers]: <OffersTab />,
             [tabs.activity]: <ActivityTab />,

--- a/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
+++ b/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
@@ -173,7 +173,7 @@ export function Collectible(props: CollectibleProps) {
                     <Box sx={{ flex: 1, padding: 1 }}> {CollectibleProviderSwitcher}</Box>
                     <Box sx={{ flex: 1, padding: 1 }}>
                         <Button fullWidth onClick={() => asset.retry()} variant="roundedDark">
-                            Refresh
+                            {t('refresh')}
                         </Button>
                     </Box>
                 </Box>

--- a/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
+++ b/packages/mask/src/plugins/Collectible/SNSAdaptor/Collectible.tsx
@@ -173,7 +173,7 @@ export function Collectible(props: CollectibleProps) {
                     <Box sx={{ flex: 1, padding: 1 }}> {CollectibleProviderSwitcher}</Box>
                     <Box sx={{ flex: 1, padding: 1 }}>
                         <Button fullWidth onClick={() => asset.retry()} variant="roundedDark">
-                            {t('refresh')}
+                            {t('plugin_collectible_refresh')}
                         </Button>
                     </Box>
                 </Box>

--- a/packages/mask/src/plugins/Collectible/SNSAdaptor/Tabs/AboutTab.tsx
+++ b/packages/mask/src/plugins/Collectible/SNSAdaptor/Tabs/AboutTab.tsx
@@ -1,11 +1,11 @@
-import { LoadingBase, makeStyles } from '@masknet/theme'
 import { useMemo } from 'react'
-import type { Web3Helper } from '@masknet/plugin-infra/src/web3-helpers'
-import type { NetworkPluginID, SourceType, NonFungibleTokenOrder } from '@masknet/web3-shared-base'
-import type { ChainId, SchemaType } from '@masknet/web3-shared-evm'
 import type { AsyncState } from 'react-use/lib/useAsyncFn'
 import BigNumber from 'bignumber.js'
 import { first } from 'lodash-unified'
+import { LoadingBase, makeStyles } from '@masknet/theme'
+import type { Web3Helper } from '@masknet/plugin-infra/src/web3-helpers'
+import type { NetworkPluginID, NonFungibleTokenOrder } from '@masknet/web3-shared-base'
+import type { ChainId, SchemaType } from '@masknet/web3-shared-evm'
 import { CollectibleState } from '../../hooks/useCollectibleState'
 import { CollectibleTab } from '../CollectibleTab'
 import { NFTBasicInfo } from '../../../../components/shared/NFTCard/NFTBasicInfo'
@@ -24,13 +24,6 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export interface AboutTabProps {
-    asset: AsyncState<Web3Helper.NonFungibleAssetScope<void, NetworkPluginID.PLUGIN_EVM>>
-    onChangeProvider: (v: SourceType) => void
-    providers: SourceType[]
-    currentProvider: SourceType
-}
-
 const resolveTopOffer = (orders?: Array<NonFungibleTokenOrder<ChainId, SchemaType>>) => {
     if (!orders || !orders.length) return
     return first(
@@ -42,8 +35,12 @@ const resolveTopOffer = (orders?: Array<NonFungibleTokenOrder<ChainId, SchemaTyp
     )
 }
 
+export interface AboutTabProps {
+    asset: AsyncState<Web3Helper.NonFungibleAssetScope<void, NetworkPluginID.PLUGIN_EVM>>
+}
+
 export function AboutTab(props: AboutTabProps) {
-    const { asset, providers, currentProvider, onChangeProvider } = props
+    const { asset } = props
     const { orders } = CollectibleState.useContainer()
     const { classes } = useStyles()
 
@@ -61,13 +58,7 @@ export function AboutTab(props: AboutTabProps) {
             <CollectibleTab>
                 <div className={classes.body}>
                     <div className={classes.basic}>
-                        <NFTBasicInfo
-                            currentProvider={currentProvider}
-                            providers={providers}
-                            onChangeProvider={onChangeProvider}
-                            hideSubTitle
-                            asset={asset.value}
-                        />
+                        <NFTBasicInfo hideSubTitle asset={asset.value} />
                     </div>
                     <NFTPriceCard topOffer={topOffer} asset={asset.value} />
                 </div>

--- a/packages/mask/src/plugins/Collectible/constants.ts
+++ b/packages/mask/src/plugins/Collectible/constants.ts
@@ -1,4 +1,5 @@
 import { PluginId } from '@masknet/plugin-infra'
+import { SourceType } from '@masknet/web3-shared-base'
 
 export const PLUGIN_NAME = 'Collectibles'
 export const PLUGIN_DESCRIPTION = 'An NFT collectible viewer.'
@@ -23,3 +24,14 @@ export const OpenSeaTestnetURL = 'https://testnets.opensea.io'
 export const RaribleUserURL = 'https://rarible.com/user/'
 export const RaribleRopstenUserURL = 'https://ropsten.rarible.com/user/'
 export const RaribleRinkebyUserURL = 'https://rinkeby.rarible.com/user/'
+
+export const SupportedProvider = [
+    SourceType.Gem,
+    SourceType.NFTScan,
+    SourceType.Rarible,
+    SourceType.OpenSea,
+    // SourceType.X2Y2,
+    // SourceType.NFTScan,
+    // SourceType.Zora,
+    // SourceType.LooksRare,
+]

--- a/packages/mask/src/plugins/Collectible/hooks/useCollectibleState.ts
+++ b/packages/mask/src/plugins/Collectible/hooks/useCollectibleState.ts
@@ -11,7 +11,7 @@ import { NetworkPluginID, SourceType } from '@masknet/web3-shared-base'
 import { ChainId } from '@masknet/web3-shared-evm'
 
 function useCollectibleState(token?: CollectibleToken) {
-    const [provider, setProvider] = useState(token?.provider ?? SourceType.Gem)
+    const [provider, setProvider] = useState(SourceType.NFTScan)
 
     const asset = useNonFungibleAsset(NetworkPluginID.PLUGIN_EVM, token?.contractAddress ?? '', token?.tokenId ?? '', {
         sourceType: provider,

--- a/packages/mask/src/plugins/NFTCard/SNSAdaptor/NFTCardDialog.tsx
+++ b/packages/mask/src/plugins/NFTCard/SNSAdaptor/NFTCardDialog.tsx
@@ -24,7 +24,7 @@ export function NFTCardDialog() {
     const [tokenAddress, setTokenAddress] = useState('')
     const chainIdValid = useChainIdValid(NetworkPluginID.PLUGIN_EVM)
     const [open, setOpen] = useState(false)
-    const { asset, orders, events, rarity, provider, setProvider } = useNFTCardInfo(tokenAddress, tokenId)
+    const { asset, orders, events, provider } = useNFTCardInfo(tokenAddress, tokenId)
 
     const [currentTab, onChange] = useTabs<NFTCardDialogTabs>(
         NFTCardDialogTabs.About,
@@ -60,7 +60,6 @@ export function NFTCardDialog() {
                         provider={provider}
                         events={events}
                         orders={orders}
-                        onChangeProvider={setProvider}
                         asset={asset}
                         currentTab={currentTab}
                     />

--- a/packages/mask/src/plugins/NFTCard/SNSAdaptor/NFTCardDialogUI.tsx
+++ b/packages/mask/src/plugins/NFTCard/SNSAdaptor/NFTCardDialogUI.tsx
@@ -22,19 +22,17 @@ import type { Web3Helper } from '@masknet/plugin-infra/src/web3-helpers'
 import type { AsyncStateRetry } from 'react-use/lib/useAsyncRetry'
 import { LoadingBase } from '@masknet/theme'
 import { base as pluginDefinition } from '../base'
-interface NFTCardDialogUIProps {
+
+export interface NFTCardDialogUIProps {
     currentTab: NFTCardDialogTabs
     asset: AsyncStateRetry<Web3Helper.NonFungibleAssetScope<void, NetworkPluginID.PLUGIN_EVM>>
-    onChangeProvider: (v: SourceType) => void
     orders: AsyncStateRetry<Pageable<NonFungibleTokenOrder<ChainId, SchemaType>>>
     events: AsyncStateRetry<Pageable<NonFungibleTokenEvent<ChainId, SchemaType>>>
     provider: SourceType
 }
 
-const supportedProvider = [SourceType.OpenSea, SourceType.Gem, SourceType.Rarible, SourceType.NFTScan]
-
 export function NFTCardDialogUI(props: NFTCardDialogUIProps) {
-    const { currentTab, asset, orders, onChangeProvider, provider, events } = props
+    const { currentTab, asset, orders, provider, events } = props
     const { classes } = useStyles()
     const { t: tb } = useBaseI18n()
     const { setDialog: setSelectProviderDialog } = useRemoteControlledDialog(
@@ -66,13 +64,7 @@ export function NFTCardDialogUI(props: NFTCardDialogUIProps) {
         <div className={classes.contentWrapper}>
             <div className={classes.contentLayout}>
                 <div className={classes.mediaBox}>
-                    <NFTBasicInfo
-                        timeline
-                        providers={supportedProvider}
-                        currentProvider={provider}
-                        asset={asset.value}
-                        onChangeProvider={onChangeProvider}
-                    />
+                    <NFTBasicInfo timeline asset={asset.value} />
                 </div>
 
                 <div className={classes.tabWrapper}>


### PR DESCRIPTION
## Description

1. Set NFTScan as the default provider.
2. Remove provider selector in NFT info card.

![image](https://user-images.githubusercontent.com/52657989/187821499-7158efad-9188-44ef-a5d6-5240cd233d4a.png)

Closes MF-1849

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [x] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)
