### PR TITLE
fix: empty content header selector

### DIFF
--- a/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
@@ -141,6 +141,7 @@ export const postEditorDraftContentSelector = () => {
 }
 
 export const searchResultHeadingSelector: () => LiveSelector<E, true> = () =>
+    // To match the scenario with no results in timeline.
     querySelector<E>('[role="main"] [data-testid="primaryColumn"] > div > div > :nth-child(2)')
 
 export const postEditorToolbarSelector: () => LiveSelector<E, true> = () =>

--- a/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/utils/selector.ts
@@ -141,7 +141,7 @@ export const postEditorDraftContentSelector = () => {
 }
 
 export const searchResultHeadingSelector: () => LiveSelector<E, true> = () =>
-    querySelector<E>('[role="main"] [data-testid="primaryColumn"] [role="region"]')
+    querySelector<E>('[role="main"] [data-testid="primaryColumn"] > div > div > :nth-child(2)')
 
 export const postEditorToolbarSelector: () => LiveSelector<E, true> = () =>
     querySelector<E>('[data-testid="toolBar"] > div > *:last-child')


### PR DESCRIPTION
## Description
Try https://twitter.com/search?q=%F0%9F%8D%BF%F0%9F%8D%BF%F0%9F%8D%BF%F0%9F%8D%BF.eth&src=typed_query&f=top


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
