### PR TITLE
fix: debank 429

### DIFF
--- a/packages/dashboard/src/components/LoadingPlaceholder/index.tsx
+++ b/packages/dashboard/src/components/LoadingPlaceholder/index.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react'
 import { Box, Typography } from '@mui/material'
 import { makeStyles, MaskColorVar, LoadingBase } from '@masknet/theme'
+import { useDashboardI18N } from '../../locales'
 
 const useStyles = makeStyles()((theme) => ({
     container: {
@@ -21,10 +22,11 @@ const useStyles = makeStyles()((theme) => ({
 
 export const LoadingPlaceholder = memo(() => {
     const { classes } = useStyles()
+    const t = useDashboardI18N()
     return (
         <Box className={classes.container}>
             <LoadingBase size={30} color={MaskColorVar.primary} />
-            <Typography className={classes.prompt}>loading...</Typography>
+            <Typography className={classes.prompt}>{t.wallets_loading_token()}</Typography>
         </Box>
     )
 })

--- a/packages/dashboard/src/locales/en-US.json
+++ b/packages/dashboard/src/locales/en-US.json
@@ -199,7 +199,7 @@
     "wallets_history_time": "Time",
     "wallets_history_receiver": "Interacted with (to)",
     "wallets_empty_history_tips": "No transaction history",
-    "wallets_loading_token": "Loading Token",
+    "wallets_loading_token": "Loading tokens...",
     "personas_setup_connect_tips": "Please connect to your {{type}} account.",
     "personas_setup_tip": "Please create or restore a Mask identity.",
     "personas_setup_connect": "Connect",

--- a/packages/dashboard/src/pages/Wallets/components/Assets/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Assets/index.tsx
@@ -38,13 +38,13 @@ export enum AssetTab {
 
 const assetTabs = [AssetTab.Token, AssetTab.Collectibles] as const
 
-interface TokenAssetsProps {
+export interface AssetsProps {
     network: Web3Helper.NetworkDescriptorAll | null
 }
 
-export const Assets = memo<TokenAssetsProps>(({ network }) => {
+export const Assets = memo<AssetsProps>(({ network }) => {
     const t = useDashboardI18N()
-    const pluginId = useCurrentWeb3NetworkPluginID()
+    const pluginID = useCurrentWeb3NetworkPluginID()
     const { classes } = useStyles()
     const assetTabsLabel: Record<AssetTab, string> = {
         [AssetTab.Token]: t.wallets_assets_token(),
@@ -58,9 +58,9 @@ export const Assets = memo<TokenAssetsProps>(({ network }) => {
 
     useEffect(() => {
         setTab(AssetTab.Token)
-    }, [pluginId])
+    }, [pluginID])
 
-    const showCollectibles = [NetworkPluginID.PLUGIN_EVM, NetworkPluginID.PLUGIN_SOLANA].includes(pluginId)
+    const showCollectibles = [NetworkPluginID.PLUGIN_EVM, NetworkPluginID.PLUGIN_SOLANA].includes(pluginID)
     const selectFungibleToken = useSelectFungibleToken()
 
     return (
@@ -75,7 +75,7 @@ export const Assets = memo<TokenAssetsProps>(({ network }) => {
                                     <Tab key={key} value={key} label={assetTabsLabel[key]} />
                                 ))}
                         </TabList>
-                        {pluginId === NetworkPluginID.PLUGIN_EVM && network && (
+                        {pluginID === NetworkPluginID.PLUGIN_EVM && network && (
                             <Button
                                 size="small"
                                 color="secondary"

--- a/packages/dashboard/src/pages/Wallets/components/Balance/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/Balance/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import { noop } from 'lodash-unified'
 import { Icons } from '@masknet/icons'
 import { FormattedCurrency, MiniNetworkSelector } from '@masknet/shared'
@@ -9,6 +9,10 @@ import { Box, Button, buttonClasses, styled, Typography } from '@mui/material'
 import { useDashboardI18N } from '../../../../locales'
 import { useIsMatched } from '../../hooks'
 import type { Web3Helper } from '@masknet/plugin-infra/web3'
+import { useContainer } from 'unstated-next'
+import { Context } from '../../hooks/useContext'
+import { getTokenUSDValue } from '../../utils/getTokenUSDValue'
+import BigNumber from 'bignumber.js'
 
 const BalanceContainer = styled('div')(
     ({ theme }) => `
@@ -69,7 +73,6 @@ const ButtonGroup = styled('div')`
 `
 
 export interface BalanceCardProps {
-    balance: number
     onSend(): void
     onBuy(): void
     onSwap(): void
@@ -94,11 +97,22 @@ export interface BalanceCardProps {
 }
 
 export const Balance = memo<BalanceCardProps>(
-    ({ balance, onSend, onBuy, onSwap, onReceive, onSelectNetwork, networks, selectedNetwork, showOperations }) => {
+    ({ onSend, onBuy, onSwap, onReceive, onSelectNetwork, networks, selectedNetwork, showOperations }) => {
         const t = useDashboardI18N()
 
         const isWalletTransferPath = useIsMatched(DashboardRoutes.WalletsTransfer)
         const isWalletHistoryPath = useIsMatched(DashboardRoutes.WalletsHistory)
+
+        const { fungibleAssets } = useContainer(Context)
+
+        const balance = useMemo(() => {
+            if (!fungibleAssets.value?.length) return 0
+
+            const values = fungibleAssets.value
+                .filter((x) => (selectedNetwork ? x.chainId === selectedNetwork.chainId : true))
+                .map((y) => getTokenUSDValue(y.value))
+            return BigNumber.sum(...values).toNumber()
+        }, [selectedNetwork, fungibleAssets.value])
 
         const isDisabledNonCurrentChainSelect = !!isWalletTransferPath
         const isHiddenAllButton = isWalletHistoryPath || isWalletTransferPath || networks.length <= 1

--- a/packages/dashboard/src/pages/Wallets/hooks/useContext.ts
+++ b/packages/dashboard/src/pages/Wallets/hooks/useContext.ts
@@ -1,0 +1,21 @@
+import { createContainer } from 'unstated-next'
+import type { NetworkPluginID } from '@masknet/web3-shared-base'
+import { Web3Helper, useFungibleAssets, useAccount, useChainId } from '@masknet/plugin-infra/web3'
+
+function useContext(initialState?: { account?: string; chainId?: Web3Helper.ChainIdAll; pluginID?: NetworkPluginID }) {
+    const account = useAccount(initialState?.pluginID, initialState?.account)
+    const chainId = useChainId(initialState?.pluginID, initialState?.chainId)
+    const fungibleAssets = useFungibleAssets<'all'>(initialState?.pluginID, undefined, {
+        account,
+        chainId,
+    })
+
+    return {
+        account,
+        chainId,
+
+        fungibleAssets,
+    }
+}
+
+export const Context = createContainer(useContext)

--- a/packages/dashboard/src/pages/routes.tsx
+++ b/packages/dashboard/src/pages/routes.tsx
@@ -3,6 +3,7 @@ import { Route, Routes, Navigate } from 'react-router-dom'
 import { DashboardFrame } from '../components/DashboardFrame'
 import { DashboardRoutes } from '@masknet/shared-base'
 import NoPersonaGuardRoute from '../GuardRoute'
+
 const Wallets = lazy(() => import(/* webpackPrefetch: true */ './Wallets'))
 const Setup = lazy(() => import('./Setup'))
 const SignUp = lazy(() => import('./SignUp'))

--- a/packages/dashboard/stories/components/Wallet/Balance.tsx
+++ b/packages/dashboard/stories/components/Wallet/Balance.tsx
@@ -7,7 +7,6 @@ export default meta({ title: 'Components/Wallet/Balance Card' })
 
 export const BalanceCard = of({
     args: {
-        balance: 9000000,
         onBuy: action('onBuy'),
         onSend: action('onSend'),
         onSwap: action('onSwap'),

--- a/packages/plugin-infra/src/web3/useFungibleAssets.ts
+++ b/packages/plugin-infra/src/web3/useFungibleAssets.ts
@@ -95,5 +95,5 @@ export function useFungibleAssets<S extends 'all' | void = void, T extends Netwo
 
                 return 0
             })
-    }, [account, chainId, hub, trustedTokens, blockedTokens, Others])
+    }, [account, chainId, schemaType, hub, trustedTokens, blockedTokens, Others])
 }

--- a/packages/plugins/EVM/src/state/Hub/hub.ts
+++ b/packages/plugins/EVM/src/state/Hub/hub.ts
@@ -101,7 +101,7 @@ class Hub implements EVM_Hub {
                 [SourceType.DeBank]: DeBank,
                 [SourceType.Zerion]: Zerion,
             },
-            [DeBank, Zerion],
+            [Zerion, DeBank],
             initial,
         )
     }

--- a/packages/plugins/EVM/src/state/Hub/hub.ts
+++ b/packages/plugins/EVM/src/state/Hub/hub.ts
@@ -101,7 +101,7 @@ class Hub implements EVM_Hub {
                 [SourceType.DeBank]: DeBank,
                 [SourceType.Zerion]: Zerion,
             },
-            [Zerion, DeBank],
+            [DeBank, Zerion],
             initial,
         )
     }

--- a/packages/web3-providers/src/debank/index.ts
+++ b/packages/web3-providers/src/debank/index.ts
@@ -83,32 +83,28 @@ export class DeBankAPI
             }),
         )
         const result = (await response.json()) as WalletTokenRecord[] | undefined
-        try {
-            return createPageable(
-                unionWith(
-                    formatAssets(
-                        (result ?? []).map((x) => ({
-                            ...x,
+        return createPageable(
+            unionWith(
+                formatAssets(
+                    (result ?? []).map((x) => ({
+                        ...x,
 
-                            // rename bsc to bnb
-                            id: x.id === 'bsc' ? 'bnb' : x.id,
-                            chain: x.chain === 'bsc' ? 'bnb' : x.chain,
-                            // prefix ARETH
-                            symbol: x.chain === 'arb' && x.symbol === 'ETH' ? 'ARETH' : x.symbol,
-                            logo_url:
-                                x.chain === 'arb' && x.symbol === 'ETH'
-                                    ? 'https://assets.debank.com/static/media/arbitrum.8e326f58.svg'
-                                    : x.logo_url,
-                        })),
-                    ),
-                    getAllEVMNativeAssets(),
-                    (a, z) => a.symbol === z.symbol && a.chainId === z.chainId,
+                        // rename bsc to bnb
+                        id: x.id === 'bsc' ? 'bnb' : x.id,
+                        chain: x.chain === 'bsc' ? 'bnb' : x.chain,
+                        // prefix ARETH
+                        symbol: x.chain === 'arb' && x.symbol === 'ETH' ? 'ARETH' : x.symbol,
+                        logo_url:
+                            x.chain === 'arb' && x.symbol === 'ETH'
+                                ? 'https://assets.debank.com/static/media/arbitrum.8e326f58.svg'
+                                : x.logo_url,
+                    })),
                 ),
-                createIndicator(options?.indicator),
-            )
-        } catch {
-            return createPageable([], createIndicator(options?.indicator))
-        }
+                getAllEVMNativeAssets(),
+                (a, z) => a.symbol === z.symbol && a.chainId === z.chainId,
+            ),
+            createIndicator(options?.indicator),
+        )
     }
 
     async getTransactions(


### PR DESCRIPTION
## Description

This PR is a workaround for the Debank HTTP 429 problem. The attempt-until mechanism was broken cause the Debank implementation captured all HTTP errors. Moreover, this PR also fixes the duplication of hub invocation problem in the asset table implementation.

+ fix: captured error breaks the attemptions
+ fix: the Zerion API (by sharing state in context)

Closes MF-2070

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Screenshot

![image](https://user-images.githubusercontent.com/52657989/190841714-11c0da36-b8d3-453e-882a-437a82634a62.png)
