### PR TITLE
fix: past image on twitter

### DIFF
--- a/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteImageToComposition.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/automation/pasteImageToComposition.ts
@@ -1,7 +1,7 @@
 import { delay } from '@dimensiondev/kit'
 import type { SocialNetworkUI } from '../../../social-network/index.js'
-import { hasFocus } from '../utils/postBox.js'
-import { postEditorDraftContentSelector } from '../utils/selector.js'
+import { hasEditor, hasFocus, isCompose } from '../utils/postBox.js'
+import { newPostButtonSelector, postEditorDraftContentSelector } from '../utils/selector.js'
 import { untilElementAvailable } from '../../../utils/dom.js'
 import { pasteImageToCompositionDefault } from '../../../social-network/defaults/automation/AttachImageToComposition.js'
 
@@ -12,6 +12,13 @@ export function pasteImageToCompositionTwitter(hasSucceed: () => Promise<boolean
         options: SocialNetworkUI.AutomationCapabilities.NativeCompositionAttachImageOptions,
     ) {
         const interval = 500
+
+        if (!isCompose() && !hasEditor() && options?.reason !== 'reply') {
+            // open tweet window
+            await untilElementAvailable(newPostButtonSelector())
+            newPostButtonSelector().evaluate()!.click()
+        }
+
         // get focus
         const i = postEditorDraftContentSelector()
         await untilElementAvailable(i)


### PR DESCRIPTION
 fix: past image

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-2547

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
