### PR TITLE
chore: allow use lodash-es

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,8 +31,7 @@
             "error",
             {
                 "paths": [
-                    { "name": "lodash", "message": "Please use lodash-unified instead." },
-                    { "name": "lodash-es", "message": "Please use lodash-unified instead." },
+                    { "name": "lodash", "message": "Please use lodash-es instead." },
                     { "name": "date-fns", "message": "Please use date-fns/{submodule} instead." },
                     { "name": "date-fns/esm", "message": "Please use date-fns/{submodule} instead." },
                     { "name": "@masknet/typed-message/base", "message": "Please use @masknet/typed-message instead." },

--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -14,8 +14,7 @@
             "error",
             {
                 "paths": [
-                    { "name": "lodash", "message": "Please use lodash-unified instead." },
-                    { "name": "lodash-es", "message": "Please use lodash-unified instead." },
+                    { "name": "lodash", "message": "Please use lodash-es instead." },
                     { "name": "date-fns", "message": "Please use date-fns/{submodule} instead." },
                     { "name": "date-fns/esm", "message": "Please use date-fns/{submodule} instead." },
                     { "name": "idb/with-async-ittr-cjs", "message": "Please use idb/with-async-ittr instead." },
@@ -26,6 +25,11 @@
                     },
                     {
                         "name": "lodash-unified",
+                        "message": "Avoid using type unsafe methods.",
+                        "importNames": ["get"]
+                    },
+                    {
+                        "name": "lodash-es",
                         "message": "Avoid using type unsafe methods.",
                         "importNames": ["get"]
                     }


### PR DESCRIPTION
Since we're moving to full esm, using a dual-package (lodash-unified) that supports both lodash (cjs) and lodash-es (esm) is not necessary
