### PR TITLE
fix: hide mask hint tooltip

### DIFF
--- a/packages/mask/src/components/InjectedComponents/PostDialogHint.tsx
+++ b/packages/mask/src/components/InjectedComponents/PostDialogHint.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react'
-import { IconButton, Tooltip, Typography } from '@mui/material'
-import { useStylesExtends, makeStyles } from '@masknet/theme'
+import { IconButton, Typography } from '@mui/material'
+import { useStylesExtends, makeStyles, ShadowRootTooltip } from '@masknet/theme'
 import { useI18N } from '../../utils/index.js'
 import { isMobileFacebook } from '../../social-network-adaptor/facebook.com/utils/isMobile.js'
 import { MaskSharpIcon, MaskIconInMinds } from '@masknet/shared'
@@ -52,13 +52,13 @@ const EntryIconButton = memo((props: PostDialogHintUIProps) => {
     const classes = useStylesExtends(useStyles(), props)
 
     const getEntry = () => (
-        <Tooltip
-            title="Mask Network"
+        <ShadowRootTooltip
+            title={t('mask_network')}
             classes={{ tooltip: classes.tooltip }}
             placement={tooltip?.placement}
             disableHoverListener={tooltip?.disabled}
             PopperProps={{
-                disablePortal: true,
+                disablePortal: false,
             }}>
             <IconButton
                 size="large"
@@ -66,7 +66,7 @@ const EntryIconButton = memo((props: PostDialogHintUIProps) => {
                 onClick={props.onHintButtonClicked}>
                 {ICON_MAP?.[props?.iconType ?? 'default']}
             </IconButton>
-        </Tooltip>
+        </ShadowRootTooltip>
     )
 
     return disableGuideTip ? (

--- a/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteImageToComposition.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteImageToComposition.ts
@@ -1,0 +1,25 @@
+import { delay } from '@dimensiondev/kit'
+import type { SocialNetworkUI } from '../../../social-network/index.js'
+import { hasFocus } from '../utils/postBox.js'
+import { postEditorDraftContentSelector } from '../utils/selector.js'
+import { untilElementAvailable } from '../../../utils/dom.js'
+import { pasteImageToCompositionDefault } from '../../../social-network/defaults/automation/AttachImageToComposition.js'
+
+export function pasteImageToCompositionTwitter(hasSucceed: () => Promise<boolean> | boolean) {
+    const pasteImage = pasteImageToCompositionDefault(hasSucceed)
+    return async function (
+        url: string | Blob,
+        data: SocialNetworkUI.AutomationCapabilities.NativeCompositionAttachImageOptions,
+    ) {
+        const interval = 500
+        // get focus
+        const i = postEditorDraftContentSelector()
+        await untilElementAvailable(i)
+
+        while (!hasFocus(i)) {
+            i.evaluate()!.focus()
+            await delay(interval)
+        }
+        pasteImage(url, data)
+    }
+}

--- a/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteImageToComposition.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteImageToComposition.ts
@@ -9,7 +9,7 @@ export function pasteImageToCompositionTwitter(hasSucceed: () => Promise<boolean
     const pasteImage = pasteImageToCompositionDefault(hasSucceed)
     return async function (
         url: string | Blob,
-        data: SocialNetworkUI.AutomationCapabilities.NativeCompositionAttachImageOptions,
+        options: SocialNetworkUI.AutomationCapabilities.NativeCompositionAttachImageOptions,
     ) {
         const interval = 500
         // get focus
@@ -20,6 +20,6 @@ export function pasteImageToCompositionTwitter(hasSucceed: () => Promise<boolean
             i.evaluate()!.focus()
             await delay(interval)
         }
-        pasteImage(url, data)
+        pasteImage(url, options)
     }
 }

--- a/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteTextToComposition.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteTextToComposition.ts
@@ -2,7 +2,7 @@ import { abortSignalTimeout, delay } from '@dimensiondev/kit'
 import { inputText, pasteText } from '@masknet/injected-script'
 import { newPostButtonSelector, postEditorDraftContentSelector } from '../utils/selector.js'
 import type { SocialNetworkUI } from '../../../social-network/index.js'
-import { getEditorContent, hasFocus } from '../utils/postBox.js'
+import { getEditorContent, hasEditor, hasFocus, isCompose } from '../utils/postBox.js'
 import { untilElementAvailable } from '../../../utils/dom.js'
 import { isMobileTwitter } from '../utils/isMobile.js'
 import { MaskMessages } from '../../../utils/messages.js'
@@ -20,9 +20,7 @@ export const pasteTextToCompositionTwitter: SocialNetworkUI.AutomationCapabiliti
                 if (abort.aborted) throw new Error('Aborted')
             }
 
-            // Workaround: To open the compose dialog even if it's already opened(UX insensitivity)
-            //  to set the editor element as the correct `document.activeElement`.
-            if (opt?.reason !== 'reply') {
+            if (!isCompose() && !hasEditor() && opt?.reason !== 'reply') {
                 // open tweet window
                 await untilElementAvailable(newPostButtonSelector())
                 newPostButtonSelector().evaluate()!.click()

--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/PostDialogHint.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/PostDialogHint.tsx
@@ -74,7 +74,7 @@ function PostDialogHintAtTwitter({ reason }: { reason: 'timeline' | 'popup' }) {
             classes={{ iconButton: classes.iconButton, tooltip: classes.tooltip }}
             size={20}
             onHintButtonClicked={onHintButtonClicked}
-            tooltip={{ disabled: false }}
+            tooltip={{ disabled: false, placement: 'top' }}
         />
     )
 }

--- a/packages/mask/src/social-network-adaptor/twitter.com/ui-provider.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/ui-provider.ts
@@ -5,6 +5,7 @@ import { twitterShared } from './shared.js'
 import { InitAutonomousStateProfiles } from '../../social-network/defaults/state/InitProfiles.js'
 import { openComposeBoxTwitter } from './automation/openComposeBox.js'
 import { pasteTextToCompositionTwitter } from './automation/pasteTextToComposition.js'
+import { pasteImageToCompositionTwitter } from './automation/pasteImageToComposition.js'
 import { gotoNewsFeedPageTwitter } from './automation/gotoNewsFeedPage.js'
 import { gotoProfilePageTwitter } from './automation/gotoProfilePage.js'
 import { IdentityProviderTwitter, CurrentVisitingIdentityProviderTwitter } from './collecting/identity.js'
@@ -21,7 +22,6 @@ import { injectSetupPromptAtTwitter } from './injection/SetupPrompt.js'
 import { injectPostBoxComposed } from './injection/inject.js'
 import { createTaskStartSetupGuideDefault } from '../../social-network/defaults/inject/StartSetupGuide.js'
 import { injectMaskUserBadgeAtTwitter } from './injection/MaskIcon.js'
-import { pasteImageToCompositionDefault } from '../../social-network/defaults/automation/AttachImageToComposition.js'
 import { injectPostInspectorAtTwitter } from './injection/PostInspector.js'
 import { injectPostActionsAtTwitter } from './injection/PostActions/index.js'
 import { EnhanceableSite, NextIDPlatform, ProfileIdentifier } from '@masknet/shared-base'
@@ -132,8 +132,7 @@ const twitterUI: SocialNetworkUI.Definition = {
         nativeCommentBox: undefined,
         nativeCompositionDialog: {
             appendText: pasteTextToCompositionTwitter,
-            // TODO: make a better way to detect
-            attachImage: pasteImageToCompositionDefault(() => false),
+            attachImage: pasteImageToCompositionTwitter(() => false),
         },
         redirect: {
             newsFeed: gotoNewsFeedPageTwitter,

--- a/packages/mask/src/social-network-adaptor/twitter.com/ui-provider.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/ui-provider.ts
@@ -132,6 +132,7 @@ const twitterUI: SocialNetworkUI.Definition = {
         nativeCommentBox: undefined,
         nativeCompositionDialog: {
             appendText: pasteTextToCompositionTwitter,
+            // TODO: make a better way to detect
             attachImage: pasteImageToCompositionTwitter(() => false),
         },
         redirect: {


### PR DESCRIPTION
## Description
https://mask.atlassian.net/browse/MF-2293

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
