### PR TITLE
fix: mf-2011 size of copy icon is unset

### DIFF
--- a/packages/dashboard/src/pages/SignUp/steps/PreviewDialog.tsx
+++ b/packages/dashboard/src/pages/SignUp/steps/PreviewDialog.tsx
@@ -35,13 +35,10 @@ const useStyles = makeStyles()((theme) => ({
     },
     infoIcon: {
         color: MaskColorVar.secondaryInfoText,
-        fontSize: 24,
         marginRight: 12,
     },
     copyIcon: {
-        stroke: '#F6F6F8',
-        fontSize: '14px',
-        cursor: 'pointer',
+        color: '#F6F6F8',
         verticalAlign: 'middle',
     },
 }))
@@ -163,7 +160,11 @@ const ComponentToPrint = forwardRef((props: PreviewDialogProps, ref: ForwardedRe
                         <Box display="flex">
                             <Typography fontSize={14} fontWeight={600} width={102}>
                                 <span style={{ verticalAlign: 'middle' }}>{t.create_account_private_key()} </span>
-                                <Icons.Copy className={classes.copyIcon} onClick={() => copyToClipboard(privateKey)} />
+                                <Icons.Copy
+                                    className={classes.copyIcon}
+                                    size={14}
+                                    onClick={() => copyToClipboard(privateKey)}
+                                />
                             </Typography>
                             <Typography
                                 fontSize={10}


### PR DESCRIPTION
https://mask.atlassian.net/browse/MF-2011

<img width="601" alt="image" src="https://user-images.githubusercontent.com/1141198/190940709-e556e819-87ad-4f22-9317-4e5e84e38de2.png">
