### PR TITLE
fix: treat inline svg code as locale resource

### DIFF
--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/ProfileCard/index.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/ProfileCard/index.tsx
@@ -21,6 +21,7 @@ export function injectProfileCardHolder(signal: AbortSignal) {
 
 const CARD_WIDTH = 450
 const CARD_HEIGHT = 500
+const DISMISS_TIMEOUT = process.env.NODE_ENV === 'production' ? 2000 : 120_000
 const useStyles = makeStyles()((theme) => ({
     root: {
         position: 'absolute',
@@ -70,7 +71,7 @@ function ProfileCardHolder() {
         }
         const leave = () => {
             activeRef.current = false
-            timer = setTimeout(hideProfileCard, 2000)
+            timer = setTimeout(hideProfileCard, DISMISS_TIMEOUT)
         }
         holder.addEventListener('mouseenter', enter)
         holder.addEventListener('mouseleave', leave)

--- a/packages/shared/src/UI/components/Image/index.tsx
+++ b/packages/shared/src/UI/components/Image/index.tsx
@@ -64,7 +64,7 @@ export function Image({ fallback, disableSpinner, classes: externalClasses, ...r
 
     if (image) {
         return (
-            <Box className={classes.container} data-url={rest.src}>
+            <Box className={classes.container}>
                 <img {...rest} src={image} />
             </Box>
         )
@@ -82,7 +82,7 @@ export function Image({ fallback, disableSpinner, classes: externalClasses, ...r
     )
 
     return (
-        <Box className={classes.container} data-url={rest.src}>
+        <Box className={classes.container}>
             <img {...rest} src={fallbackImageURL} className={classNames(classes.failImage, classes.fallbackImage)} />
         </Box>
     )

--- a/packages/shared/src/UI/components/Image/loadImage.ts
+++ b/packages/shared/src/UI/components/Image/loadImage.ts
@@ -1,6 +1,7 @@
 import { isLocaleResource } from '@masknet/web3-shared-base'
 
 export async function loadImage(url: string) {
+    if (url.startsWith('<svg ')) return `data:image/svg+xml;base64,${btoa(url)}`
     if (isLocaleResource(url)) return url
     return new Promise<string>((resolve, reject) => {
         const img = document.createElement('img')

--- a/packages/web3-shared/base/src/utils/resolver.ts
+++ b/packages/web3-shared/base/src/utils/resolver.ts
@@ -234,8 +234,7 @@ export const isIpfsCid = (cid: string) => {
 }
 
 export const isLocaleResource = (url: string): boolean => {
-    // base64 image
-    return /^data|blob:|(chrome|moz)-extension:\/\//.test(url)
+    return /^data|blob:|(chrome|moz)-extension:\/\/|<svg\s/.test(url)
 }
 
 export function resolveIPFSLink(cidOrURL?: string): string | undefined {

--- a/packages/web3-shared/base/tests/resolver.ts
+++ b/packages/web3-shared/base/tests/resolver.ts
@@ -17,6 +17,7 @@ describe('resolveCORSLink', () => {
         { give: CHROME_EXTENSION_URL, expected: CHROME_EXTENSION_URL },
         { give: MOZ_EXTENSION_URL, expected: MOZ_EXTENSION_URL },
         { give: IMAGE_DATA_PARTIAL, expected: IMAGE_DATA_PARTIAL },
+        { give: '<svg xmlns></svg>', expected: '<svg xmlns></svg>' },
     ])('.resolveCORSLink', ({ give, expected }) => {
         expect(resolveCORSLink(give)).toBe(expected)
     })


### PR DESCRIPTION
closes #7270
