### PR TITLE
fix: add strict mode with attemp utils

### DIFF
--- a/packages/plugins/EVM/src/state/NameService/Chainbase.ts
+++ b/packages/plugins/EVM/src/state/NameService/Chainbase.ts
@@ -5,7 +5,7 @@ import { ChainId } from '@masknet/web3-shared-evm'
 
 export class ChainbaseResolver implements NameServiceResolver {
     get id(): NameServiceID {
-        return NameServiceID.Chainbase
+        return NameServiceID.ENS
     }
 
     async lookup(name: string) {

--- a/packages/plugins/EVM/src/state/NameService/ENS.ts
+++ b/packages/plugins/EVM/src/state/NameService/ENS.ts
@@ -47,8 +47,9 @@ export class ENS_Resolver implements NameServiceResolver {
             const name = await ens.reverse(address)
             if (!name.endsWith('.eth')) return
             return name
-        } catch {
-            return
+        } catch (error: unknown) {
+            if (error instanceof Error && error.message === 'ENS name not defined.') return
+            throw error
         }
     }
 }

--- a/packages/web3-shared/base/src/utils/function.ts
+++ b/packages/web3-shared/base/src/utils/function.ts
@@ -2,13 +2,13 @@ export function createPredicate<T, P extends T>(candidates: T[]) {
     return (candidate?: unknown): candidate is P => !!candidate && candidates.includes(candidate as T)
 }
 
-export async function attemptUntil<T>(funcs: Array<() => Promise<T> | undefined>, fallback: T) {
+export async function attemptUntil<T>(funcs: Array<() => Promise<T> | undefined>, fallback: T, strict = false) {
     let hasError = false
     for (const func of funcs) {
         try {
             const result = await func()
-            if (typeof result === 'undefined') continue
-            return result
+            if (typeof result === 'undefined' && !strict) continue
+            return result ?? fallback
         } catch (error) {
             hasError = true
             continue

--- a/packages/web3-state/src/NameService.ts
+++ b/packages/web3-state/src/NameService.ts
@@ -86,7 +86,7 @@ export class NameServiceState<
                 return
             }
         })
-        return attemptUntil(callbacks, undefined)
+        return attemptUntil(callbacks, undefined, true)
     }
 
     createResolvers(chainId: ChainId): NameServiceResolver[] {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-2446

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
