### PR TITLE
refactor: gas price in wei

### DIFF
--- a/packages/mask/src/plugins/Collectible/tests/helpers.ts
+++ b/packages/mask/src/plugins/Collectible/tests/helpers.ts
@@ -67,7 +67,7 @@ describe('getPayloadFromURL', () => {
                 pluginID: NetworkPluginID.PLUGIN_SOLANA,
                 chainId: ChainIdSolana.Mainnet,
                 address: 'zyru7e6AadBrhFZFQe9r7vM3HxHAVee4Xb8d46qb5Tb',
-                tokenId: 'zyru7e6AadBrhFZFQe9r7vM3HxHAVee4Xb8d46qb5Tb',
+                tokenId: '',
                 provider: SourceType.Rarible,
             },
         },

--- a/packages/plugins/Debugger/src/SNSAdaptor/components/HubContent.tsx
+++ b/packages/plugins/Debugger/src/SNSAdaptor/components/HubContent.tsx
@@ -138,7 +138,7 @@ export function HubContent(props: HubContentProps) {
                                 size="small"
                                 onClick={(e) => setAnchorEl(e.currentTarget)}
                                 endIcon={<Icons.ArrowDownRound size={14} />}>
-                                {sourceType ? resolveSourceTypeName(sourceType) : 'NOT PROVIDER'}
+                                {sourceType ? resolveSourceTypeName(sourceType) : 'NO PROVIDER'}
                             </Button>
                             <ShadowRootMenu
                                 anchorEl={anchorEl}

--- a/packages/shared/src/UI/components/SelectGasSettingsToolbar/index.tsx
+++ b/packages/shared/src/UI/components/SelectGasSettingsToolbar/index.tsx
@@ -11,13 +11,7 @@ import {
     FungibleToken,
     formatCurrency,
 } from '@masknet/web3-shared-base'
-import {
-    formatEtherToGwei,
-    formatGweiToWei,
-    formatWeiToEther,
-    formatWeiToGwei,
-    GasOptionConfig,
-} from '@masknet/web3-shared-evm'
+import { formatEtherToGwei, formatWeiToEther, formatWeiToGwei, GasOptionConfig } from '@masknet/web3-shared-evm'
 import { Typography, MenuItem, Box } from '@mui/material'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { useChainId, useCurrentWeb3NetworkPluginID, useWeb3State } from '@masknet/plugin-infra/web3'

--- a/packages/shared/src/UI/components/SettingsBoard/GasForm.tsx
+++ b/packages/shared/src/UI/components/SettingsBoard/GasForm.tsx
@@ -14,7 +14,7 @@ import { useGasSchema } from './hooks/index.js'
 
 function getDefaultValues(transaction: Transaction, gasOptions: Record<GasOptionType, GasOption>) {
     return {
-        gasLimit: (transaction.gas as string)?.toString() ?? '21000',
+        gasLimit: (transaction.gas as string | number | undefined)?.toString() ?? '21000',
         gasPrice: formatWeiToGwei(
             (transaction.gasPrice as string) || gasOptions.normal.suggestedMaxFeePerGas,
         ).toString(),

--- a/packages/shared/src/UI/components/SettingsBoard/GasForm.tsx
+++ b/packages/shared/src/UI/components/SettingsBoard/GasForm.tsx
@@ -1,16 +1,31 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useUpdateEffect } from 'react-use'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
+import type { z as zod } from 'zod'
 import { makeStyles, MaskAlert, MaskTextField } from '@masknet/theme'
 import { Grid, Typography } from '@mui/material'
 import { Icons } from '@masknet/icons'
 import { useSharedI18N } from '@masknet/shared'
-import { ChainId, formatGweiToWei, formatWeiToGwei, GasOption, Transaction } from '@masknet/web3-shared-evm'
+import { ChainId, formatWeiToGwei, GasOption, Transaction } from '@masknet/web3-shared-evm'
 import { formatBalance, GasOptionType, isPositive, isZero, NetworkPluginID, scale10 } from '@masknet/web3-shared-base'
 import { useWeb3State } from '@masknet/plugin-infra/web3'
-import type { z as zod } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useGasSchema } from './hooks/index.js'
+
+function getDefaultValues(transaction: Transaction, gasOptions: Record<GasOptionType, GasOption>) {
+    return {
+        gasLimit: (transaction.gas as string)?.toString() ?? '21000',
+        gasPrice: formatWeiToGwei(
+            (transaction.gasPrice as string) || gasOptions.normal.suggestedMaxFeePerGas,
+        ).toString(),
+        maxPriorityFeePerGas: formatWeiToGwei(
+            (transaction.maxPriorityFeePerGas as string) || gasOptions.normal.suggestedMaxPriorityFeePerGas,
+        ).toString(),
+        maxFeePerGas: formatWeiToGwei(
+            (transaction.maxFeePerGas as string) || gasOptions.normal.suggestedMaxFeePerGas,
+        ).toString(),
+    }
+}
 
 const useStyles = makeStyles()((theme) => {
     return {
@@ -61,7 +76,7 @@ export interface GasFormProps {
     gasOptions: Record<GasOptionType, GasOption>
     onChange?: (transactionOptions?: Partial<Transaction>) => void
     maxPriorityFeePerGasByUser?: string
-    setMaxPriorityFeePerGasByUser: (s: string | undefined) => void
+    setMaxPriorityFeePerGasByUser: (s: string) => void
 }
 
 export function GasForm(props: GasFormProps) {
@@ -91,18 +106,7 @@ export function GasForm(props: GasFormProps) {
         shouldUnregister: false,
         mode: 'onChange',
         resolver: zodResolver(schema),
-        defaultValues: {
-            gasLimit: (transactionComputed.gas as string | number | undefined)?.toString() ?? '21000',
-            gasPrice: transactionComputed.gasPrice
-                ? formatWeiToGwei(transactionComputed.gasPrice as string).toString()
-                : gasOptions.normal.suggestedMaxFeePerGas,
-            maxPriorityFeePerGas: transactionComputed.maxPriorityFeePerGas
-                ? formatWeiToGwei(transactionComputed.maxPriorityFeePerGas as string).toString()
-                : gasOptions.normal.suggestedMaxPriorityFeePerGas,
-            maxFeePerGas: transactionComputed.maxFeePerGas
-                ? formatWeiToGwei(transactionComputed.maxFeePerGas as string).toString()
-                : gasOptions.normal.suggestedMaxFeePerGas,
-        },
+        defaultValues: getDefaultValues(transactionComputed, gasOptions),
     })
 
     const { errors } = methods.formState
@@ -139,13 +143,16 @@ export function GasForm(props: GasFormProps) {
         if (!gasOptions) return
 
         if (!gasPriceByUser) {
-            methods.setValue('gasPrice', gasOptions.normal.suggestedMaxFeePerGas)
+            methods.setValue('gasPrice', formatWeiToGwei(gasOptions.normal.suggestedMaxFeePerGas).toString())
         }
         if (!maxFeePerGasByUser) {
-            methods.setValue('maxFeePerGas', gasOptions.normal.suggestedMaxFeePerGas)
+            methods.setValue('maxFeePerGas', formatWeiToGwei(gasOptions.normal.suggestedMaxFeePerGas).toString())
         }
         if (!maxPriorityFeePerGasByUser) {
-            methods.setValue('maxPriorityFeePerGas', gasOptions.normal.suggestedMaxPriorityFeePerGas)
+            methods.setValue(
+                'maxPriorityFeePerGas',
+                formatWeiToGwei(gasOptions.normal.suggestedMaxPriorityFeePerGas).toString(),
+            )
         }
     }, [gasOptions, gasPriceByUser, maxFeePerGasByUser, maxPriorityFeePerGasByUser, methods.setValue])
     // #endregion
@@ -154,11 +161,11 @@ export function GasForm(props: GasFormProps) {
         const payload = isEIP1559
             ? {
                   gas: gasLimit,
-                  maxFeePerGas: formatGweiToWei(maxFeePerGas).toFixed(),
-                  maxPriorityFeePerGas: formatGweiToWei(maxPriorityFeePerGas).toFixed(),
+                  maxFeePerGas,
+                  maxPriorityFeePerGas,
               }
             : {
-                  gasPrice: formatGweiToWei(gasPrice).toFixed(),
+                  gasPrice,
               }
         onChange?.(!errorCenter && !errorBottom ? payload : undefined)
     }, [errorCenter, errorBottom, isEIP1559, gasLimit, gasPrice, maxFeePerGas, maxPriorityFeePerGas, gasOptions])

--- a/packages/shared/src/UI/components/SettingsBoard/GasOption.tsx
+++ b/packages/shared/src/UI/components/SettingsBoard/GasOption.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
+import formatDistanceStrict from 'date-fns/formatDistanceStrict'
+import addSeconds from 'date-fns/addSeconds'
 import { makeStyles } from '@masknet/theme'
 import { GasOptionType, getLocale } from '@masknet/web3-shared-base'
 import { useSharedI18N } from '@masknet/shared'
 import { Typography, useTheme } from '@mui/material'
 import { CheckCircle, RadioButtonUnchecked } from '@mui/icons-material'
 import type { Web3Helper } from '@masknet/web3-helpers'
-import formatDistanceStrict from 'date-fns/formatDistanceStrict'
-import addSeconds from 'date-fns/addSeconds'
+import { formatWeiToGwei } from '@masknet/web3-shared-evm'
 import type { SupportedLanguages } from '@masknet/public-api'
 import { SettingsContext } from './Context.js'
 
@@ -77,7 +78,7 @@ export function GasOption(props: GasOptionProps) {
             </Typography>
             <Typography className={classes.amount}>
                 {t.gas_settings_gas_option_amount_in_gwei({
-                    amount: new BigNumber(option.suggestedMaxFeePerGas).toFixed(2),
+                    amount: new BigNumber(formatWeiToGwei(option.suggestedMaxFeePerGas)).toFixed(2),
                 })}
             </Typography>
         </div>

--- a/packages/shared/src/UI/components/SettingsBoard/GasOptionSelector.tsx
+++ b/packages/shared/src/UI/components/SettingsBoard/GasOptionSelector.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect } from 'react'
 import { makeStyles } from '@masknet/theme'
 import { Box, Divider, Skeleton } from '@mui/material'
 import { GasOptionType, NetworkPluginID } from '@masknet/web3-shared-base'
-import { ChainId, formatGweiToWei, GasOption, Transaction } from '@masknet/web3-shared-evm'
+import type { ChainId, GasOption, Transaction } from '@masknet/web3-shared-evm'
 import { useWeb3State } from '@masknet/plugin-infra/web3'
 import { GasOption as GasOptionItem } from './GasOption.js'
 import { SettingsContext } from './Context.js'
@@ -52,11 +52,11 @@ export function GasOptionSelector(props: GasOptionSelectorProps) {
             onChange?.(
                 isEIP1559
                     ? {
-                          maxFeePerGas: formatGweiToWei(option.suggestedMaxFeePerGas).toFixed(),
-                          maxPriorityFeePerGas: formatGweiToWei(option.suggestedMaxPriorityFeePerGas).toFixed(),
+                          maxFeePerGas: option.suggestedMaxFeePerGas,
+                          maxPriorityFeePerGas: option.suggestedMaxPriorityFeePerGas,
                       }
                     : {
-                          gasPrice: formatGweiToWei(option.suggestedMaxFeePerGas).toFixed(),
+                          gasPrice: option.suggestedMaxFeePerGas,
                       },
             )
         },

--- a/packages/shared/src/UI/components/SettingsBoard/GasSection.tsx
+++ b/packages/shared/src/UI/components/SettingsBoard/GasSection.tsx
@@ -3,15 +3,14 @@ import { makeStyles, MaskTabList } from '@masknet/theme'
 import { useSharedI18N } from '@masknet/shared'
 import { TabContext } from '@mui/lab'
 import { Tab, Typography } from '@mui/material'
-import { formatBalance, GasOptionType, NetworkPluginID, scale10, isZero } from '@masknet/web3-shared-base'
-import { ChainId, formatWeiToGwei, formatGweiToWei, Transaction } from '@masknet/web3-shared-evm'
+import { formatBalance, GasOptionType, NetworkPluginID, scale10, isZero, plus } from '@masknet/web3-shared-base'
+import { ChainId, formatGweiToWei, formatWeiToGwei, Transaction } from '@masknet/web3-shared-evm'
 import { useWeb3State } from '@masknet/plugin-infra/web3'
 import { GasOptionSelector } from './GasOptionSelector.js'
 import { SettingsContext } from './Context.js'
 import { Section } from './Section.js'
 import { GasForm } from './GasForm.js'
 import { GasSettingsType } from './types/index.js'
-import BigNumber from 'bignumber.js'
 
 const useStyles = makeStyles()((theme) => {
     return {
@@ -60,7 +59,7 @@ export function GasSection(props: GasSectionProps) {
         GAS_OPTION_NAMES,
     } = SettingsContext.useContainer()
     const { Others } = useWeb3State(NetworkPluginID.PLUGIN_EVM)
-    const [maxPriorityFeePerGasByUser, setMaxPriorityFeePerGasByUser] = useState<string>()
+    const [maxPriorityFeePerGasByUser, setMaxPriorityFeePerGasByUser] = useState('0')
 
     // EVM only
     if (pluginID !== NetworkPluginID.PLUGIN_EVM) return null
@@ -69,21 +68,21 @@ export function GasSection(props: GasSectionProps) {
     const suggestedMaxFeePerGas = gasOptions?.[gasOptionType ?? GasOptionType.NORMAL].suggestedMaxFeePerGas as
         | string
         | undefined
+    const suggestedMaxPriorityFeePerGas = gasOptions?.[gasOptionType ?? GasOptionType.NORMAL]
+        .suggestedMaxPriorityFeePerGas as string | undefined
     const baseFeePerGas = gasOptions?.[GasOptionType.FAST].baseFeePerGas ?? '0'
-    const priorityFee = !isZero(maxPriorityFeePerGasByUser || 0)
-        ? maxPriorityFeePerGasByUser
-        : formatWeiToGwei((transaction as Transaction)?.maxPriorityFeePerGas as string)
+    const priorityFee = !isZero(maxPriorityFeePerGasByUser)
+        ? formatGweiToWei(maxPriorityFeePerGasByUser)
+        : ((transaction as Transaction)?.maxPriorityFeePerGas as string)
 
     const gasPrice = (transactionOptions as Transaction | undefined)?.gasPrice as string | undefined
     const customPrice = formatBalance(
         scale10(
             activeTab === GasSettingsType.Basic
-                ? suggestedMaxFeePerGas ?? 0
+                ? formatWeiToGwei(suggestedMaxFeePerGas ?? 0)
                 : formatWeiToGwei(
                       isEIP1559
-                          ? formatGweiToWei(new BigNumber(baseFeePerGas).plus(priorityFee ?? 0)) ??
-                                suggestedMaxFeePerGas ??
-                                0
+                          ? plus(baseFeePerGas, priorityFee ?? suggestedMaxPriorityFeePerGas ?? 0)
                           : gasPrice ?? suggestedMaxFeePerGas ?? 0,
                   ),
             2,

--- a/packages/shared/src/UI/components/SettingsBoard/SlippageToleranceSection.tsx
+++ b/packages/shared/src/UI/components/SettingsBoard/SlippageToleranceSection.tsx
@@ -39,15 +39,15 @@ export function SlippageToleranceSection(props: SlippageToleranceSectionProps) {
     const { classes } = useStyles()
     const { DEFAULT_SLIPPAGE_TOLERANCES, slippageTolerance, setSlippageTolerance } = SettingsContext.useContainer()
 
-    const percentage = formatBalance(multipliedBy(slippageTolerance, 100), 2, 2)
-
     return (
         <div className={classes.root}>
             <Section
                 title={t.gas_settings_section_title_slippage_tolerance()}
                 additions={
                     <Typography className={classes.additions} component="span">
-                        <span className={classes.percentage}>{percentage}%</span>
+                        <span className={classes.percentage}>
+                            {formatBalance(multipliedBy(slippageTolerance, 100), 2, 2)}%
+                        </span>
                     </Typography>
                 }>
                 <SlippageToleranceForm

--- a/packages/shared/src/UI/components/SettingsBoard/hooks/useGasSchema.ts
+++ b/packages/shared/src/UI/components/SettingsBoard/hooks/useGasSchema.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
+import { z as zod } from 'zod'
 import { useSharedI18N } from '@masknet/shared'
-import type { ChainId, GasOption, Transaction } from '@masknet/web3-shared-evm'
+import { ChainId, formatGweiToWei, GasOption, Transaction } from '@masknet/web3-shared-evm'
 import {
     GasOptionType,
     isGreaterThanOrEqualTo,
@@ -11,7 +12,6 @@ import {
     NetworkPluginID,
 } from '@masknet/web3-shared-base'
 import { useWeb3State } from '@masknet/plugin-infra/web3'
-import { z as zod } from 'zod'
 
 const HIGH_FEE_WARNING_MULTIPLIER = 1.5
 
@@ -22,7 +22,6 @@ export function useGasSchema(
 ) {
     const t = useSharedI18N()
     const { Others } = useWeb3State(NetworkPluginID.PLUGIN_EVM)
-    const isEIP1559 = Others?.chainResolver.isSupport(chainId, 'EIP1559')
     return useMemo(() => {
         return zod
             .object({
@@ -39,13 +38,17 @@ export function useGasSchema(
                     .min(1, t.gas_settings_error_gas_price_absence())
                     .refine(isPositive, t.gas_settings_error_gas_price_positive())
                     .refine(
-                        (value) => isGreaterThanOrEqualTo(value, gasOptions?.slow?.suggestedMaxFeePerGas ?? 0),
+                        (value) =>
+                            isGreaterThanOrEqualTo(
+                                formatGweiToWei(value),
+                                gasOptions?.slow?.suggestedMaxFeePerGas ?? 0,
+                            ),
                         t.gas_settings_error_gas_price_too_low(),
                     )
                     .refine(
                         (value) =>
                             isLessThan(
-                                value,
+                                formatGweiToWei(value),
                                 multipliedBy(gasOptions?.fast?.suggestedMaxFeePerGas ?? 0, HIGH_FEE_WARNING_MULTIPLIER),
                             ),
                         t.gas_settings_error_gas_price_too_high(),
@@ -55,13 +58,17 @@ export function useGasSchema(
                     .min(1, t.gas_settings_error_max_priority_fee_absence())
                     .refine(isPositive, t.gas_settings_error_max_priority_gas_fee_positive())
                     .refine(
-                        (value) => isGreaterThanOrEqualTo(value, gasOptions?.slow?.suggestedMaxPriorityFeePerGas ?? 0),
+                        (value) =>
+                            isGreaterThanOrEqualTo(
+                                formatGweiToWei(value),
+                                gasOptions?.slow?.suggestedMaxPriorityFeePerGas ?? 0,
+                            ),
                         t.gas_settings_error_max_priority_gas_fee_too_low(),
                     )
                     .refine(
                         (value) =>
                             isLessThan(
-                                value,
+                                formatGweiToWei(value),
                                 multipliedBy(
                                     gasOptions?.fast?.suggestedMaxPriorityFeePerGas ?? 0,
                                     HIGH_FEE_WARNING_MULTIPLIER,
@@ -73,13 +80,17 @@ export function useGasSchema(
                     .string()
                     .min(1, t.gas_settings_error_max_fee_absence())
                     .refine(
-                        (value) => isGreaterThanOrEqualTo(value, gasOptions?.slow?.suggestedMaxFeePerGas ?? 0),
+                        (value) =>
+                            isGreaterThanOrEqualTo(
+                                formatGweiToWei(value),
+                                gasOptions?.slow?.suggestedMaxFeePerGas ?? 0,
+                            ),
                         t.gas_settings_error_max_fee_too_low(),
                     )
                     .refine(
                         (value) =>
                             isLessThan(
-                                value,
+                                formatGweiToWei(value),
                                 multipliedBy(gasOptions?.fast?.suggestedMaxFeePerGas ?? 0, HIGH_FEE_WARNING_MULTIPLIER),
                             ),
                         t.gas_settings_error_max_fee_too_high(),
@@ -89,5 +100,5 @@ export function useGasSchema(
                 message: t.gas_settings_error_max_priority_gas_fee_imbalance(),
                 path: ['maxFeePerGas'],
             })
-    }, [t, isEIP1559, transaction?.gas, gasOptions, Others])
+    }, [t, transaction?.gas, gasOptions, Others])
 }

--- a/packages/shared/src/locales/en-US.json
+++ b/packages/shared/src/locales/en-US.json
@@ -81,6 +81,7 @@
     "gas_settings_custom": "Custom",
     "gas_settings_tab_basic": "Basic",
     "gas_settings_tab_advanced": "Advanced",
+    "gas_settings_label_gas_fee": "Gas Fee",
     "gas_settings_label_gas_price": "Gas Price",
     "gas_settings_label_gas_limit": "Gas Limit",
     "gas_settings_label_max_priority_fee": "Max Priority Fee",

--- a/packages/web3-providers/src/astar/index.ts
+++ b/packages/web3-providers/src/astar/index.ts
@@ -17,19 +17,19 @@ export class AstarAPI implements GasOptionAPI.Provider<ChainId, GasOption> {
             [GasOptionType.FAST]: {
                 estimatedBaseFee: toFixed(result.eip1559.baseFeePerGas),
                 estimatedSeconds: 15,
-                suggestedMaxFeePerGas: toFixed(result.fast ?? 0).toString(),
+                suggestedMaxFeePerGas: toFixed(result.fast ?? 0),
                 suggestedMaxPriorityFeePerGas: toFixed(priorityFeePerGas.fast),
             },
             [GasOptionType.NORMAL]: {
                 estimatedBaseFee: toFixed(result.eip1559.baseFeePerGas),
                 estimatedSeconds: 30,
-                suggestedMaxFeePerGas: toFixed(result.average ?? 0).toString(),
+                suggestedMaxFeePerGas: toFixed(result.average ?? 0),
                 suggestedMaxPriorityFeePerGas: toFixed(priorityFeePerGas.average),
             },
             [GasOptionType.SLOW]: {
                 estimatedBaseFee: toFixed(result.eip1559.baseFeePerGas),
                 estimatedSeconds: 60,
-                suggestedMaxFeePerGas: toFixed(result.slow ?? 0).toString(),
+                suggestedMaxFeePerGas: toFixed(result.slow ?? 0),
                 suggestedMaxPriorityFeePerGas: toFixed(priorityFeePerGas.slow),
             },
         }

--- a/packages/web3-providers/src/astar/index.ts
+++ b/packages/web3-providers/src/astar/index.ts
@@ -1,8 +1,7 @@
-import { GasOptionType } from '@masknet/web3-shared-base'
+import { GasOptionType, toFixed } from '@masknet/web3-shared-base'
 import type { ChainId, GasOption } from '@masknet/web3-shared-evm'
 import type { GasOptionAPI } from '../types/index.js'
 import type { EstimateSuggestResponse } from './types.js'
-import { formatWeiToGwei } from '@masknet/web3-shared-evm'
 
 const ASTAR_API = 'https://gas.astar.network/api/gasnow?network=astar'
 
@@ -16,22 +15,22 @@ export class AstarAPI implements GasOptionAPI.Provider<ChainId, GasOption> {
 
         return {
             [GasOptionType.FAST]: {
-                estimatedBaseFee: formatWeiToGwei(result.eip1559.baseFeePerGas).toString() ?? '0',
+                estimatedBaseFee: toFixed(result.eip1559.baseFeePerGas),
                 estimatedSeconds: 15,
-                suggestedMaxFeePerGas: formatWeiToGwei(result.fast ?? 0).toString(),
-                suggestedMaxPriorityFeePerGas: formatWeiToGwei(priorityFeePerGas.fast).toString() ?? '0',
+                suggestedMaxFeePerGas: toFixed(result.fast ?? 0).toString(),
+                suggestedMaxPriorityFeePerGas: toFixed(priorityFeePerGas.fast),
             },
             [GasOptionType.NORMAL]: {
-                estimatedBaseFee: formatWeiToGwei(result.eip1559.baseFeePerGas).toString() ?? '0',
+                estimatedBaseFee: toFixed(result.eip1559.baseFeePerGas),
                 estimatedSeconds: 30,
-                suggestedMaxFeePerGas: formatWeiToGwei(result.average ?? 0).toString(),
-                suggestedMaxPriorityFeePerGas: formatWeiToGwei(priorityFeePerGas.average).toString() ?? '0',
+                suggestedMaxFeePerGas: toFixed(result.average ?? 0).toString(),
+                suggestedMaxPriorityFeePerGas: toFixed(priorityFeePerGas.average),
             },
             [GasOptionType.SLOW]: {
-                estimatedBaseFee: formatWeiToGwei(result.eip1559.baseFeePerGas).toString() ?? '0',
+                estimatedBaseFee: toFixed(result.eip1559.baseFeePerGas),
                 estimatedSeconds: 60,
-                suggestedMaxFeePerGas: formatWeiToGwei(result.slow ?? 0).toString(),
-                suggestedMaxPriorityFeePerGas: formatWeiToGwei(priorityFeePerGas.slow).toString() ?? '0',
+                suggestedMaxFeePerGas: toFixed(result.slow ?? 0).toString(),
+                suggestedMaxPriorityFeePerGas: toFixed(priorityFeePerGas.slow),
             },
         }
     }

--- a/packages/web3-providers/src/debank/index.ts
+++ b/packages/web3-providers/src/debank/index.ts
@@ -9,15 +9,9 @@ import {
     createIndicator,
     Pageable,
     isSameAddress,
+    toFixed,
 } from '@masknet/web3-shared-base'
-import {
-    ChainId,
-    formatGweiToWei,
-    getDeBankConstants,
-    SchemaType,
-    GasOption,
-    formatWeiToGwei,
-} from '@masknet/web3-shared-evm'
+import { ChainId, formatGweiToWei, getDeBankConstants, SchemaType, GasOption } from '@masknet/web3-shared-evm'
 import { formatAssets, formatTransactions } from './format.js'
 import type { WalletTokenRecord, HistoryResponse, GasPriceDictResponse } from './type.js'
 import type { FungibleTokenAPI, HistoryAPI, GasOptionAPI } from '../types/index.js'
@@ -59,17 +53,17 @@ export class DeBankAPI
         return {
             [GasOptionType.FAST]: {
                 estimatedSeconds: responseModified.data.fast.estimated_seconds || 15,
-                suggestedMaxFeePerGas: formatWeiToGwei(responseModified.data.fast.price).toString(),
+                suggestedMaxFeePerGas: toFixed(responseModified.data.fast.price),
                 suggestedMaxPriorityFeePerGas: '0',
             },
             [GasOptionType.NORMAL]: {
                 estimatedSeconds: responseModified.data.normal.estimated_seconds || 30,
-                suggestedMaxFeePerGas: formatWeiToGwei(responseModified.data.normal.price).toString(),
+                suggestedMaxFeePerGas: toFixed(responseModified.data.normal.price),
                 suggestedMaxPriorityFeePerGas: '0',
             },
             [GasOptionType.SLOW]: {
                 estimatedSeconds: responseModified.data.slow.estimated_seconds || 60,
-                suggestedMaxFeePerGas: formatWeiToGwei(responseModified.data.slow.price).toString(),
+                suggestedMaxFeePerGas: toFixed(responseModified.data.slow.price),
                 suggestedMaxPriorityFeePerGas: '0',
             },
         }

--- a/packages/web3-providers/src/metaswap/index.ts
+++ b/packages/web3-providers/src/metaswap/index.ts
@@ -1,10 +1,14 @@
 import urlcat from 'urlcat'
 import { GasOptionType } from '@masknet/web3-shared-base'
-import type { ChainId, GasOption } from '@masknet/web3-shared-evm'
+import { ChainId, formatGweiToWei, GasOption } from '@masknet/web3-shared-evm'
 import type { GasOptionAPI } from '../types/index.js'
 import type { EstimateSuggestResponse } from './types.js'
 
 const METASWAP_API = 'https://gas-api.metaswap.codefi.network/'
+
+function formatAmountAsWei(amount = '0') {
+    return formatGweiToWei(amount).toFixed()
+}
 
 export class MetaSwapAPI implements GasOptionAPI.Provider<ChainId, GasOption> {
     async getGasOptions(chainId: ChainId): Promise<Record<GasOptionType, GasOption>> {
@@ -15,25 +19,25 @@ export class MetaSwapAPI implements GasOptionAPI.Provider<ChainId, GasOption> {
 
         return {
             [GasOptionType.FAST]: {
-                estimatedBaseFee: result.estimatedBaseFee ?? '0',
+                estimatedBaseFee: formatAmountAsWei(result.estimatedBaseFee),
                 estimatedSeconds: 15,
-                baseFeePerGas: result.estimatedBaseFee ?? '0',
-                suggestedMaxFeePerGas: result.high?.suggestedMaxFeePerGas ?? '0',
-                suggestedMaxPriorityFeePerGas: result.high?.suggestedMaxPriorityFeePerGas ?? '0',
+                baseFeePerGas: formatAmountAsWei(result.estimatedBaseFee),
+                suggestedMaxFeePerGas: formatAmountAsWei(result.high?.suggestedMaxFeePerGas),
+                suggestedMaxPriorityFeePerGas: formatAmountAsWei(result.high?.suggestedMaxPriorityFeePerGas),
             },
             [GasOptionType.NORMAL]: {
-                estimatedBaseFee: result.estimatedBaseFee ?? '0',
+                estimatedBaseFee: formatAmountAsWei(result.estimatedBaseFee),
                 estimatedSeconds: 30,
-                baseFeePerGas: result.estimatedBaseFee ?? '0',
-                suggestedMaxFeePerGas: result.medium?.suggestedMaxFeePerGas ?? '0',
-                suggestedMaxPriorityFeePerGas: result.medium?.suggestedMaxPriorityFeePerGas ?? '0',
+                baseFeePerGas: formatAmountAsWei(result.estimatedBaseFee),
+                suggestedMaxFeePerGas: formatAmountAsWei(result.medium?.suggestedMaxFeePerGas),
+                suggestedMaxPriorityFeePerGas: formatAmountAsWei(result.medium?.suggestedMaxPriorityFeePerGas),
             },
             [GasOptionType.SLOW]: {
-                estimatedBaseFee: result.estimatedBaseFee ?? '0',
+                estimatedBaseFee: formatAmountAsWei(result.estimatedBaseFee),
                 estimatedSeconds: 60,
-                baseFeePerGas: result.estimatedBaseFee ?? '0',
-                suggestedMaxFeePerGas: result.low?.suggestedMaxFeePerGas ?? '0',
-                suggestedMaxPriorityFeePerGas: result.low?.suggestedMaxPriorityFeePerGas ?? '0',
+                baseFeePerGas: formatAmountAsWei(result.estimatedBaseFee),
+                suggestedMaxFeePerGas: formatAmountAsWei(result.low?.suggestedMaxFeePerGas),
+                suggestedMaxPriorityFeePerGas: formatAmountAsWei(result.low?.suggestedMaxPriorityFeePerGas),
             },
         }
     }

--- a/packages/web3-providers/src/web3/index.ts
+++ b/packages/web3-providers/src/web3/index.ts
@@ -1,8 +1,8 @@
 import { first, nth } from 'lodash-unified'
 import Web3SDK from 'web3'
 import type { FeeHistoryResult } from 'web3-eth'
-import { GasOptionType } from '@masknet/web3-shared-base'
-import { ChainId, chainResolver, formatWeiToGwei, GasOption, getRPCConstants, Web3 } from '@masknet/web3-shared-evm'
+import { GasOptionType, toFixed } from '@masknet/web3-shared-base'
+import { ChainId, chainResolver, GasOption, getRPCConstants, Web3 } from '@masknet/web3-shared-evm'
 import type { GasOptionAPI } from '../types/index.js'
 
 function avg(arr: number[]) {
@@ -46,25 +46,25 @@ export class EthereumWeb3API implements GasOptionAPI.Provider<ChainId, GasOption
 
         return {
             [GasOptionType.FAST]: {
-                estimatedBaseFee: formatWeiToGwei(baseFeePerGas).toFixed(),
+                estimatedBaseFee: toFixed(baseFeePerGas),
                 estimatedSeconds: 0,
-                baseFeePerGas: formatWeiToGwei(baseFeePerGas).toFixed(),
-                suggestedMaxFeePerGas: formatWeiToGwei(baseFeePerGas + fast).toFixed(),
-                suggestedMaxPriorityFeePerGas: formatWeiToGwei(fast).toFixed(),
+                baseFeePerGas: toFixed(baseFeePerGas),
+                suggestedMaxFeePerGas: toFixed(baseFeePerGas + fast),
+                suggestedMaxPriorityFeePerGas: toFixed(fast),
             },
             [GasOptionType.NORMAL]: {
-                estimatedBaseFee: formatWeiToGwei(baseFeePerGas).toFixed(),
+                estimatedBaseFee: toFixed(baseFeePerGas),
                 estimatedSeconds: 0,
-                baseFeePerGas: formatWeiToGwei(baseFeePerGas).toFixed(),
-                suggestedMaxFeePerGas: formatWeiToGwei(baseFeePerGas + normal).toFixed(),
-                suggestedMaxPriorityFeePerGas: formatWeiToGwei(normal).toFixed(),
+                baseFeePerGas: toFixed(baseFeePerGas),
+                suggestedMaxFeePerGas: toFixed(baseFeePerGas + normal),
+                suggestedMaxPriorityFeePerGas: toFixed(normal),
             },
             [GasOptionType.SLOW]: {
-                estimatedBaseFee: formatWeiToGwei(baseFeePerGas).toFixed(),
+                estimatedBaseFee: toFixed(baseFeePerGas),
                 estimatedSeconds: 0,
-                baseFeePerGas: formatWeiToGwei(baseFeePerGas).toFixed(),
-                suggestedMaxFeePerGas: formatWeiToGwei(baseFeePerGas + slow).toFixed(),
-                suggestedMaxPriorityFeePerGas: formatWeiToGwei(slow).toFixed(),
+                baseFeePerGas: toFixed(baseFeePerGas),
+                suggestedMaxFeePerGas: toFixed(baseFeePerGas + slow),
+                suggestedMaxPriorityFeePerGas: toFixed(slow),
             },
         }
     }
@@ -75,19 +75,19 @@ export class EthereumWeb3API implements GasOptionAPI.Provider<ChainId, GasOption
             [GasOptionType.FAST]: {
                 estimatedBaseFee: '0',
                 estimatedSeconds: 15,
-                suggestedMaxFeePerGas: formatWeiToGwei(gasPrice).toFixed(),
+                suggestedMaxFeePerGas: toFixed(gasPrice),
                 suggestedMaxPriorityFeePerGas: '0',
             },
             [GasOptionType.NORMAL]: {
                 estimatedBaseFee: '0',
                 estimatedSeconds: 30,
-                suggestedMaxFeePerGas: formatWeiToGwei(gasPrice).toFixed(),
+                suggestedMaxFeePerGas: toFixed(gasPrice),
                 suggestedMaxPriorityFeePerGas: '0',
             },
             [GasOptionType.SLOW]: {
                 estimatedBaseFee: '0',
                 estimatedSeconds: 60,
-                suggestedMaxFeePerGas: formatWeiToGwei(gasPrice).toFixed(),
+                suggestedMaxFeePerGas: toFixed(gasPrice),
                 suggestedMaxPriorityFeePerGas: '0',
             },
         }

--- a/packages/web3-shared/base/src/utils/number.ts
+++ b/packages/web3-shared/base/src/utils/number.ts
@@ -54,6 +54,11 @@ export function multipliedBy(a: BigNumber.Value, b: BigNumber.Value) {
     return new BigNumber(a).multipliedBy(b)
 }
 
+/** a + b */
+export function plus(a: BigNumber.Value, b: BigNumber.Value) {
+    return new BigNumber(a).plus(b)
+}
+
 /** a - b */
 export function minus(a: BigNumber.Value, b: BigNumber.Value) {
     return new BigNumber(a).minus(b)


### PR DESCRIPTION
## Description

It's easier to handle gas options uniformly across networks in its fundamental units. Accordingly, we don't have to pay attention to unit conversion on gas amounts and prices.

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [x] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)
