### PR TITLE
refactor: apply asset previewer in dashboard nft list

### DIFF
--- a/packages/dashboard/src/pages/Wallets/components/CollectibleCard/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/CollectibleCard/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { useHoverDirty } from 'react-use'
-import { WalletIcon, NFTCardStyledAssetPlayer } from '@masknet/shared'
+import { AssetPreviewer, NetworkIcon } from '@masknet/shared'
 import { Box, Button, Link, Tooltip, Typography } from '@mui/material'
 import { makeStyles, MaskColorVar } from '@masknet/theme'
 import { NetworkPluginID } from '@masknet/shared-base'
@@ -47,14 +47,6 @@ const useStyles = makeStyles()((theme) => ({
         overflow: 'hidden',
         fontSize: 12,
     },
-    chainIcon: {
-        position: 'absolute',
-        right: 8,
-        top: 8,
-        height: 20,
-        width: 20,
-        zIndex: 20,
-    },
     tip: {
         padding: theme.spacing(1),
         background: '#111432',
@@ -68,12 +60,6 @@ const useStyles = makeStyles()((theme) => ({
         transform: 'translateY(10px)',
         width: 64,
         height: 64,
-    },
-    wrapper: {
-        width: '100%',
-        minWidth: 140,
-        height: '100%',
-        minHeight: 186,
     },
     linkWrapper: {
         position: 'relative',
@@ -121,9 +107,6 @@ export const CollectibleCard = memo<CollectibleCardProps>(({ asset, onSend, rend
     return (
         <Box className={`${classes.container} ${isHovering || isHoveringTooltip ? classes.hover : ''}`} ref={ref}>
             <div className={classes.card}>
-                <Box className={classes.chainIcon}>
-                    <WalletIcon mainIcon={networkDescriptor?.icon} size={20} />
-                </Box>
                 <Link
                     target={asset.link ?? nftLink ? '_blank' : '_self'}
                     rel="noopener noreferrer"
@@ -131,16 +114,12 @@ export const CollectibleCard = memo<CollectibleCardProps>(({ asset, onSend, rend
                     href={asset.link ?? nftLink}>
                     <div className={classes.blocker} />
                     <div className={classes.mediaContainer}>
-                        <NFTCardStyledAssetPlayer
-                            contractAddress={asset.contract?.address}
-                            chainId={asset.contract?.chainId}
-                            renderOrder={renderOrder}
-                            url={asset.metadata?.imageURL || asset.metadata?.mediaURL}
-                            tokenId={asset.tokenId}
+                        <AssetPreviewer
                             classes={{
                                 fallbackImage: classes.fallbackImage,
-                                wrapper: classes.wrapper,
                             }}
+                            url={asset.metadata?.imageURL || asset.metadata?.mediaURL}
+                            icon={<NetworkIcon pluginID={currentPluginId} chainId={asset.chainId} />}
                         />
                     </div>
                 </Link>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-1812

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
