### PR TITLE
fix: alchemy api

### DIFF
--- a/packages/mask/src/plugins/Avatar/hooks/useNFT.ts
+++ b/packages/mask/src/plugins/Avatar/hooks/useNFT.ts
@@ -1,15 +1,9 @@
 import { ChainId } from '@masknet/web3-shared-evm'
 import { useAsyncRetry } from 'react-use'
 import { useWeb3Hub, useWeb3State } from '@masknet/plugin-infra/web3'
-import {
-    formatBalance,
-    CurrencyType,
-    NetworkPluginID,
-    NonFungibleToken,
-    NonFungibleAsset,
-} from '@masknet/web3-shared-base'
-import type { NFTInfo } from '../types.js'
+import { formatBalance, CurrencyType, NetworkPluginID } from '@masknet/web3-shared-base'
 import type { Web3Helper } from '@masknet/web3-helpers'
+import type { NFTInfo } from '../types.js'
 
 export function useNFT(
     account: string,
@@ -37,8 +31,8 @@ export function useNFT(
         ])
 
         const [token, asset] = allSettled.map((x) => (x.status === 'fulfilled' ? x.value : undefined)) as [
-            NonFungibleToken<Web3Helper.ChainIdAll, Web3Helper.SchemaTypeAll> | undefined,
-            NonFungibleAsset<Web3Helper.ChainIdAll, Web3Helper.SchemaTypeAll> | undefined,
+            Web3Helper.NonFungibleTokenScope<'all'> | undefined,
+            Web3Helper.NonFungibleAssetScope<'all'> | undefined,
         ]
 
         const contract = token?.contract || asset?.contract

--- a/packages/mask/src/plugins/Tips/SNSAdaptor/components/WalletItem.tsx
+++ b/packages/mask/src/plugins/Tips/SNSAdaptor/components/WalletItem.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { useReverseAddress, useWallets, useWeb3State } from '@masknet/plugin-infra/web3'
 import { FormattedAddress, useSnackbarCallback } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
-import { NetworkPluginID } from '@masknet/web3-shared-base'
+import { isSameAddress, NetworkPluginID } from '@masknet/web3-shared-base'
 import { ChainId, formatEthereumAddress } from '@masknet/web3-shared-evm'
 import { Link, Typography } from '@mui/material'
 import { useMemo } from 'react'
@@ -106,7 +106,7 @@ export function WalletItem({ address, isDefault, deletable, fallbackName, setAsD
         if (domain && Others?.formatDomainName) {
             return Others.formatDomainName(domain)
         }
-        const currentWallet = wallets.find((x) => Others?.isSameAddress(x.address, address))
+        const currentWallet = wallets.find((x) => isSameAddress(x.address, address))
         const name = currentWallet?.name
         return name !== undefined && currentWallet?.hasStoredKeyInfo ? name : fallbackName
     }, [address, domain, fallbackName])

--- a/packages/mask/src/plugins/Tips/components/RecipientSelect.tsx
+++ b/packages/mask/src/plugins/Tips/components/RecipientSelect.tsx
@@ -1,7 +1,7 @@
 import { Icons } from '@masknet/icons'
 import { useChainId, useWeb3State } from '@masknet/plugin-infra/web3'
 import { makeStyles } from '@masknet/theme'
-import { NetworkPluginID, SocialAddressType } from '@masknet/web3-shared-base'
+import { isSameAddress, NetworkPluginID, SocialAddressType } from '@masknet/web3-shared-base'
 import { Link, MenuItem, Select, Tooltip, TooltipProps, Typography } from '@mui/material'
 import { FC, memo, ReactNode, useRef } from 'react'
 import { useTip } from '../contexts/index.js'
@@ -221,7 +221,7 @@ export const RecipientSelect: FC = memo(() => {
                         <Icons.LinkOut size={20} />
                     </Link>
                     <TipsAccountSource tipsAccount={tipsAccount} />
-                    {Others?.isSameAddress(tipsAccount.address, recipientAddress) ? (
+                    {isSameAddress(tipsAccount.address, recipientAddress) ? (
                         <Icons.CheckCircle className={cx(classes.checkIcon, classes.icon)} />
                     ) : null}
                 </MenuItem>

--- a/packages/mask/src/plugins/Tips/components/TipTaskManager.tsx
+++ b/packages/mask/src/plugins/Tips/components/TipTaskManager.tsx
@@ -1,5 +1,6 @@
 import { PluginIDContextProvider, PluginWeb3ContextProvider, useWeb3State } from '@masknet/plugin-infra/web3'
 import { EMPTY_LIST } from '@masknet/shared-base'
+import { isSameAddress } from '@masknet/web3-shared-base'
 import { FC, useCallback, useEffect, useState } from 'react'
 import { TargetRuntimeContext, TipTaskProvider } from '../contexts/index.js'
 import { PluginTipsMessages } from '../messages.js'
@@ -41,7 +42,7 @@ export const TipTaskManager: FC<React.PropsWithChildren<{}>> = ({ children }) =>
     return (
         <PluginWeb3ContextProvider pluginID={pluginId} value={{ chainId: targetChainId }}>
             {tasks.map((task) => {
-                const tipsAccount = task.addresses.find((x) => Others?.isSameAddress(x.address, task.recipient))
+                const tipsAccount = task.addresses.find((x) => isSameAddress(x.address, task.recipient))
                 const taskSession = (
                     <TipTaskProvider key={task.id} task={task}>
                         <TipDialog open key={task.id} onClose={() => removeTask(task)} />

--- a/packages/plugin-infra/src/web3/useBalance.ts
+++ b/packages/plugin-infra/src/web3/useBalance.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useAsyncRetry } from 'react-use'
 import { noop } from 'lodash-unified'
-import type { NetworkPluginID } from '@masknet/web3-shared-base'
+import { isSameAddress, NetworkPluginID } from '@masknet/web3-shared-base'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { useAccount } from './useAccount.js'
 import { useChainId } from './useChainId.js'
@@ -15,7 +15,7 @@ export function useBalance<S extends 'all' | void = void, T extends NetworkPlugi
     const account = useAccount(pluginID, options?.account)
     const chainId = useChainId(pluginID, options?.chainId)
     const connection = useWeb3Connection(pluginID, options)
-    const { BalanceNotifier, Others } = useWeb3State(pluginID)
+    const { BalanceNotifier } = useWeb3State(pluginID)
 
     const asyncResult = useAsyncRetry(async () => {
         if (!account || !connection) return '0'
@@ -25,10 +25,10 @@ export function useBalance<S extends 'all' | void = void, T extends NetworkPlugi
     useEffect(() => {
         return (
             BalanceNotifier?.emitter.on('update', (ev) => {
-                if (Others?.isSameAddress(account, ev.account)) asyncResult.retry()
+                if (isSameAddress(account, ev.account)) asyncResult.retry()
             }) ?? noop
         )
-    }, [account, asyncResult.retry, BalanceNotifier, Others])
+    }, [account, asyncResult.retry, BalanceNotifier])
 
     return asyncResult
 }

--- a/packages/plugin-infra/src/web3/useFungibleTokenBalance.ts
+++ b/packages/plugin-infra/src/web3/useFungibleTokenBalance.ts
@@ -1,8 +1,8 @@
-import type { Web3Helper } from '@masknet/web3-helpers'
-import type { NetworkPluginID } from '@masknet/web3-shared-base'
-import { noop } from 'lodash-unified'
 import { useEffect } from 'react'
 import useAsyncRetry from 'react-use/lib/useAsyncRetry'
+import { noop } from 'lodash-unified'
+import type { Web3Helper } from '@masknet/web3-helpers'
+import { isSameAddress, NetworkPluginID } from '@masknet/web3-shared-base'
 import { useWeb3State } from '../entry-web3.js'
 import { useAccount } from './useAccount.js'
 import { useWeb3Connection } from './useWeb3Connection.js'
@@ -14,7 +14,7 @@ export function useFungibleTokenBalance<S extends 'all' | void = void, T extends
 ) {
     const account = useAccount(pluginID, options?.account)
     const connection = useWeb3Connection(pluginID, options)
-    const { BalanceNotifier, Others } = useWeb3State(pluginID)
+    const { BalanceNotifier } = useWeb3State(pluginID)
 
     const asyncRetry = useAsyncRetry(async () => {
         if (!connection) return '0'
@@ -24,12 +24,12 @@ export function useFungibleTokenBalance<S extends 'all' | void = void, T extends
     useEffect(() => {
         return (
             BalanceNotifier?.emitter.on('update', (ev) => {
-                if (Others?.isSameAddress(account, ev.account)) {
+                if (isSameAddress(account, ev.account)) {
                     asyncRetry.retry()
                 }
             }) ?? noop
         )
-    }, [account, asyncRetry.retry, BalanceNotifier, Others])
+    }, [account, asyncRetry.retry, BalanceNotifier])
 
     return asyncRetry
 }

--- a/packages/plugin-infra/src/web3/useWallet.ts
+++ b/packages/plugin-infra/src/web3/useWallet.ts
@@ -1,15 +1,15 @@
 import { useMemo } from 'react'
 import { useSubscription } from 'use-subscription'
-import type { NetworkPluginID } from '@masknet/web3-shared-base'
+import { isSameAddress, NetworkPluginID } from '@masknet/web3-shared-base'
 import { EMPTY_ARRAY } from '../utils/subscription.js'
 import { useAccount } from './useAccount.js'
 import { useWeb3State } from './useWeb3State.js'
 
 export function useWallet<T extends NetworkPluginID>(pluginID?: T) {
     const account = useAccount(pluginID)
-    const { Others, Wallet } = useWeb3State(pluginID)
+    const { Wallet } = useWeb3State(pluginID)
     const wallets = useSubscription(Wallet?.wallets ?? EMPTY_ARRAY)
     return useMemo(() => {
-        return account ? wallets.find((x) => Others?.isSameAddress?.(x.address, account)) ?? null : null
+        return account ? wallets.find((x) => isSameAddress?.(x.address, account)) ?? null : null
     }, [account, wallets?.map((x) => x.address.toLowerCase()).join()])
 }

--- a/packages/plugins/EVM/src/state/Others.ts
+++ b/packages/plugins/EVM/src/state/Others.ts
@@ -1,6 +1,5 @@
 import type { Plugin } from '@masknet/plugin-infra'
 import { OthersState } from '@masknet/plugin-infra/web3'
-import { isSameAddress } from '@masknet/web3-shared-base'
 import {
     isValidDomain,
     isValidAddress,
@@ -41,7 +40,6 @@ export class Others extends OthersState<ChainId, SchemaType, ProviderType, Netwo
 
     override isValidDomain = isValidDomain
     override isValidAddress = isValidAddress
-    override isSameAddress = isSameAddress
     override isZeroAddress = isZeroAddress
     override isNativeTokenAddress = isNativeTokenAddress
     override isNativeTokenSchemaType = isNativeTokenSchemaType

--- a/packages/plugins/Flow/src/state/Others.ts
+++ b/packages/plugins/Flow/src/state/Others.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '@masknet/plugin-infra'
 import { OthersState } from '@masknet/plugin-infra/web3'
-import { createExplorerResolver, isSameAddress } from '@masknet/web3-shared-base'
+import { createExplorerResolver } from '@masknet/web3-shared-base'
 import {
     isValidDomain,
     isValidAddress,
@@ -51,7 +51,6 @@ export class Others extends OthersState<ChainId, SchemaType, ProviderType, Netwo
 
     override isValidDomain = isValidDomain
     override isValidAddress = isValidAddress
-    override isSameAddress = isSameAddress
     override isZeroAddress = isZeroAddress
     override isNativeTokenAddress = isNativeTokenAddress
     override isNativeTokenSchemaType = isNativeTokenSchemaType

--- a/packages/plugins/Solana/src/state/Others.ts
+++ b/packages/plugins/Solana/src/state/Others.ts
@@ -1,6 +1,5 @@
 import type { Plugin } from '@masknet/plugin-infra'
 import { OthersState } from '@masknet/plugin-infra/web3'
-import { isSameAddress } from '@masknet/web3-shared-base'
 import { formatDomainName } from '@masknet/web3-shared-evm'
 import {
     isValidDomain,
@@ -43,7 +42,6 @@ export class Others extends OthersState<ChainId, SchemaType, ProviderType, Netwo
 
     override isValidDomain = isValidDomain
     override isValidAddress = isValidAddress
-    override isSameAddress = isSameAddress
     override isZeroAddress = isZeroAddress
     override isNativeTokenAddress = isNativeTokenAddress
 

--- a/packages/web3-constants/flow/token.json
+++ b/packages/web3-constants/flow/token.json
@@ -1,18 +1,18 @@
 {
     "FLOW_ADDRESS": {
-        "Mainnet": "0x1654653399040a61",
+        "Mainnet": "A.1654653399040a61.FlowToken",
         "Testnet": ""
     },
     "FUSD_ADDRESS": {
-        "Mainnet": "0x3c5959b568896393",
-        "Testnet": "0xe223d8a629e49c68"
+        "Mainnet": "A.3c5959b568896393.FUSD",
+        "Testnet": "A.e223d8a629e49c68.FUSD"
     },
     "TETHER_ADDRESS": {
-        "Mainnet": "0xcfdd90d4a00f7b5b",
+        "Mainnet": "A.cfdd90d4a00f7b5b.TeleportedTetherToken",
         "Testnet": ""
     },
     "FUNGIBLE_TOKEN_ADDRESS": {
-        "Mainnet": "0xf233dcee88fe0abe",
+        "Mainnet": "A.f233dcee88fe0abe.FungibleToken",
         "Testnet": "0x9a0766d93b6608b7"
     }
 }

--- a/packages/web3-providers/src/alchemy/apis/Flow.ts
+++ b/packages/web3-providers/src/alchemy/apis/Flow.ts
@@ -49,12 +49,6 @@ function createNonFungibleToken(chainId: ChainId, asset: AlchemyNFT_FLOW): NonFu
             name: asset?.contract?.name ?? '',
             symbol: '',
         },
-        collection: {
-            chainId,
-            name: '',
-            slug: '',
-            description: asset.description,
-        },
     }
 }
 

--- a/packages/web3-providers/src/alchemy/apis/Flow.ts
+++ b/packages/web3-providers/src/alchemy/apis/Flow.ts
@@ -7,7 +7,7 @@ import {
     NonFungibleAsset,
     TokenType,
 } from '@masknet/web3-shared-base'
-import { ChainId, SchemaType } from '@masknet/web3-shared-flow'
+import { ChainId, getContractAddress, SchemaType } from '@masknet/web3-shared-flow'
 import type { NonFungibleTokenAPI } from '../../types/index.js'
 import { fetchJSON } from '../../helpers.js'
 import { Alchemy_FLOW_NetworkMap, FILTER_WORDS } from '../constants.js'
@@ -108,15 +108,14 @@ function createNonFungibleAsset(
 
 export class AlchemyFlowAPI implements NonFungibleTokenAPI.Provider<ChainId, SchemaType> {
     async getAsset(address: string, tokenId: string, { account, chainId = ChainId.Mainnet }: HubOptions<ChainId> = {}) {
-        const [_, contractAddress, ...contractIdentifiers] = address.split(/\./g)
-        if (!account || !contractAddress || !contractIdentifiers.length) return
+        const { address: contractAddress, identifier: contractName } = getContractAddress(address) ?? {}
+        if (!account || !contractAddress || !contractName) return
         const chainInfo = Alchemy_FLOW_NetworkMap?.chains?.find((chain) => chain.chainId === chainId)
-
         const metadata = await fetchJSON<AlchemyResponse_FLOW_Metadata>(
             urlcat(`${chainInfo?.baseURL}/getNFTMetadata/`, {
                 owner: account,
-                contractAddress: `0x${contractAddress}`,
-                contractName: contractIdentifiers.join('.'),
+                contractAddress,
+                contractName,
                 tokenId,
             }),
         )

--- a/packages/web3-providers/src/alchemy/helpers.ts
+++ b/packages/web3-providers/src/alchemy/helpers.ts
@@ -3,3 +3,7 @@ import { hexToNumberString, isHex } from 'web3-utils'
 export function formatAlchemyTokenId(tokenId: string) {
     return isHex(tokenId) && tokenId.startsWith('0x') ? hexToNumberString(tokenId) : tokenId
 }
+
+export function formatAlchemyTokenAddress(address: string, identifier: string) {
+    return `A.${address.replace(/^0x/, '')}.${identifier}`
+}

--- a/packages/web3-shared/base/src/specs/index.ts
+++ b/packages/web3-shared/base/src/specs/index.ts
@@ -1354,7 +1354,6 @@ export interface OthersState<ChainId, SchemaType, ProviderType, NetworkType, Tra
     isValidAddress(address?: string): boolean
     isZeroAddress(address?: string): boolean
     isNativeTokenAddress(address?: string): boolean
-    isSameAddress(address?: string, otherAddress?: string): boolean
     isNativeTokenSchemaType(schemaType?: SchemaType): boolean
     isFungibleTokenSchemaType(schemaType?: SchemaType): boolean
     isNonFungibleTokenSchemaType(schemaType?: SchemaType): boolean

--- a/packages/web3-shared/flow/src/utils/address.ts
+++ b/packages/web3-shared/flow/src/utils/address.ts
@@ -8,7 +8,7 @@ export function formatAddress(address: string, size = 0) {
         if (size === 0 || size >= 8) return partial
         return `${partial.slice(0, Math.max(0, 2 + size))}...${partial.slice(-size)}`
     }
-    if (isValidAcountAddress(address)) return format(address)
+    if (isValidAccountAddress(address)) return format(address)
     if (isValidContractAddress(address)) return format(`0x${address.split(/\./g)[1]}`)
     return address
 }
@@ -17,7 +17,7 @@ export function formatTokenId(id: string) {
     return `#${id}`
 }
 
-export function isValidAcountAddress(address: string) {
+export function isValidAccountAddress(address: string) {
     return /0x\w{16}/.test(address)
 }
 
@@ -26,7 +26,7 @@ export function isValidContractAddress(address: string) {
 }
 
 export function isValidAddress(address: string) {
-    return isValidAcountAddress(address) || isValidContractAddress(address)
+    return isValidAccountAddress(address) || isValidContractAddress(address)
 }
 
 export function isValidChainId(chainId: ChainId) {

--- a/packages/web3-shared/flow/src/utils/address.ts
+++ b/packages/web3-shared/flow/src/utils/address.ts
@@ -49,6 +49,17 @@ export function getZeroAddress() {
     return ZERO_ADDRESS
 }
 
+export function getContractAddress(address: string) {
+    if (isValidContractAddress(address)) {
+        const [_, contractAddress, ...identifierFramgents] = address.split(/\./g)
+        return {
+            address: `0x${contractAddress}`,
+            identifier: identifierFramgents.join('.'),
+        }
+    }
+    return
+}
+
 export function getNativeTokenAddress(chainId = ChainId.Mainnet) {
     return getTokenConstant(chainId, 'FLOW_ADDRESS')
 }

--- a/packages/web3-shared/flow/src/utils/address.ts
+++ b/packages/web3-shared/flow/src/utils/address.ts
@@ -51,10 +51,10 @@ export function getZeroAddress() {
 
 export function getContractAddress(address: string) {
     if (isValidContractAddress(address)) {
-        const [_, contractAddress, ...identifierFramgents] = address.split(/\./g)
+        const [_, contractAddress, ...identifierFragments] = address.split(/\./g)
         return {
             address: `0x${contractAddress}`,
-            identifier: identifierFramgents.join('.'),
+            identifier: identifierFragments.join('.'),
         }
     }
     return

--- a/packages/web3-shared/flow/src/utils/address.ts
+++ b/packages/web3-shared/flow/src/utils/address.ts
@@ -4,17 +4,29 @@ import { getTokenConstant, ZERO_ADDRESS } from '../constants/index.js'
 import { ChainId, NetworkType, ProviderType } from '../types.js'
 
 export function formatAddress(address: string, size = 0) {
-    if (!isValidAddress(address)) return address
-    if (size === 0 || size >= 8) return address
-    return `${address.slice(0, Math.max(0, 2 + size))}...${address.slice(-size)}`
+    const format = (partial: string) => {
+        if (size === 0 || size >= 8) return partial
+        return `${partial.slice(0, Math.max(0, 2 + size))}...${partial.slice(-size)}`
+    }
+    if (isValidAcountAddress(address)) return format(address)
+    if (isValidContractAddress(address)) return format(`0x${address.split(/\./g)[1]}`)
+    return address
 }
 
 export function formatTokenId(id: string) {
     return `#${id}`
 }
 
-export function isValidAddress(address: string) {
+export function isValidAcountAddress(address: string) {
     return /0x\w{16}/.test(address)
+}
+
+export function isValidContractAddress(address: string) {
+    return /A\.\w{16}\.\w+/.test(address)
+}
+
+export function isValidAddress(address: string) {
+    return isValidAcountAddress(address) || isValidContractAddress(address)
 }
 
 export function isValidChainId(chainId: ChainId) {

--- a/packages/web3-shared/flow/test/utils/address.ts
+++ b/packages/web3-shared/flow/test/utils/address.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest'
+import { formatAddress, isValidAccountAddress, isValidContractAddress } from '../../src/utils/address.js'
+
+describe('formatAddress', () => {
+    test.each([
+        { give: '0x329feb3ab062d289', expected: '0x329f...d289' },
+        { give: 'A.329feb3ab062d289.NFT', expected: '0x329f...d289' },
+        { give: 'NFT', expected: 'NFT' },
+    ])('.formatAddress($give)', ({ give, expected }) => {
+        expect(formatAddress(give)).toBe(expected)
+    })
+})
+
+describe('isValidAccountAddress', () => {
+    test.each([
+        { give: '0x329feb3ab062d289', expected: true },
+        { give: 'A.329feb3ab062d289.NFT', expected: false },
+        { give: 'NFT', expected: false },
+    ])('.isValidAccountAddress($give)', ({ give, expected }) => {
+        expect(isValidAccountAddress(give)).toBe(expected)
+    })
+})
+
+describe('isValidContractAddress', () => {
+    test.each([
+        { give: '0x329feb3ab062d289', expected: false },
+        { give: 'A.329feb3ab062d289.NFT', expected: true },
+        { give: 'NFT', expected: false },
+    ])('.isValidContractAddress($give)', ({ give, expected }) => {
+        expect(isValidContractAddress(give)).toBe(expected)
+    })
+})


### PR DESCRIPTION
## Description

For Flow, we found that the contract name of a non-fungible token is required to query its metadata. It's quite varied from other blockchains. We add the fundamental ability to handle account addresses and contract addresses differently. This will need all input of contract addresses must follow the pattern: `A.[address w/o 0x prefix].[resource identifier]`.

Here is an example:

| Account Address | Contract Address |
| ----------------- | ------------------ |
| https://flowscan.org/account/0x329feb3ab062d289 | https://flowscan.org/contract/A.329feb3ab062d289.Canes_Vault_NFT |

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
