### PR TITLE
fix: mf-2179 tweet nodes can't be collectly distinguished

### DIFF
--- a/packages/mask/src/social-network-adaptor/twitter.com/collecting/post.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/collecting/post.ts
@@ -40,9 +40,7 @@ function isQuotedTweet(tweetNode: HTMLElement | null) {
 }
 
 function isDetailTweet(tweetNode: HTMLElement) {
-    const isDetail =
-        /^\/[^/]+\/status\//.test(location.pathname) &&
-        !!tweetNode.querySelector(`a[role="link"][href="${location.pathname}"] time[datetime]`)
+    const isDetail = !!tweetNode.querySelector('a[role="link"] time[datetime]')
     return isDetail
 }
 


### PR DESCRIPTION
don't compare detail page with url, check the time node is enough

https://mask.atlassian.net/browse/MF-2179
https://mask.atlassian.net/browse/MF-2177
