### PR TITLE
refactor: render all ui in a single react root

### DIFF
--- a/packages/external-plugin-previewer/src/DOMImpl.tsx
+++ b/packages/external-plugin-previewer/src/DOMImpl.tsx
@@ -1,9 +1,9 @@
 import { setDOMImpl } from 'ef.js'
-import { createReactRootShadowedPartial, ReactRootShadowed } from '@masknet/theme'
+import { attachReactTreeToMountedRoot_noHost, ReactRootShadowed } from '@masknet/theme'
 import * as Components from './Components/index.js'
 import { RenderContext } from './RenderContext.js'
 
-const createReactRootShadowed = createReactRootShadowedPartial({
+const createReactRootShadowed = attachReactTreeToMountedRoot_noHost({
     preventEventPropagationList: [],
 })
 setDOMImpl({

--- a/packages/external-plugin-previewer/src/playground.ts
+++ b/packages/external-plugin-previewer/src/playground.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import { t } from 'ef.js'
-import { setupPortalShadowRoot } from '@masknet/theme'
-setupPortalShadowRoot({ mode: 'open' })
+import { setupReactShadowRootEnvironment } from '@masknet/theme'
+setupReactShadowRootEnvironment({ mode: 'open' })
 
 Object.assign(globalThis, { React })
 

--- a/packages/mask/src/social-network/ui.ts
+++ b/packages/mask/src/social-network/ui.ts
@@ -17,7 +17,7 @@ import type { SetupGuideContext } from '../../shared/legacy-settings/types.js'
 import { createPartialSharedUIContext, createPluginHost } from '../../shared/plugin-infra/host.js'
 import Services from '../extension/service.js'
 import { getCurrentIdentifier, getCurrentSNSNetwork } from '../social-network-adaptor/utils.js'
-import { MaskMessages, setupShadowRootPortal } from '../utils/index.js'
+import { MaskMessages, setupReactShadowRootEnvironment } from '../utils/index.js'
 import '../utils/debug/general.js'
 import { RestPartOfPluginUIContextShared } from '../utils/plugin-context-shared-ui.js'
 import { definedSocialNetworkUIs } from './define.js'
@@ -46,7 +46,7 @@ export async function activateSocialNetworkUIInner(ui_deferred: SocialNetworkUI.
     assertNotEnvironment(Environment.ManifestBackground)
 
     console.log('Activating provider', ui_deferred.networkIdentifier)
-    setupShadowRootPortal()
+    setupReactShadowRootEnvironment()
     const ui = (activatedSocialNetworkUI = await loadSocialNetworkUI(ui_deferred.networkIdentifier))
 
     sharedUINetworkIdentifier.value = ui_deferred.networkIdentifier

--- a/packages/mask/src/utils/shadow-root/renderInShadowRoot.tsx
+++ b/packages/mask/src/utils/shadow-root/renderInShadowRoot.tsx
@@ -1,4 +1,8 @@
-import { createReactRootShadowedPartial, setupPortalShadowRoot, CSSVariableInjector } from '@masknet/theme'
+import {
+    attachReactTreeToMountedRoot_noHost,
+    setupReactShadowRootEnvironment as setupReactShadowRootEnvironmentUpper,
+    CSSVariableInjector,
+} from '@masknet/theme'
 import { MaskUIRoot } from '../../UIRoot.js'
 import { useClassicMaskSNSTheme } from '../theme/index.js'
 
@@ -15,13 +19,13 @@ const captureEvents: Array<keyof HTMLElementEventMap> = [
     'dragstart',
     'change',
 ]
-export const setupShadowRootPortal = () => {
-    const shadow = setupPortalShadowRoot({ mode: process.env.shadowRootMode })
-    createReactRootShadowed(shadow, { key: 'css-vars' }).render(<CSSVariableInjector />)
+export function setupReactShadowRootEnvironment() {
+    const shadow = setupReactShadowRootEnvironmentUpper({ mode: process.env.shadowRootMode })
+    attachReactTreeToGlobalContainer_inner(shadow, { key: 'css-vars' }).render(<CSSVariableInjector />)
 }
 
 // https://github.com/DimensionDev/Maskbook/issues/3265 with fast refresh or import order?
-const createReactRootShadowed_raw = createReactRootShadowedPartial({
+const attachReactTreeToGlobalContainer_inner = attachReactTreeToMountedRoot_noHost({
     preventEventPropagationList: captureEvents,
     wrapJSX(jsx) {
         return (
@@ -32,6 +36,16 @@ const createReactRootShadowed_raw = createReactRootShadowedPartial({
         )
     },
 })
-export function createReactRootShadowed(...args: Parameters<typeof createReactRootShadowed_raw>) {
-    return createReactRootShadowed_raw(...args)
+
+/** @deprecated Renamed to attachReactTreeToGlobalContainer */
+export function createReactRootShadowed(...args: Parameters<typeof attachReactTreeToGlobalContainer_inner>) {
+    // @ts-expect-error
+    createReactRootShadowed = attachReactTreeToGlobalContainer_inner
+    return attachReactTreeToGlobalContainer_inner(...args)
+}
+
+export function attachReactTreeToGlobalContainer(...args: Parameters<typeof attachReactTreeToGlobalContainer_inner>) {
+    // @ts-expect-error
+    attachReactTreeToGlobalContainer = attachReactTreeToGlobalContainer_inner
+    return attachReactTreeToGlobalContainer_inner(...args)
 }

--- a/packages/theme/src/ShadowRoot/Contexts.ts
+++ b/packages/theme/src/ShadowRoot/Contexts.ts
@@ -3,10 +3,15 @@ import type { StyleSheet } from './ShadowRootStyleSheet.js'
 
 /** @internal */
 export const StyleSheetsContext = createContext<readonly StyleSheet[]>([])
+StyleSheetsContext.displayName = 'StyleSheetsContext'
+
 /** @internal */
-export const PreventEventPropagationListContext = createContext<Array<keyof HTMLElementEventMap>>([])
+export const PreventShadowRootEventPropagationListContext = createContext<Array<keyof HTMLElementEventMap>>([])
+PreventShadowRootEventPropagationListContext.displayName = 'PreventShadowRootEventPropagationListContext'
+
 /** This context does not join any ShadowRoot related feature. */
 export const DisableShadowRootContext = createContext(false)
+DisableShadowRootContext.displayName = 'DisableShadowRootContext'
 
 /** @internal */
 export const stopPropagation = (e: Event): void => e.stopPropagation()

--- a/packages/theme/src/ShadowRoot/Portal.tsx
+++ b/packages/theme/src/ShadowRoot/Portal.tsx
@@ -3,19 +3,11 @@ import { useRef, forwardRef, useContext } from 'react'
 import type { PopperProps } from '@mui/material'
 import {
     DisableShadowRootContext,
-    PreventEventPropagationListContext,
+    PreventShadowRootEventPropagationListContext,
     stopPropagation,
     StyleSheetsContext,
 } from './Contexts.js'
-
-let mountingPoint: HTMLDivElement
-let mountingShadowRoot: ShadowRoot
-export function setupPortalShadowRoot(init: ShadowRootInit) {
-    if (mountingShadowRoot) return mountingShadowRoot
-    mountingShadowRoot = document.body.appendChild(document.createElement('div')).attachShadow(init)
-    mountingPoint = mountingShadowRoot.appendChild(document.createElement('div'))
-    return mountingShadowRoot
-}
+import { ref } from './ShadowRootSetup.js'
 
 /**
  * Render to a React Portal in to the page needs this hook. It will provide a wrapped container that provides ShadowRoot isolation and CSS support for it.
@@ -35,16 +27,16 @@ export function setupPortalShadowRoot(init: ShadowRootInit) {
  */
 export function usePortalShadowRoot<T>(renderer: (container: HTMLElement | undefined) => T): T {
     const disabled = useRef(useContext(DisableShadowRootContext)).current
-    // we ignore the changes on this property during multiple render
+    // we ignore the changes on DisableShadowRootContext during multiple render
     // so we can violates the React hooks rule and still be safe.
     if (disabled) return renderer(undefined)
 
     const sheets = useContext(StyleSheetsContext)
     const signal = useRef<AbortController | null>(null)
-    const preventEventPropagationList = useContext(PreventEventPropagationListContext)
-    const { container } = useRefInit(() => {
+    const preventEventPropagationList = useContext(PreventShadowRootEventPropagationListContext)
+    const container = useRefInit(() => {
         signal.current = new AbortController()
-        const portal = PortalShadowRoot()
+        const portal = ref.portalContainer
 
         const root = document.createElement('div')
         root.dataset.portalShadowRoot = ''
@@ -57,7 +49,7 @@ export function usePortalShadowRoot<T>(renderer: (container: HTMLElement | undef
         const container = shadow.appendChild(document.createElement('main'))
         sheets.map((x) => x.addContainer(shadow))
 
-        // This is proved to be important to the correct portal orders...
+        // This is important to make the portal orders correct.
         Object.defineProperty(container, 'appendChild', {
             configurable: true,
             writable: true,
@@ -77,7 +69,7 @@ export function usePortalShadowRoot<T>(renderer: (container: HTMLElement | undef
             },
         })
 
-        return { container }
+        return container
     })
 
     return renderer(container)
@@ -104,16 +96,6 @@ export function createShadowRootForwardedPopperComponent<
             return <Component {...props} PopperProps={{ container, ...props.PopperProps }} ref={ref} />
         })
     }) as any as typeof Component
-}
-
-/**
- * ! Do not export !
- */
-function PortalShadowRoot(): Element {
-    if (location.protocol.includes('extension')) return document.body
-    if (globalThis.location.hostname === 'localhost') return document.body
-    if (!mountingPoint) throw new TypeError('Please call setupPortalShadowRoot first')
-    return mountingPoint
 }
 
 function useRefInit<T>(f: () => T): T {

--- a/packages/theme/src/ShadowRoot/ShadowRootSetup.tsx
+++ b/packages/theme/src/ShadowRoot/ShadowRootSetup.tsx
@@ -1,0 +1,55 @@
+import { ALL_EVENTS, ObservableMap } from '@masknet/shared-base'
+import { StrictMode, useEffect, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+
+/**
+ * This container is used to attach the single React root.
+ * It does not contain direct DOM decedents.
+ * All decedents are mounted via <Portal>.
+ */
+let globalContainer: HTMLElement
+/**
+ * This container is prepared for all the Modals.
+ */
+let portalContainer: ShadowRoot
+/** @internal */
+export const shadowEnvironmentMountingRoots = new ObservableMap<any, JSX.Element>()
+
+export function setupReactShadowRootEnvironment(init: ShadowRootInit) {
+    if (portalContainer) return portalContainer
+    // TODO: make sure globalContainer is the last DOM in the body?
+    globalContainer = document.body.appendChild(document.createElement('div'))
+    portalContainer = globalContainer.attachShadow(init)
+
+    // Note: This React Root does not expect to have any direct DOM children.
+    createRoot(globalContainer).render(
+        <StrictMode>
+            <App />
+        </StrictMode>,
+    )
+    return portalContainer
+}
+function App() {
+    const [children, setChildren] = useState<JSX.Element[]>([])
+    useEffect(() => {
+        shadowEnvironmentMountingRoots.event.on(ALL_EVENTS, () => {
+            setChildren(Array.from(shadowEnvironmentMountingRoots.values()))
+        })
+    }, [])
+    // Note: This is safe because Map is ordered when iterating
+    return <>{children}</>
+}
+
+/** @internal */
+export const ref = {
+    get portalContainer(): Element | ShadowRoot {
+        let dom: Element | ShadowRoot
+        if (location.protocol.includes('extension')) dom = document.body
+        else if (globalThis.location.hostname === 'localhost') return document.body
+        else if (!portalContainer) throw new TypeError('Please call setupPortalShadowRoot first')
+        else dom = portalContainer
+
+        Object.defineProperty(ref, 'mountingPoint', { value: dom })
+        return dom
+    },
+}

--- a/packages/theme/src/ShadowRoot/index.ts
+++ b/packages/theme/src/ShadowRoot/index.ts
@@ -1,14 +1,14 @@
 export {
-    createReactRootShadowedPartial,
-    type CreateRenderInShadowRootHostConfig as CreateRenderInShadowRootConfig,
-    type RenderInShadowRootOptions as RenderInShadowRootConfig,
+    attachReactTreeToMountedRoot_noHost,
+    type AttachInShadowRootHostConfig,
+    type AttachInShadowRootOptions,
     type ReactRootShadowed,
-} from './createReactRootShadowed.js'
+} from './attachReactTreeToMountedRoot.js'
 export {
     usePortalShadowRoot,
-    setupPortalShadowRoot,
     createShadowRootForwardedComponent,
     createShadowRootForwardedPopperComponent,
 } from './Portal.js'
+export { setupReactShadowRootEnvironment } from './ShadowRootSetup.js'
 export { ShadowRootIsolation } from './ShadowRootIsolation.js'
 export { DisableShadowRootContext } from './Contexts.js'


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
