### PR TITLE
fix: web3-constant run `start` failed

### DIFF
--- a/packages/web3-constants/compile-constants.ts
+++ b/packages/web3-constants/compile-constants.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs'
 import path from 'path'
-import { run } from '../web3-contracts/utils.js'
+import { run } from '@masknet/web3-contracts/utils'
 
 async function compileConstants(folderPath: string, names: string[]) {
     // fix constants

--- a/packages/web3-constants/package.json
+++ b/packages/web3-constants/package.json
@@ -3,5 +3,8 @@
   "private": true,
   "scripts": {
     "start": "ts-node compile-constants.ts"
+  },
+  "dependencies": {
+    "@masknet/web3-contracts": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2216,7 +2216,11 @@ importers:
         specifier: ^5.0.3
         version: 5.0.3
 
-  packages/web3-constants: {}
+  packages/web3-constants:
+    dependencies:
+      '@masknet/web3-contracts':
+        specifier: workspace:*
+        version: link:../web3-contracts
 
   packages/web3-contracts:
     dependencies:
@@ -20954,7 +20958,7 @@ packages:
     patched: true
 
   /immutable/3.8.1:
-    resolution: {integrity: sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ==}
+    resolution: {integrity: sha1-IAgH8Rqw9ycQ6khVQt4IgHX2jNI=}
     engines: {node: '>=0.10.0'}
     dev: false
 


### PR DESCRIPTION
## Description
<img width="708" alt="image" src="https://user-images.githubusercontent.com/19925717/189843312-e5b070a2-afa1-490e-8c59-a59524e9c1d2.png">

## Why do this
Remove the `.js` of `import { run } from '../web3-contracts/utils.js'` is also work.
But I think the `web3-contracts` is the individual package, use it by `@@masknet/....` is better.

