### PR TITLE
feat: set popper boundary for tooltip in dialog

### DIFF
--- a/packages/mask/src/components/shared/ApplicationBoard.tsx
+++ b/packages/mask/src/components/shared/ApplicationBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, createContext, PropsWithChildren, useMemo } from 'react'
+import { useState, useContext, createContext, PropsWithChildren, useMemo, useRef } from 'react'
 import { makeStyles, getMaskColor } from '@masknet/theme'
 import { Typography } from '@mui/material'
 import { useActivatedPluginsSNSAdaptor } from '@masknet/plugin-infra/content-script'
@@ -127,6 +127,7 @@ function ApplicationBoardContent(props: Props) {
     const currentWeb3Network = useCurrentWeb3NetworkPluginID()
     const chainId = useChainId()
     const account = useAccount()
+    const popperBoundaryRef = useRef<HTMLElement | null>(null)
     const currentSNSNetwork = getCurrentSNSNetwork(activatedSocialNetworkUI.networkIdentifier)
     const applicationList = useMemo(
         () =>
@@ -178,6 +179,7 @@ function ApplicationBoardContent(props: Props) {
 
             {listedAppList.length > 0 ? (
                 <section
+                    ref={popperBoundaryRef}
                     className={cx(
                         classes.applicationWrapper,
                         recommendFeatureAppList.length > 2 && isCarouselReady() && isHoveringCarousel
@@ -185,7 +187,11 @@ function ApplicationBoardContent(props: Props) {
                             : '',
                     )}>
                     {listedAppList.map((application) => (
-                        <RenderEntryComponent key={application.entry.ApplicationEntryID} application={application} />
+                        <RenderEntryComponent
+                            key={application.entry.ApplicationEntryID}
+                            application={application}
+                            popperBoundary={popperBoundaryRef.current}
+                        />
                     ))}
                 </section>
             ) : (
@@ -205,7 +211,13 @@ function ApplicationBoardContent(props: Props) {
     )
 }
 
-function RenderEntryComponent({ application }: { application: Application }) {
+function RenderEntryComponent({
+    application,
+    popperBoundary,
+}: {
+    application: Application
+    popperBoundary?: HTMLElement | null
+}) {
     const Entry = application.entry.RenderEntryComponent!
     const { t } = useI18N()
     const { setDialog: setSelectProviderDialog } = useRemoteControlledDialog(
@@ -251,7 +263,9 @@ function RenderEntryComponent({ application }: { application: Application }) {
     })()
     // #endregion
 
-    return <Entry disabled={disabled} tooltipHint={tooltipHint} onClick={clickHandler} />
+    return (
+        <Entry disabled={disabled} tooltipHint={tooltipHint} onClick={clickHandler} popperBoundary={popperBoundary} />
+    )
 }
 
 interface ApplicationEntryStatusContextProps {

--- a/packages/mask/src/components/shared/ApplicationSettingPluginList.tsx
+++ b/packages/mask/src/components/shared/ApplicationSettingPluginList.tsx
@@ -4,7 +4,7 @@ import {
     PluginI18NFieldRender,
     PluginID,
 } from '@masknet/plugin-infra/content-script'
-import { useMemo, useState, useCallback } from 'react'
+import { useMemo, useState, useCallback, useRef } from 'react'
 import { List, ListItem, Typography } from '@mui/material'
 import { makeStyles, getMaskColor, ShadowRootTooltip } from '@masknet/theme'
 import { useI18N } from '../../utils/index.js'
@@ -143,13 +143,15 @@ interface AppListProps {
 function AppList(props: AppListProps) {
     const { appList, setUnlistedApp, isListed } = props
     const { classes } = useStyles({ iconFilterColor: undefined })
+    const popperBoundaryRef = useRef<HTMLUListElement | null>(null)
     const { t } = useI18N()
 
     return appList.length > 0 ? (
-        <List className={classes.list}>
+        <List className={classes.list} ref={popperBoundaryRef}>
             {appList.map((application, index) => (
                 <AppListItem
                     key={index}
+                    popperBoundary={popperBoundaryRef.current}
                     application={application}
                     setUnlistedApp={setUnlistedApp}
                     isListed={isListed}
@@ -169,18 +171,28 @@ function AppList(props: AppListProps) {
 
 interface AppListItemProps {
     application: Application
+    popperBoundary: HTMLUListElement | null
     setUnlistedApp: (app: Application, unlisted: boolean) => void
     isListed: boolean
 }
 
 function AppListItem(props: AppListItemProps) {
-    const { application, setUnlistedApp, isListed } = props
+    const { application, setUnlistedApp, isListed, popperBoundary } = props
     const { classes } = useStyles({ iconFilterColor: application.entry.iconFilterColor })
     return (
         <ShadowRootTooltip
             PopperProps={{
                 disablePortal: true,
                 placement: 'top',
+                modifiers: [
+                    {
+                        name: 'flip',
+                        options: {
+                            boundary: popperBoundary,
+                            flipVariations: false,
+                        },
+                    },
+                ],
             }}
             title={
                 <Typography>

--- a/packages/plugin-infra/src/types.ts
+++ b/packages/plugin-infra/src/types.ts
@@ -539,6 +539,7 @@ export namespace Plugin.SNSAdaptor {
             disabled: boolean
             tooltipHint?: string
             onClick?: (walletConnectedCallback?: () => void) => void
+            popperBoundary?: HTMLElement | null
         }) => JSX.Element | null
         /**
          * Used to order the applications on the board

--- a/packages/shared/src/UI/components/ApplicationEntry/index.tsx
+++ b/packages/shared/src/UI/components/ApplicationEntry/index.tsx
@@ -94,13 +94,23 @@ interface ApplicationEntryProps {
     title: React.ReactNode
     disabled?: boolean
     recommendFeature?: Plugin.SNSAdaptor.ApplicationEntry['recommendFeature']
+    popperBoundary?: HTMLElement | null
     iconFilterColor?: string
     tooltipHint?: string | React.ReactElement
     onClick: () => void
 }
 
 export function ApplicationEntry(props: ApplicationEntryProps) {
-    const { title, onClick, disabled = false, icon, tooltipHint, recommendFeature, iconFilterColor } = props
+    const {
+        title,
+        onClick,
+        disabled = false,
+        icon,
+        tooltipHint,
+        recommendFeature,
+        iconFilterColor,
+        popperBoundary,
+    } = props
     const { classes } = useStyles({ disabled, iconFilterColor })
     const jsx = recommendFeature ? (
         <div
@@ -135,6 +145,15 @@ export function ApplicationEntry(props: ApplicationEntryProps) {
             PopperProps={{
                 disablePortal: true,
                 placement: recommendFeature ? 'bottom' : 'top',
+                modifiers: [
+                    {
+                        name: 'flip',
+                        options: {
+                            boundary: popperBoundary,
+                            flipVariations: false,
+                        },
+                    },
+                ],
             }}
             classes={{
                 tooltip: classes.tooltip,


### PR DESCRIPTION
## Description
Fix the bug: Tooltip within dialog changes its position unnecessarily when scrolling the `document.body`.

https://mask.atlassian.net/browse/MF-2031
https://mask.atlassian.net/browse/MF-2029

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
