### PR TITLE
refactor: migrate useStyleExtends and classNames

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -45,7 +45,6 @@
     "@types/react-avatar-editor": "^13.0.0",
     "async-call-rpc": "^6.1.5",
     "bignumber.js": "9.1.0",
-    "classnames": "^2.3.1",
     "color": "^4.2.3",
     "date-fns": "2.28.0",
     "html-to-image": "^1.9.0",

--- a/packages/dashboard/src/components/LoadingButton/index.tsx
+++ b/packages/dashboard/src/components/LoadingButton/index.tsx
@@ -1,6 +1,5 @@
 import { getMaskColor, makeStyles, MaskLoadingButton, LoadingBase } from '@masknet/theme'
 import { memo } from 'react'
-import classNames from 'classnames'
 import type { LoadingButtonProps } from '@mui/lab'
 
 interface DashboardLoadingButtonProps extends LoadingButtonProps {
@@ -18,10 +17,10 @@ const useStyles = makeStyles()((theme) => ({
 
 export const LoadingButton = memo<DashboardLoadingButtonProps>((props) => {
     const { onClick, children, ...rest } = props
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     return (
         <MaskLoadingButton
-            className={classNames(classes.icon, props.loading ? classes.loadingButtonOverride : '')}
+            className={cx(classes.icon, props.loading ? classes.loadingButtonOverride : '')}
             variant="contained"
             loadingPosition="end"
             soloLoading={false}

--- a/packages/dashboard/src/pages/Personas/components/PersonaCard/index.tsx
+++ b/packages/dashboard/src/pages/Personas/components/PersonaCard/index.tsx
@@ -11,7 +11,6 @@ import {
 } from '@masknet/shared-base'
 import { PersonaContext } from '../../hooks/usePersonaContext.js'
 import type { SocialNetwork } from '../../api.js'
-import classNames from 'classnames'
 import { usePersonaProof } from '../../hooks/usePersonaProof.js'
 
 const useStyles = makeStyles()((theme) => ({
@@ -83,11 +82,11 @@ export interface PersonaCardUIProps extends PersonaCardProps {
 export const PersonaCardUI = memo<PersonaCardUIProps>((props) => {
     const { nickname, active = false, definedSocialNetworks, identifier, profiles, publicKey } = props
     const { onConnect, onDisconnect, onClick } = props
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const proof = usePersonaProof(publicKey)
     return (
         <div className={classes.card}>
-            <div className={classNames(classes.status, active ? classes.statusActivated : classes.statusInactivated)} />
+            <div className={cx(classes.status, active ? classes.statusActivated : classes.statusInactivated)} />
             <div style={{ flex: 1 }}>
                 <div className={classes.header}>
                     <Typography variant="subtitle2" sx={{ cursor: 'pointer' }} onClick={onClick}>

--- a/packages/dashboard/src/pages/Settings/components/BackupPreviewCard.tsx
+++ b/packages/dashboard/src/pages/Settings/components/BackupPreviewCard.tsx
@@ -1,6 +1,5 @@
 import { MaskColorVar, makeStyles } from '@masknet/theme'
 import { Typography } from '@mui/material'
-import classNames from 'classnames'
 import { useDashboardI18N } from '../../../locales/index.js'
 import formatDateTime from 'date-fns/format'
 import type { BackupPreview } from '@masknet/backup-format'
@@ -29,7 +28,7 @@ export interface Props {
 
 export default function BackupPreviewCard({ json }: Props) {
     const t = useDashboardI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
 
     const records = [
         {
@@ -69,7 +68,7 @@ export default function BackupPreviewCard({ json }: Props) {
     return (
         <div className={classes.root}>
             {records.map((record, idx) => (
-                <div className={classNames(classes.item, record.sub ? classes.sub : '')} key={idx}>
+                <div className={cx(classes.item, record.sub ? classes.sub : '')} key={idx}>
                     <Typography variant="body2">{record.name}</Typography>
                     <Typography variant="body2">{record.value}</Typography>
                 </div>

--- a/packages/dashboard/src/pages/Settings/components/dialogs/BackupModeSelectDialog.tsx
+++ b/packages/dashboard/src/pages/Settings/components/dialogs/BackupModeSelectDialog.tsx
@@ -4,7 +4,6 @@ import { Icons } from '@masknet/icons'
 import { useContext, useMemo } from 'react'
 import { UserContext } from '../../hooks/UserContext.js'
 import { useDashboardI18N } from '../../../../locales/index.js'
-import classNames from 'classnames'
 
 const useStyles = makeStyles()((theme) => ({
     container: {
@@ -57,7 +56,7 @@ export interface BackupModeSelectDialogProps {
 
 export default function BackupModeSelectDialog({ open, onClose, onSelect }: BackupModeSelectDialogProps) {
     const t = useDashboardI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { user } = useContext(UserContext)
 
     const cloudDisabled = useMemo(() => {
@@ -72,7 +71,7 @@ export default function BackupModeSelectDialog({ open, onClose, onSelect }: Back
                         <Icons.LocalBackup className={classes.icon} />
                         <Typography className={classes.label}>Local Backup</Typography>
                     </Box>
-                    <Box className={classNames(classes.mode, cloudDisabled && 'disabled')}>
+                    <Box className={cx(classes.mode, cloudDisabled && 'disabled')}>
                         {cloudDisabled ? (
                             <Tooltip title={t.settings_dialogs_bind_email_or_phone()} placement="top" arrow>
                                 <div className={classes.mask} />

--- a/packages/dashboard/src/pages/Wallets/components/HistoryTableRow/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/HistoryTableRow/index.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react'
-import classNames from 'classnames'
 import formatDateTime from 'date-fns/format'
 import { Icons } from '@masknet/icons'
 import { useReverseAddress, useWeb3State } from '@masknet/web3-hooks-base'
@@ -84,7 +83,7 @@ export interface HistoryTableRowUIProps extends HistoryTableRowProps {
 
 export const HistoryTableRowUI = memo<HistoryTableRowUIProps>(
     ({ transaction, selectedChainId, formattedType, domain }) => {
-        const { classes } = useStyles()
+        const { classes, cx } = useStyles()
         const { Others } = useWeb3State()
         return (
             <TableRow className={classes.hover}>
@@ -114,7 +113,7 @@ export const HistoryTableRowUI = memo<HistoryTableRowUIProps>(
                         return (
                             <Stack
                                 key={index}
-                                className={classNames(classes.pair, { [classes.send]: direction })}
+                                className={cx(classes.pair, { [classes.send]: direction })}
                                 justifyContent="center"
                                 gap={2}
                                 direction="row">

--- a/packages/mask/package.json
+++ b/packages/mask/package.json
@@ -84,7 +84,6 @@
     "bignumber.js": "9.1.0",
     "bip39": "^3.0.2",
     "buffer": "^6.0.3",
-    "classnames": "^2.3.1",
     "clipboard-polyfill": "^3.0.3",
     "color": "^4.2.3",
     "crypto-browserify": "^3.12.0",

--- a/packages/mask/src/components/GuideStep/index.tsx
+++ b/packages/mask/src/components/GuideStep/index.tsx
@@ -1,7 +1,6 @@
 import { useValueRef } from '@masknet/shared-base-ui'
 import { makeStyles, usePortalShadowRoot } from '@masknet/theme'
 import { Box, Typography, styled, Portal } from '@mui/material'
-import classNames from 'classnames'
 import { PropsWithChildren, useRef, cloneElement, useEffect, ReactElement, useState } from 'react'
 import { sayHelloShowed, userGuideStatus, userGuideVersion } from '../../../shared/legacy-settings/settings.js'
 import { activatedSocialNetworkUI } from '../../social-network/index.js'
@@ -204,7 +203,7 @@ export default function GuideStep({
                                         height: clientRect.height,
                                     }}>
                                     <div
-                                        className={classNames(
+                                        className={cx(
                                             classes.card,
                                             arrow ? (bottomAvailable ? 'arrow-top' : 'arrow-bottom') : '',
                                         )}

--- a/packages/mask/src/components/InjectedComponents/AdditionalPostContent.tsx
+++ b/packages/mask/src/components/InjectedComponents/AdditionalPostContent.tsx
@@ -1,6 +1,5 @@
 import { Typography, Card, Box, CircularProgress, CircularProgressProps } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
-import classNames from 'classnames'
 import { TypedMessage, makeTypedMessageText } from '@masknet/typed-message'
 import { TextResizeContext, TypedMessageRender } from '@masknet/typed-message/dom'
 import { TypedMessageRenderContext } from '../../../shared-ui/TypedMessageRender/context.js'
@@ -52,7 +51,7 @@ export const AdditionalContent = memo(function AdditionalContent(props: Addition
             variant="caption"
             color={message ? 'textSecondary' : 'textPrimary'}
             gutterBottom
-            className={classNames(classes.title)}>
+            className={classes.title}>
             <span className={classes.icon}>{ProgressJSX || <MaskIcon />}</span>
             <Box
                 sx={{

--- a/packages/mask/src/components/InjectedComponents/AutoPasteFailedDialog.tsx
+++ b/packages/mask/src/components/InjectedComponents/AutoPasteFailedDialog.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles()((theme) => ({
 export function AutoPasteFailedDialog(props: AutoPasteFailedDialogProps) {
     const { onClose, data } = props
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const url = data.image ? URL.createObjectURL(data.image) : undefined
     const { showSnackbar } = useCustomSnackbar()
     const [, copy] = useCopyToClipboard()

--- a/packages/mask/src/components/InjectedComponents/PostComments.tsx
+++ b/packages/mask/src/components/InjectedComponents/PostComments.tsx
@@ -23,7 +23,7 @@ const useStyle = makeStyles()({
 })
 export type PostCommentDecryptedProps = React.PropsWithChildren<{ ChipProps?: ChipProps }>
 export function PostCommentDecrypted(props: PostCommentDecryptedProps) {
-    const classes = useStylesExtends(useStyle(), props.ChipProps || {})
+    const { classes } = useStylesExtends(useStyle(), props.ChipProps || {})
     return (
         <>
             <Chip

--- a/packages/mask/src/components/InjectedComponents/PostDialogHint.tsx
+++ b/packages/mask/src/components/InjectedComponents/PostDialogHint.tsx
@@ -4,7 +4,6 @@ import { useStylesExtends, makeStyles, ShadowRootTooltip } from '@masknet/theme'
 import { useI18N } from '../../utils/index.js'
 import { isMobileFacebook } from '../../social-network-adaptor/facebook.com/utils/isMobile.js'
 import { MaskSharpIcon, MaskIconInMinds } from '@masknet/shared'
-import classNames from 'classnames'
 import GuideStep from '../GuideStep/index.js'
 
 interface TooltipConfigProps {
@@ -46,7 +45,7 @@ const ICON_MAP: Record<string, JSX.Element> = {
 const EntryIconButton = memo((props: PostDialogHintUIProps) => {
     const { t } = useI18N()
     const { tooltip, disableGuideTip } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
 
     const getEntry = () => (
         <ShadowRootTooltip
@@ -59,7 +58,7 @@ const EntryIconButton = memo((props: PostDialogHintUIProps) => {
             arrow>
             <IconButton
                 size="large"
-                className={classNames(classes.button, classes.iconButton)}
+                className={cx(classes.button, classes.iconButton)}
                 onClick={props.onHintButtonClicked}>
                 {ICON_MAP?.[props?.iconType ?? 'default']}
             </IconButton>
@@ -77,7 +76,7 @@ const EntryIconButton = memo((props: PostDialogHintUIProps) => {
 
 export const PostDialogHint = memo(function PostDialogHintUI(props: PostDialogHintUIProps) {
     const { onHintButtonClicked, size, ...others } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { t } = useI18N()
 
     return isMobileFacebook ? (

--- a/packages/mask/src/components/InjectedComponents/PostDialogIcon.tsx
+++ b/packages/mask/src/components/InjectedComponents/PostDialogIcon.tsx
@@ -11,6 +11,6 @@ export interface PostDialogIconProps extends withClasses<SvgIconClassKey> {
 }
 
 export function PostDialogIcon(props: PostDialogIconProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return <MaskSharpIcon classes={{ root: classes.root }} onClick={props.onClick} color="primary" />
 }

--- a/packages/mask/src/components/InjectedComponents/ProfileCard/ProfileBar.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileCard/ProfileBar.tsx
@@ -1,6 +1,5 @@
-import { HTMLProps, memo, useEffect, useRef, useState } from 'react'
+import { HTMLProps, memo, useEffect, useId, useRef, useState } from 'react'
 import { useCopyToClipboard } from 'react-use'
-import { v4 as uuid } from 'uuid'
 import { Icons } from '@masknet/icons'
 import { Box, Link, MenuItem, Typography } from '@mui/material'
 import { useWeb3State, useChainContext } from '@masknet/web3-hooks-base'
@@ -120,7 +119,7 @@ export const ProfileBar = memo<ProfileBarProps>(
         const { classes, theme, cx } = useStyles()
         const { t } = useI18N()
         const containerRef = useRef<HTMLDivElement>(null)
-        const { current: avatarClipPathId } = useRef<string>(uuid())
+        const avatarClipPathId = useId()
 
         const [, copyToClipboard] = useCopyToClipboard()
 

--- a/packages/mask/src/components/InjectedComponents/ProfileTab.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileTab.tsx
@@ -1,6 +1,5 @@
 import { ReactElement, useCallback, useEffect, useState } from 'react'
 import { useMount } from 'react-use'
-import classnames from 'classnames'
 import { Typography } from '@mui/material'
 import { MaskMessages, useMatchXS, useLocationChange } from '../../utils/index.js'
 import { isTwitter } from '../../social-network-adaptor/twitter.com/base.js'
@@ -56,7 +55,7 @@ export function ProfileTab(props: ProfileTabProps) {
     return (
         <div key="nfts" className={classes.root}>
             <Typography
-                className={classnames(classes.button, active ? classes.selected : '')}
+                className={cx(classes.button, active ? classes.selected : '')}
                 onClick={onClick}
                 component="div">
                 {props.icon}

--- a/packages/mask/src/components/InjectedComponents/ProfileTab.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileTab.tsx
@@ -55,7 +55,7 @@ export function ProfileTab(props: ProfileTabProps) {
     return (
         <div key="nfts" className={classes.root}>
             <Typography
-                className={cx(classes.button, active ? classes.selected : '')}
+                className={classes.button + ' ' + (active ? classes.selected : '')}
                 onClick={onClick}
                 component="div">
                 {props.icon}

--- a/packages/mask/src/components/InjectedComponents/ProfileTabContent.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileTabContent.tsx
@@ -135,7 +135,7 @@ const useStyles = makeStyles()((theme) => ({
 export interface ProfileTabContentProps extends withClasses<'text' | 'button' | 'root'> {}
 
 export function ProfileTabContent(props: ProfileTabContentProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const { t } = useI18N()
     const translate = usePluginI18NField()

--- a/packages/mask/src/components/InjectedComponents/SetupGuide/FindUsername.tsx
+++ b/packages/mask/src/components/InjectedComponents/SetupGuide/FindUsername.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { SetupGuideStep } from '../../../../shared/legacy-settings/types.js'
 import { Box, Typography } from '@mui/material'
 import { MaskIcon, ActionButtonPromise } from '@masknet/shared'
-import classNames from 'classnames'
 import { Icons } from '@masknet/icons'
 import { makeStyles, MaskColorVar } from '@masknet/theme'
 import { Trans } from 'react-i18next'
@@ -97,7 +96,7 @@ export function FindUsername({
     const { t } = useI18N()
     const [connected, setConnected] = useState(false)
 
-    const { classes } = useFindUsernameStyles()
+    const { classes, cx } = useFindUsernameStyles()
 
     return (
         <WizardDialog
@@ -116,10 +115,7 @@ export function FindUsername({
                             <Box className={classes.line} />
                             <Box className={classes.connectItem}>
                                 <Box position="relative" width={48}>
-                                    <img
-                                        src={avatar}
-                                        className={classNames(classes.avatar, connected ? 'connected' : '')}
-                                    />
+                                    <img src={avatar} className={cx(classes.avatar, connected ? 'connected' : '')} />
                                     {connected ? <Icons.Verified className={classes.verified} /> : null}
                                 </Box>
                                 <Typography variant="body2" className={classes.name}>

--- a/packages/mask/src/components/InjectedComponents/SetupGuide/VerifyNextID.tsx
+++ b/packages/mask/src/components/InjectedComponents/SetupGuide/VerifyNextID.tsx
@@ -1,7 +1,6 @@
 import { useI18N } from '../../../utils/index.js'
 import { Box, Checkbox, FormControlLabel, Typography } from '@mui/material'
 import { MaskIcon, ActionButtonPromise } from '@masknet/shared'
-import classNames from 'classnames'
 import { Icons } from '@masknet/icons'
 import { WizardDialogProps, WizardDialog } from './WizardDialog.js'
 import { SetupGuideStep } from '../../../../shared/legacy-settings/types.js'
@@ -104,7 +103,7 @@ export const VerifyNextID = ({
 }: VerifyNextIDProps) => {
     const { t } = useI18N()
 
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const [checked, setChecked] = useState(false)
 
     if (!personaIdentifier) return null
@@ -126,7 +125,7 @@ export const VerifyNextID = ({
                             <Box className={classes.line} />
                             <Box className={classes.connectItem}>
                                 <Box position="relative" width={48}>
-                                    <img src={avatar} className={classNames(classes.avatar, 'connected')} />
+                                    <img src={avatar} className={cx(classes.avatar, 'connected')} />
                                     <Icons.Verified className={classes.verified} />
                                 </Box>
                                 <Typography variant="body2" className={classes.name}>

--- a/packages/mask/src/components/InjectedComponents/SetupGuide/WizardDialog.tsx
+++ b/packages/mask/src/components/InjectedComponents/SetupGuide/WizardDialog.tsx
@@ -1,5 +1,4 @@
 import { Box, IconButton, Paper, Typography } from '@mui/material'
-import classNames from 'classnames'
 import { Close as CloseIcon } from '@mui/icons-material'
 import { makeStyles } from '@masknet/theme'
 import { SetupGuideStep } from '../../../../shared/legacy-settings/types.js'
@@ -99,10 +98,10 @@ export interface WizardDialogProps {
 
 export function WizardDialog(props: WizardDialogProps) {
     const { small, title, dialogType, content, tip, footer, dismiss, onClose } = props
-    const { classes } = useWizardDialogStyles()
+    const { classes, cx } = useWizardDialogStyles()
 
     return (
-        <Paper className={classNames(classes.root, small ? 'small' : '')}>
+        <Paper className={cx(classes.root, small ? 'small' : '')}>
             <header className={classes.header}>
                 <Typography color="textPrimary" variant="h3" fontSize={24}>
                     {title}

--- a/packages/mask/src/components/Welcomes/Banner.tsx
+++ b/packages/mask/src/components/Welcomes/Banner.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles()({
 })
 
 export function BannerUI(props: BannerUIProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return props.nextStep === 'hidden' ? null : (
         <IconButton size="large" className={classes.buttonText} onClick={props.nextStep.onClick}>

--- a/packages/mask/src/components/shared/AbstractTab.tsx
+++ b/packages/mask/src/components/shared/AbstractTab.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, useStylesExtends } from '@masknet/theme'
-import classNames from 'classnames'
 import { Tabs, Tab, Box, BoxProps, Paper } from '@mui/material'
 
 const useStyles = makeStyles()((theme) => ({
@@ -42,7 +41,7 @@ export interface AbstractTabProps
 
 export default function AbstractTab(props: AbstractTabProps) {
     const { tabs, state, index, height = 200, hasOnlyOneChild = false, scrollable = false } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
     const [value, setValue] = state ?? [undefined, undefined]
     const tabIndicatorStyle = tabs.length && !scrollable ? { width: 100 / tabs.length + '%' } : undefined
 
@@ -66,7 +65,7 @@ export default function AbstractTab(props: AbstractTabProps) {
                     {tabs.map((tab, i) => (
                         <Tab
                             disabled={tab.disabled}
-                            className={classNames(
+                            className={cx(
                                 classes.tab,
                                 [index, value].includes(i) ? classes.focusTab : '',
                                 tab.disabled ? classes.disabledTab : '',

--- a/packages/mask/src/components/shared/PersonaSelectPanel/PersonaItemUI.tsx
+++ b/packages/mask/src/components/shared/PersonaSelectPanel/PersonaItemUI.tsx
@@ -63,7 +63,7 @@ const useStyles = makeStyles()((theme) => {
 
 export const PersonaItemUI = (props: PersonaItemProps) => {
     const { data, onCopy, onClick, currentPersona, currentPersonaIdentifier, currentProfileIdentify } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const isVerified = useMemo(() => {
         return data.proof.some(

--- a/packages/mask/src/components/shared/PersonaSelectPanel/PersonaSelectPanel.tsx
+++ b/packages/mask/src/components/shared/PersonaSelectPanel/PersonaSelectPanel.tsx
@@ -62,7 +62,7 @@ export const PersonaSelectPanel = memo<PersonaSelectPanelProps>((props) => {
     const currentPersona = useCurrentPersona()
     const currentPersonaIdentifier = currentPersona?.identifier
 
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const [selectedPersona, setSelectedPersona] = useState<PersonaNextIDMixture>()
 
@@ -250,7 +250,7 @@ interface ActionContentProps extends withClasses<never | 'button'> {
 
 function ActionContent(props: ActionContentProps) {
     const { buttonText, hint, onClick } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     if (!buttonText) return null
     return (
         <Stack gap={1.5} mt={1.5}>

--- a/packages/mask/src/components/shared/PluginEnableBoundary.tsx
+++ b/packages/mask/src/components/shared/PluginEnableBoundary.tsx
@@ -25,7 +25,7 @@ interface PluginEnableBoundaryProps extends withClasses<'root'> {
 export const PluginEnableBoundary = memo<PluginEnableBoundaryProps>((props) => {
     const { t } = useI18N()
     const { children, pluginID } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const disabled = useIsMinimalMode(pluginID)
     const plugins = useActivatedPluginsSNSAdaptor(true)

--- a/packages/mask/src/components/shared/SelectProfileUI/SelectProfileUI.tsx
+++ b/packages/mask/src/components/shared/SelectProfileUI/SelectProfileUI.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles()({
 })
 export function SelectProfileUI(props: SelectProfileUIProps) {
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const { frozenSelected, onSetSelected, disabled, items, selected } = props
 

--- a/packages/mask/src/components/shared/SelectRecipients/ClickableChip.tsx
+++ b/packages/mask/src/components/shared/SelectRecipients/ClickableChip.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { makeStyles } from '@masknet/theme'
 import { Done as DoneIcon } from '@mui/icons-material'
 import Chip, { ChipProps } from '@mui/material/Chip'
@@ -34,7 +33,7 @@ const useStyles = makeStyles<StyleProps>()((theme, { checked }) => ({
 }))
 
 export function ClickableChip(props: ClickableChipProps) {
-    const { classes } = useStyles({ checked: Boolean(props.checked) })
+    const { classes, cx } = useStyles({ checked: Boolean(props.checked) })
     return (
         <Chip
             deleteIcon={props.checked ? <DoneIcon className={classes.icon} /> : undefined}
@@ -43,8 +42,8 @@ export function ClickableChip(props: ClickableChipProps) {
             {...props}
             classes={{
                 ...props.classes,
-                root: classNames(classes.root, props.classes?.root),
-                label: classNames(classes.label, props.classes?.label),
+                root: cx(classes.root, props.classes?.root),
+                label: cx(classes.label, props.classes?.label),
             }}
         />
     )

--- a/packages/mask/src/components/shared/SelectWallet/WalletInList.tsx
+++ b/packages/mask/src/components/shared/SelectWallet/WalletInList.tsx
@@ -42,7 +42,7 @@ export interface WalletInListProps extends withClasses<never> {
 
 export function WalletInList(props: WalletInListProps) {
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyle(), props)
+    const { classes } = useStylesExtends(useStyle(), props)
     const { wallet, selected = false, disabled = false, onClick, ListItemProps } = props
     const blockie = useBlockie(wallet.address)
 

--- a/packages/mask/src/components/shared/WalletStatusBox/TransactionList.tsx
+++ b/packages/mask/src/components/shared/WalletStatusBox/TransactionList.tsx
@@ -7,7 +7,6 @@ import { makeStyles, MaskColorVar } from '@masknet/theme'
 import { isSameAddress, RecentTransactionComputed, TransactionStatusType, Transaction } from '@masknet/web3-shared-base'
 import { getContractOwnerDomain } from '@masknet/web3-shared-evm'
 import { Grid, GridProps, Link, List, ListItem, ListProps, Stack, Typography } from '@mui/material'
-import classnames from 'classnames'
 import format from 'date-fns/format'
 import { noop } from 'lodash-unified'
 import { useI18N } from '../../../utils/index.js'
@@ -167,11 +166,11 @@ interface Props extends ListProps {
 }
 
 export const TransactionList: FC<Props> = forwardRef(({ className, transactions, onClear = noop, ...rest }, ref) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { chainId } = useChainContext()
     if (!transactions.length) return null
     return (
-        <List className={classnames(classes.list, className)} {...rest} ref={ref}>
+        <List className={cx(classes.list, className)} {...rest} ref={ref}>
             {transactions.map((tx) => (
                 <ListItem key={tx.id} className={classes.listItem}>
                     <Transaction className={classes.transaction} transaction={tx} chainId={chainId} onClear={onClear} />

--- a/packages/mask/src/components/shared/WalletStatusBox/index.tsx
+++ b/packages/mask/src/components/shared/WalletStatusBox/index.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { useCopyToClipboard } from 'react-use'
 import {
     useChainContext,
@@ -113,7 +112,7 @@ export function WalletStatusBox(props: WalletStatusBox) {
 
     const providerDescriptor = useProviderDescriptor<'all'>()
     const theme = useTheme()
-    const { classes } = useStyles({
+    const { classes, cx } = useStyles({
         contentBackground: providerDescriptor?.backgroundGradient,
         disableChange: props.disableChange,
         withinRiskWarningDialog: props.withinRiskWarningDialog,
@@ -174,7 +173,7 @@ export function WalletStatusBox(props: WalletStatusBox) {
         return (
             <section className={classes.connectButtonWrapper}>
                 <Button
-                    className={classNames(classes.actionButton)}
+                    className={cx(classes.actionButton)}
                     color="primary"
                     variant="contained"
                     size="small"
@@ -188,7 +187,7 @@ export function WalletStatusBox(props: WalletStatusBox) {
     return (
         <>
             <section
-                className={classNames(
+                className={cx(
                     classes.statusBox,
                     classes.currentAccount,
                     isDashboardPage() ? classes.dashboardBackground : '',
@@ -217,7 +216,7 @@ export function WalletStatusBox(props: WalletStatusBox) {
                             component="button"
                             title={t('wallet_status_button_copy_address')}
                             onClick={onCopy}>
-                            <Icons.Copy className={classNames(classes.icon, classes.copyIcon)} />
+                            <Icons.Copy className={cx(classes.icon, classes.copyIcon)} />
                         </Link>
                         {chainIdValid ? (
                             <Link
@@ -226,7 +225,7 @@ export function WalletStatusBox(props: WalletStatusBox) {
                                 target="_blank"
                                 title={t('plugin_wallet_view_on_explorer')}
                                 rel="noopener noreferrer">
-                                <Icons.LinkOut className={classNames(classes.icon, classes.linkIcon)} />
+                                <Icons.LinkOut className={cx(classes.icon, classes.linkIcon)} />
                             </Link>
                         ) : null}
                     </div>
@@ -245,7 +244,7 @@ export function WalletStatusBox(props: WalletStatusBox) {
                 {!props.disableChange && (
                     <section>
                         <Button
-                            className={classNames(classes.actionButton)}
+                            className={cx(classes.actionButton)}
                             variant="contained"
                             size="small"
                             onClick={async () => {
@@ -259,7 +258,7 @@ export function WalletStatusBox(props: WalletStatusBox) {
                             {t('plugin_wallet_disconnect')}
                         </Button>
                         <Button
-                            className={classNames(classes.actionButton)}
+                            className={cx(classes.actionButton)}
                             variant="contained"
                             size="small"
                             onClick={openSelectProviderDialog}>

--- a/packages/mask/src/components/shared/WalletStatusBox/usePendingTransactions.tsx
+++ b/packages/mask/src/components/shared/WalletStatusBox/usePendingTransactions.tsx
@@ -6,7 +6,6 @@ import {
 import { makeStyles, MaskColorVar } from '@masknet/theme'
 import { TransactionStatusType } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import classnames from 'classnames'
 import { useState } from 'react'
 import { useI18N } from '../../../utils/index.js'
 import { TransactionList } from './TransactionList.js'
@@ -36,7 +35,7 @@ const useStyles = makeStyles()((theme) => ({
 }))
 
 export function usePendingTransactions() {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { t } = useI18N()
 
     // #region recent pending transactions
@@ -53,7 +52,7 @@ export function usePendingTransactions() {
     // #endregion
     const summary = pendingTransactions.length ? (
         <section className={classes.summaryWrapper}>
-            <div className={classnames(pendingTransactions.length ? '' : classes.hide)}>
+            <div className={cx(pendingTransactions.length ? '' : classes.hide)}>
                 {pendingTransactions.length ? (
                     <Typography className={classes.pendingSummary} variant="body2" mr={1} fontWeight={700}>
                         {t('wallet_status_pending', { count: pendingTransactions.length })}

--- a/packages/mask/src/extension/options-page/DashboardComponents/ActionsBarNFT.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/ActionsBarNFT.tsx
@@ -29,7 +29,7 @@ export function ActionsBarNFT(props: ActionsBarNFT_Props) {
     const { wallet, asset } = props
 
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const chainIdValid = useChainIdValid()
 

--- a/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectionIcon.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectionIcon.tsx
@@ -2,7 +2,6 @@ import { memo } from 'react'
 import { Box, Tooltip } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { Image, Icon } from '@masknet/shared'
-import classNames from 'classnames'
 import { isSameAddress, NonFungibleCollection } from '@masknet/web3-shared-base'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { Icons } from '@masknet/icons'
@@ -38,7 +37,7 @@ export interface CollectionIconProps {
 }
 
 export const CollectionIcon = memo<CollectionIconProps>(({ collection, onClick, selectedCollection }) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
 
     return (
         <Tooltip
@@ -50,7 +49,7 @@ export const CollectionIcon = memo<CollectionIconProps>(({ collection, onClick, 
             title={collection?.name ?? ''}
             arrow>
             <Box
-                className={classNames(
+                className={cx(
                     classes.collectionWrap,
                     isSameAddress(collection?.address, selectedCollection) ? classes.selected : '',
                 )}

--- a/packages/mask/src/extension/options-page/DashboardComponents/InputBox.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/InputBox.tsx
@@ -19,7 +19,7 @@ export interface InputBoxProps extends withClasses<'root'> {
 }
 export function InputBox(props: InputBoxProps) {
     const { label, children, onChange, value } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <InputBase

--- a/packages/mask/src/extension/options-page/DashboardDialogs/Base.tsx
+++ b/packages/mask/src/extension/options-page/DashboardDialogs/Base.tsx
@@ -1,5 +1,4 @@
 import { cloneElement, useCallback, useReducer } from 'react'
-import classNames from 'classnames'
 import {
     DialogProps,
     Dialog,
@@ -258,7 +257,7 @@ interface DashboardDialogWrapperProps extends withClasses<'wrapper'> {
 /** @deprecated Do not use in new code */
 export function DashboardDialogWrapper(props: DashboardDialogWrapperProps) {
     const { size, icon, iconColor, primary, secondary, constraintSecondary = true, content, footer } = props
-    const { classes } = useDashboardDialogWrapperStyles(props)
+    const { classes, cx } = useDashboardDialogWrapperStyles(props)
     return (
         <ThemeProvider theme={dialogTheme}>
             <DialogContent className={classes.wrapper}>
@@ -268,7 +267,7 @@ export function DashboardDialogWrapper(props: DashboardDialogWrapperProps) {
                         {primary}
                     </Typography>
                     <Typography
-                        className={classNames(
+                        className={cx(
                             classes.secondary,
                             size !== 'small' && constraintSecondary ? classes.confineSecondary : '',
                         )}

--- a/packages/mask/src/extension/options-page/DashboardDialogs/Wallet/HideTokenConfirm.tsx
+++ b/packages/mask/src/extension/options-page/DashboardDialogs/Wallet/HideTokenConfirm.tsx
@@ -5,7 +5,6 @@ import { useSnackbarCallback, DebounceButton } from '@masknet/shared'
 import { useI18N } from '../../../../utils/index.js'
 import { DashboardDialogCore, DashboardDialogWrapper, WrappedDialogProps } from '../Base.js'
 import { makeStyles } from '@masknet/theme'
-import classNames from 'classnames'
 import type { FungibleToken, NonFungibleToken, Wallet } from '@masknet/web3-shared-base'
 import { Trans } from 'react-i18next'
 
@@ -93,7 +92,7 @@ const useStyles = makeStyles()((theme) => ({
 }))
 
 function SpacedButtonGroup(_props: BoxProps) {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { className, ...props } = _props
-    return <Box className={classNames(className, classes.buttonGroup)} {...props} />
+    return <Box className={cx(className, classes.buttonGroup)} {...props} />
 }

--- a/packages/mask/src/extension/popups/components/StyledInput/index.tsx
+++ b/packages/mask/src/extension/popups/components/StyledInput/index.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, memo } from 'react'
 import { TextFieldProps, TextField } from '@mui/material'
 import { makeStyles, useStylesExtends } from '@masknet/theme'
-import classNames from 'classnames'
 
 const useStyles = makeStyles()(({ palette }) => ({
     textField: {
@@ -24,14 +23,14 @@ const useStyles = makeStyles()(({ palette }) => ({
 
 export const StyledInput = memo(
     forwardRef<{}, TextFieldProps>((props, ref) => {
-        const classes = useStylesExtends(useStyles(), props)
+        const { classes, cx } = useStylesExtends(useStyles(), props)
 
         return (
             <TextField
                 {...props}
                 inputRef={ref}
                 variant="filled"
-                className={classNames(classes.textField, props.className)}
+                className={cx(classes.textField, props.className)}
                 autoComplete="off"
                 inputProps={{ className: classes.input, 'aria-autocomplete': 'none', ...props.inputProps }}
                 InputProps={{

--- a/packages/mask/src/extension/popups/pages/Personas/SelectPersona/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Personas/SelectPersona/index.tsx
@@ -2,7 +2,6 @@ import { memo } from 'react'
 import { PersonaList } from '../components/PersonaList/index.js'
 import { makeStyles } from '@masknet/theme'
 import { Button } from '@mui/material'
-import classNames from 'classnames'
 import { PersonaContext } from '../hooks/usePersonaContext.js'
 import { MAX_PERSONA_LIMIT } from '@masknet/shared-base'
 import urlcat from 'urlcat'
@@ -44,7 +43,7 @@ const useStyles = makeStyles()({
 })
 
 const SelectPersona = memo(() => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { t } = useI18N()
     const { personas } = PersonaContext.useContainer()
 
@@ -56,7 +55,7 @@ const SelectPersona = memo(() => {
             <div className={classes.controller}>
                 <Button
                     variant="contained"
-                    className={classNames(classes.button, classes.secondaryButton)}
+                    className={cx(classes.button, classes.secondaryButton)}
                     disabled={personas && personas.length >= MAX_PERSONA_LIMIT}
                     onClick={() => {
                         browser.tabs.create({

--- a/packages/mask/src/extension/popups/pages/Personas/components/DisconnectDialog/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Personas/components/DisconnectDialog/index.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react'
 import { Button, Dialog, DialogActions, DialogContent, Typography, DialogProps } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
-import classNames from 'classnames'
 import { formatPersonaFingerprint, type ProfileIdentifier } from '@masknet/shared-base'
 import { PersonaContext } from '../../hooks/usePersonaContext.js'
 import { LoadingButton } from '@mui/lab'
@@ -59,7 +58,7 @@ interface DisconnectDialogProps extends DialogProps {
 
 export const DisconnectDialog = memo<DisconnectDialogProps>(
     ({ open, onClose, unbundledIdentity, onConfirmDisconnect, confirmLoading }) => {
-        const { classes } = useStyles()
+        const { classes, cx } = useStyles()
         const { t } = useI18N()
         const { currentPersona } = PersonaContext.useContainer()
         if (!unbundledIdentity) return null
@@ -84,11 +83,11 @@ export const DisconnectDialog = memo<DisconnectDialogProps>(
                 <DialogActions className={classes.actions}>
                     <LoadingButton
                         loading={confirmLoading}
-                        className={classNames(classes.button, classes.confirmButton)}
+                        className={cx(classes.button, classes.confirmButton)}
                         onClick={onConfirmDisconnect}>
                         {t('confirm')}
                     </LoadingButton>
-                    <Button className={classNames(classes.button, classes.cancelButton)} onClick={onClose}>
+                    <Button className={cx(classes.button, classes.cancelButton)} onClick={onClose}>
                         {t('cancel')}
                     </Button>
                 </DialogActions>

--- a/packages/mask/src/extension/popups/pages/Personas/components/DisconnectWalletDialog/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Personas/components/DisconnectWalletDialog/index.tsx
@@ -4,7 +4,6 @@ import type { DialogProps } from '@mui/material'
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material'
 import { LoadingButton } from '@mui/lab'
 import { makeStyles } from '@masknet/theme'
-import classNames from 'classnames'
 import { Trans } from 'react-i18next'
 import { formatEthereumAddress } from '@masknet/web3-shared-evm'
 
@@ -66,7 +65,7 @@ export interface DisconnectWalletDialogProps extends DialogProps {
 
 export const DisconnectWalletDialog = memo<DisconnectWalletDialogProps>(
     ({ open, confirmLoading, onConfirmDisconnect, onClose, address, personaName }) => {
-        const { classes } = useStyles()
+        const { classes, cx } = useStyles()
         const { t } = useI18N()
 
         const handleConfirm = useCallback(async () => {
@@ -93,10 +92,10 @@ export const DisconnectWalletDialog = memo<DisconnectWalletDialogProps>(
                     <LoadingButton
                         onClick={handleConfirm}
                         loading={confirmLoading}
-                        className={classNames(classes.button, classes.confirmButton)}>
+                        className={cx(classes.button, classes.confirmButton)}>
                         {t('confirm')}
                     </LoadingButton>
-                    <Button className={classNames(classes.button, classes.cancelButton)} onClick={onClose}>
+                    <Button className={cx(classes.button, classes.cancelButton)} onClick={onClose}>
                         {t('cancel')}
                     </Button>
                 </DialogActions>

--- a/packages/mask/src/extension/popups/pages/Personas/components/ProfileList/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Personas/components/ProfileList/index.tsx
@@ -19,7 +19,6 @@ import Services from '../../../../../service.js'
 import { Icons } from '@masknet/icons'
 import { DisconnectDialog } from '../DisconnectDialog/index.js'
 import { NextIDProof } from '@masknet/web3-providers'
-import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 import urlcat from 'urlcat'
 import { MethodAfterPersonaSign } from '../../../Wallet/type.js'
@@ -239,7 +238,7 @@ export interface ProfileListUIProps {
 export const ProfileListUI = memo<ProfileListUIProps>(
     ({ networks, profiles, onConnect, onDisconnect, openProfilePage }) => {
         const { t } = useI18N()
-        const { classes } = useStyles()
+        const { classes, cx } = useStyles()
 
         return (
             <List dense className={classes.list}>
@@ -260,7 +259,7 @@ export const ProfileListUI = memo<ProfileListUIProps>(
                                 {avatar ? (
                                     <Avatar
                                         src={avatar}
-                                        className={classNames(
+                                        className={cx(
                                             classes.avatar,
                                             is_valid ? classes.verified_avatar : classes.unverified_avatar,
                                         )}
@@ -268,7 +267,7 @@ export const ProfileListUI = memo<ProfileListUIProps>(
                                 ) : (
                                     <div className={classes.avatar}>
                                         <Icons.GrayMasks
-                                            className={classNames(
+                                            className={cx(
                                                 classes.avatar,
                                                 is_valid ? classes.verified_avatar : classes.unverified_avatar,
                                             )}

--- a/packages/mask/src/extension/popups/pages/Wallet/SwitchWallet/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/SwitchWallet/index.tsx
@@ -8,7 +8,6 @@ import { useI18N } from '../../../../../utils/index.js'
 import { WalletRPC } from '../../../../../plugins/Wallet/messages.js'
 import { WalletItem } from './WalletItem.js'
 import { MAX_WALLET_LIMIT } from '@masknet/shared'
-import classNames from 'classnames'
 import { useWallet, useWalletPrimary, useWallets } from '@masknet/web3-hooks-base'
 import { Services } from '../../../../service.js'
 
@@ -53,7 +52,7 @@ const useStyles = makeStyles()({
 
 const SwitchWallet = memo(() => {
     const { t } = useI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
 
     const navigate = useNavigate()
     const wallet = useWallet(NetworkPluginID.PLUGIN_EVM)
@@ -99,7 +98,7 @@ const SwitchWallet = memo(() => {
             <div className={classes.controller}>
                 <Button
                     variant="contained"
-                    className={classNames(classes.button, classes.secondaryButton)}
+                    className={cx(classes.button, classes.secondaryButton)}
                     disabled={wallets.length >= MAX_WALLET_LIMIT}
                     onClick={handleClickCreate}>
                     {t('create')}

--- a/packages/mask/src/plugins/Avatar/Application/NFTInfo.tsx
+++ b/packages/mask/src/plugins/Avatar/Application/NFTInfo.tsx
@@ -16,7 +16,7 @@ interface NFTInfoProps extends withClasses<'root'> {
 
 export function NFTInfo(props: NFTInfoProps) {
     const { isNFT = false, loading = false, tooltip = '' } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const t = useI18N()
 
     if (loading) return <LoadingBase size={24} />

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatar.tsx
@@ -95,7 +95,7 @@ export interface NFTAvatarProps extends withClasses<'root'> {
 
 export function NFTAvatar(props: NFTAvatarProps) {
     const { onChange, hideWallet } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { pluginID } = useNetworkContext()
     const { account, chainId } = useChainContext()
     const [selectedToken, setSelectedToken] = useState<AllChainsNonFungibleToken | undefined>()

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatarButton.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatarButton.tsx
@@ -34,7 +34,7 @@ export interface NFTAvatarButtonProps extends withClasses<'root' | 'text'> {
 export function NFTAvatarButton(props: NFTAvatarButtonProps) {
     const { onClick } = props
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <div className={classes.root} onClick={onClick}>

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatarClip.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTAvatarClip.tsx
@@ -1,6 +1,4 @@
-import { useMemo } from 'react'
-import { v4 as uuid } from 'uuid'
-import classNames from 'classnames'
+import { useId } from 'react'
 import type { Keyframes } from '@emotion/serialize'
 import { keyframes, makeStyles, useStylesExtends } from '@masknet/theme'
 import { useLastRecognizedIdentity } from '../../../components/DataSource/useActivatedUI.js'
@@ -85,7 +83,7 @@ interface NamePathProps extends withClasses<'root'> {
     id: string
 }
 function NamePath(props: NamePathProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return (
         <path
             className={classes.root}
@@ -133,7 +131,7 @@ interface TextProps extends withClasses<'root'> {
 
 function Text(props: TextProps) {
     const { xlinkHref, fontSize = 12, text, fill, dominantBaseline = 'mathematical' } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return (
         <text x="0%" textAnchor="middle" fill={fill} fontFamily="sans-serif" className={classes.root}>
             <textPath xlinkHref={xlinkHref} startOffset="50%" rotate="auto" dominantBaseline={dominantBaseline}>
@@ -147,8 +145,8 @@ function Text(props: TextProps) {
 
 export function NFTAvatarClip(props: NFTAvatarClipProps) {
     const { width, height, viewBoxHeight = ViewBoxHeight, viewBoxWidth = ViewBoxWidth, screenName } = props
-    const id = useMemo(() => props.id ?? uuid(), [props.id])
-    const classes = useStylesExtends(useStyles(), props)
+    const id = useId()
+    const { classes, cx } = useStylesExtends(useStyles(), props)
     const { loading, value: avatarMetadata } = useNFTContainerAtTwitter(screenName)
     const { account } = useChainContext()
     const { value = { amount: '0', symbol: 'ETH', name: '', slug: '' }, loading: loadingNFT } = useNFT(
@@ -203,10 +201,7 @@ export function NFTAvatarClip(props: NFTAvatarClipProps) {
 
                 <use xlinkHref={`#${id}-border-path`} className={classes.background} />
 
-                <use
-                    xlinkHref={`#${id}-border-path`}
-                    className={classNames(classes.rainbowBorder, classes.borderPath)}
-                />
+                <use xlinkHref={`#${id}-border-path`} className={cx(classes.rainbowBorder, classes.borderPath)} />
                 <g className={classes.text}>
                     <Text
                         xlinkHref={`#${id}-name-path`}
@@ -236,8 +231,8 @@ export function NFTAvatarClip(props: NFTAvatarClipProps) {
 
 export function NFTAvatarMiniClip(props: NFTAvatarClipProps) {
     const { width, height, viewBoxHeight = ViewBoxHeight, viewBoxWidth = ViewBoxWidth, screenName, className } = props
-    const id = useMemo(() => props.id ?? uuid(), [props.id])
-    const classes = useStylesExtends(useStyles(), props)
+    const id = useId()
+    const { classes, cx } = useStylesExtends(useStyles(), props)
     const identity = useLastRecognizedIdentity()
     const { loading, value: avatarMetadata } = useNFTContainerAtTwitter(screenName ?? identity.identifier?.userId)
 
@@ -245,7 +240,7 @@ export function NFTAvatarMiniClip(props: NFTAvatarClipProps) {
 
     return (
         <svg
-            className={classNames(classes.root, className)}
+            className={cx(classes.root, className)}
             width={width}
             height={height}
             id={id}
@@ -257,10 +252,7 @@ export function NFTAvatarMiniClip(props: NFTAvatarClipProps) {
                 <BorderPath id={id} transform={`scale(${width / viewBoxWidth})`} />
             </clipPath>
             <g>
-                <use
-                    xlinkHref={`#${id}-border-path`}
-                    className={classNames(classes.rainbowBorder, classes.miniBorder)}
-                />
+                <use xlinkHref={`#${id}-border-path`} className={cx(classes.rainbowBorder, classes.miniBorder)} />
             </g>
         </svg>
     )

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTBadge.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTBadge.tsx
@@ -25,7 +25,7 @@ interface NFTBadgeProps extends withClasses<'root' | 'text' | 'icon'> {
 
 export function NFTBadge(props: NFTBadgeProps) {
     const { avatar, nftInfo, size = 140, hasRainbow, borderSize } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { t } = useI18N()
 
     if (!nftInfo)

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTBadgeTimeline.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTBadgeTimeline.tsx
@@ -25,7 +25,7 @@ export function NFTBadgeTimeline(props: NFTBadgeTimelineProps) {
     const { loading, value: _avatar } = usePersonaNFTAvatar(userId, avatarId, '', snsKey)
     const [avatar, setAvatar] = useState<AvatarMetaDB>()
     const [avatarId_, setAvatarId_] = useState('')
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const onUpdate = (data: AvatarMetaDB) => {
         if (!data.address || !data.tokenId) {

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTImage.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/NFTImage.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { makeStyles } from '@masknet/theme'
 import { isSameAddress } from '@masknet/web3-shared-base'
 import { NetworkPluginID } from '@masknet/shared-base'
@@ -101,10 +100,7 @@ export function NFTImage(props: NFTImageProps) {
                     }}
                     onClick={() => onClick(token)}
                     src={token.metadata?.imageURL ?? ''}
-                    className={classNames(
-                        classes.image,
-                        isSameNFT(pluginID, token, selectedToken) ? classes.selected : '',
-                    )}
+                    className={cx(classes.image, isSameNFT(pluginID, token, selectedToken) ? classes.selected : '')}
                 />
                 {showBadge && isSameNFT(pluginID, token, selectedToken) ? (
                     <SelectedIcon className={classes.icon} />

--- a/packages/mask/src/plugins/Avatar/SNSAdaptor/RainbowBox.tsx
+++ b/packages/mask/src/plugins/Avatar/SNSAdaptor/RainbowBox.tsx
@@ -54,7 +54,7 @@ interface RainbowBoxProps extends withClasses<'root'> {
     children?: React.ReactNode
 }
 export function RainbowBox(props: RainbowBoxProps) {
-    const classes = useStylesExtends(
+    const { classes } = useStylesExtends(
         useStyles({
             width: props.width,
             height: props.height,

--- a/packages/mask/src/plugins/Collectible/src/SNSAdaptor/Card/CollectibleCard.tsx
+++ b/packages/mask/src/plugins/Collectible/src/SNSAdaptor/Card/CollectibleCard.tsx
@@ -21,7 +21,7 @@ export interface CollectibleCardProps extends withClasses<'root' | 'content'> {
 }
 
 export function CollectibleCard(props: CollectibleCardProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <Card className={classes.root} elevation={0} {...props.CardProps}>

--- a/packages/mask/src/plugins/Collectible/src/SNSAdaptor/List/CollectionIcon.tsx
+++ b/packages/mask/src/plugins/Collectible/src/SNSAdaptor/List/CollectionIcon.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react'
-import classNames from 'classnames'
 import { Box, Tooltip } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { Image, Icon } from '@masknet/shared'
@@ -38,7 +37,7 @@ export interface CollectionIconProps {
 }
 
 export const CollectionIcon = memo<CollectionIconProps>(({ collection, onClick, selectedCollection }) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
 
     const name = collection?.name ?? collection?.symbol ?? 'Unknown'
     // CollectionIcon should not display a character
@@ -53,7 +52,7 @@ export const CollectionIcon = memo<CollectionIconProps>(({ collection, onClick, 
             title={collection?.name ?? ''}
             arrow>
             <Box
-                className={classNames(
+                className={cx(
                     classes.collectionWrap,
                     isSameAddress(collection?.address, selectedCollection) ? classes.selected : '',
                 )}

--- a/packages/mask/src/plugins/CryptoartAI/SNSAdaptor/CollectibleTab.tsx
+++ b/packages/mask/src/plugins/CryptoartAI/SNSAdaptor/CollectibleTab.tsx
@@ -16,7 +16,7 @@ export interface CollectibleTabProps extends withClasses<'root' | 'content'> {
 }
 
 export function CollectibleTab(props: CollectibleTabProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <Card className={classes.root} elevation={0} {...props.CardProps}>

--- a/packages/mask/src/plugins/FindTruman/SNSAdaptor/PartsPanel.tsx
+++ b/packages/mask/src/plugins/FindTruman/SNSAdaptor/PartsPanel.tsx
@@ -102,7 +102,6 @@ const useStyles = makeStyles()((theme, props) => ({
 interface PartsPanelProps {}
 
 export default function PartsPanel(props: PartsPanelProps) {
-    const { classes } = useStyles()
     const { t } = useContext(FindTrumanContext)
     const { account } = useChainContext()
 

--- a/packages/mask/src/plugins/Game/SNSAdaptor/GameList.tsx
+++ b/packages/mask/src/plugins/Game/SNSAdaptor/GameList.tsx
@@ -110,7 +110,7 @@ const GameList = (props: Props) => {
 
     return (
         <>
-            <List className={classes.walletBar}>
+            <List>
                 <Typography className={classes.title}>{t.game_list_title()}</Typography>
                 <ul className={classes.gameList}>
                     {gameList

--- a/packages/mask/src/plugins/Game/SNSAdaptor/GameList.tsx
+++ b/packages/mask/src/plugins/Game/SNSAdaptor/GameList.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react'
 import { Button, List, Typography } from '@mui/material'
 import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material'
-import { makeStyles, useStylesExtends } from '@masknet/theme'
+import { makeStyles } from '@masknet/theme'
 import { useI18N } from '../locales/index.js'
 import { useGameList } from '../hook/index.js'
 import type { GameInfo } from '../types.js'
-import classNames from 'classnames'
 
 const useStyles = makeStyles()(() => ({
     title: {
@@ -93,7 +92,7 @@ interface Props {
 
 const GameList = (props: Props) => {
     const t = useI18N()
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes, cx } = useStyles()
     const gameList = useGameList()
     const [descTypes, setDescTypes] = useState<boolean[]>([])
     useEffect(() => {
@@ -122,13 +121,13 @@ const GameList = (props: Props) => {
                                       <Typography className={classes.infoTitle}>{game.name}</Typography>
                                       <div className={classes.introductionRow}>
                                           <Typography
-                                              className={classNames(classes.introduction, {
+                                              className={cx(classes.introduction, {
                                                   [classes.isOpen]: descTypes[index],
                                               })}>
                                               {game.description}
                                           </Typography>
                                           <ArrowDropDownIcon
-                                              className={classNames(classes.arrowBtn, {
+                                              className={cx(classes.arrowBtn, {
                                                   [classes.isTurn]: descTypes[index],
                                               })}
                                               onClick={() => toggleDescType(index)}

--- a/packages/mask/src/plugins/Game/SNSAdaptor/GameWindow.tsx
+++ b/packages/mask/src/plugins/Game/SNSAdaptor/GameWindow.tsx
@@ -1,9 +1,8 @@
 import { useState, useMemo } from 'react'
 import { useLocation } from 'react-use'
 import urlcat from 'urlcat'
-import classNames from 'classnames'
 import { styled } from '@mui/material/styles'
-import { makeStyles, useStylesExtends } from '@masknet/theme'
+import { makeStyles } from '@masknet/theme'
 import { IconClose, IconFull, IconShare } from '../constants.js'
 import { getCurrentIdentifier } from '../../../social-network-adaptor/utils.js'
 import { useChainContext } from '@masknet/web3-hooks-base'
@@ -90,7 +89,7 @@ interface Props {
 
 const GameWindow = (props: Props) => {
     const { gameInfo, tokenProps, isShow, onClose } = props
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes, cx } = useStyles()
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
 
     const [isFullScreen, setFullScreen] = useState(false)
@@ -134,14 +133,12 @@ const GameWindow = (props: Props) => {
     ])
 
     return isShow ? (
-        <div className={classNames(classes.root, { [classes.shadow]: props.isShadow })}>
+        <div className={cx(classes.root, { [classes.shadow]: props.isShadow })}>
             <div className={classes.body}>
-                <div
-                    className={classNames(classes.iframeBox, { [classes.fullScreen]: isFullScreen })}
-                    style={windowStyle}>
+                <div className={cx(classes.iframeBox, { [classes.fullScreen]: isFullScreen })} style={windowStyle}>
                     {!!gameInfo?.url && <IFrame src={gameUrl} />}
                 </div>
-                <div className={classNames(classes.control, { [classes.fullControl]: isFullScreen })}>
+                <div className={cx(classes.control, { [classes.fullControl]: isFullScreen })}>
                     <img src={IconClose} onClick={handleClose} alt="close" />
                     <img src={IconFull} onClick={toggleFullscreen} alt="fullscreen" />
                     {profile?.identifier.network === EnhanceableSite.Twitter ? (

--- a/packages/mask/src/plugins/Gitcoin/SNSAdaptor/DonateDialog.tsx
+++ b/packages/mask/src/plugins/Gitcoin/SNSAdaptor/DonateDialog.tsx
@@ -51,7 +51,7 @@ export interface DonateDialogProps extends withClasses<never> {}
 export function DonateDialog(props: DonateDialogProps) {
     const { t: tr } = useBaseI18N()
     const t = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const [title, setTitle] = useState('')
     const [address, setAddress] = useState('')
     const [postLink, setPostLink] = useState<string | URL>('')

--- a/packages/mask/src/plugins/GoodGhosting/UI/TimelineView.tsx
+++ b/packages/mask/src/plugins/GoodGhosting/UI/TimelineView.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@masknet/theme'
 import type { GoodGhostingInfo } from '../types.js'
 import formatDateTime from 'date-fns/format'
 import isBefore from 'date-fns/isBefore'
-import classNames from 'classnames'
 import { useTimeline } from '../hooks/useGameInfo.js'
 
 const useStyles = makeStyles()((theme) => ({
@@ -81,7 +80,7 @@ interface TimelineViewProps {
 }
 
 export function TimelineView(props: TimelineViewProps) {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const timeline = useTimeline(props.info)
 
     return (
@@ -98,13 +97,13 @@ export function TimelineView(props: TimelineViewProps) {
                                 {formatDateTime(timelineEvent.date, 'HH:mm EEE d LLL O')}
                             </Typography>
                             <div
-                                className={classNames(
+                                className={cx(
                                     classes.verticalLine,
                                     index % 2 === 0 ? classes.tallVerticalLine : classes.shortVerticalLine,
                                 )}
                             />
                             <div
-                                className={classNames(
+                                className={cx(
                                     classes.circleIndicator,
                                     isBefore(new Date(), timelineEvent.date)
                                         ? classes.circleIndicatorFilled
@@ -115,7 +114,7 @@ export function TimelineView(props: TimelineViewProps) {
                         <div className={classes.eventText}>
                             {index === timeline.length - 1 && (
                                 <div
-                                    className={classNames(
+                                    className={cx(
                                         classes.circleIndicator,
                                         classes.circleIndicatorFilled,
                                         classes.rightAligned,

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/ClaimAllDialog.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/ClaimAllDialog.tsx
@@ -1,5 +1,4 @@
 import { useState, useLayoutEffect, useRef, useCallback } from 'react'
-import classNames from 'classnames'
 import { flatten, uniq } from 'lodash-unified'
 import formatDateTime from 'date-fns/format'
 import { useChainContext, useFungibleToken, useNetworkContext, useFungibleTokens } from '@masknet/web3-hooks-base'
@@ -221,7 +220,7 @@ export function ClaimAllDialog(props: ClaimAllDialogProps) {
             },
         })
     }, [claimCallback, openShareTxDialog, retry])
-    const { classes } = useStyles({
+    const { classes, cx } = useStyles({
         shortITOwrapper: !swappedTokens || swappedTokens.length === 0,
     })
     const [initLoading, setInitLoading] = useState(true)
@@ -275,7 +274,7 @@ export function ClaimAllDialog(props: ClaimAllDialogProps) {
                                 <WalletConnectedBoundary>
                                     <ActionButton
                                         fullWidth
-                                        className={classNames(classes.actionButton)}
+                                        className={cx(classes.actionButton)}
                                         loading={isClaiming}
                                         disabled={claimablePids!.length === 0}
                                         onClick={claim}>
@@ -319,7 +318,7 @@ interface SwappedTokensProps {
 function SwappedToken({ i, swappedToken, chainId }: SwappedTokensProps) {
     const { t } = useI18N()
     const theme = useTheme()
-    const { classes } = useStyles({ shortITOwrapper: false })
+    const { classes, cx } = useStyles({ shortITOwrapper: false })
     const { value: _token } = useFungibleToken(NetworkPluginID.PLUGIN_EVM, swappedToken.token.address, undefined, {
         chainId,
     })
@@ -327,7 +326,7 @@ function SwappedToken({ i, swappedToken, chainId }: SwappedTokensProps) {
     return (
         <ListItem key={i} className={classes.tokenCard}>
             <div
-                className={classNames(
+                className={cx(
                     classes.cardHeader,
                     swappedToken.isClaimable ? classes.cardHeaderClaimable : classes.cardHeaderLocked,
                 )}>
@@ -359,7 +358,7 @@ function SwappedToken({ i, swappedToken, chainId }: SwappedTokensProps) {
                 )}
             </div>
             <Typography
-                className={classNames(
+                className={cx(
                     classes.cardContent,
                     swappedToken.isClaimable ? classes.cardContentClaimable : classes.cardContentLocked,
                 )}>

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/CreateForm.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/CreateForm.tsx
@@ -1,6 +1,5 @@
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { v4 as uuid } from 'uuid'
-import classNames from 'classnames'
 import Web3Utils from 'web3-utils'
 import formatDateTime from 'date-fns/format'
 import { SchemaType, formatAmount, useITOConstants, ChainId } from '@masknet/web3-shared-evm'
@@ -127,7 +126,7 @@ export interface CreateFormProps extends withClasses<never> {
 export function CreateForm(props: CreateFormProps) {
     const { onChangePoolSettings, onNext, origin, chainId } = props
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
 
     const { account } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const { ITO2_CONTRACT_ADDRESS, DEFAULT_QUALIFICATION2_ADDRESS } = useITOConstants(chainId)
@@ -424,7 +423,7 @@ export function CreateForm(props: CreateFormProps) {
             ) : null}
             {advanceSettingData.delayUnlocking ? <Box className={classes.date}>{UnlockTime}</Box> : null}
             {account && advanceSettingData.contract ? (
-                <Box className={classNames(classes.line, classes.column)}>
+                <Box className={cx(classes.line, classes.column)}>
                     <InputBase
                         className={classes.input}
                         onChange={(e) => setQualificationAddress(e.currentTarget.value)}
@@ -436,13 +435,13 @@ export function CreateForm(props: CreateFormProps) {
                         }
                         endAdornment={
                             qualification?.isQualification ? (
-                                <Box className={classNames(classes.iconWrapper, classes.success)}>
+                                <Box className={cx(classes.iconWrapper, classes.success)}>
                                     <CheckIcon fontSize="small" style={{ color: '#77E0B5' }} />
                                 </Box>
                             ) : qualification?.loadingERC165 || loadingQualification ? (
                                 <LoadingBase size={16} />
                             ) : qualificationAddress.length > 0 ? (
-                                <Box className={classNames(classes.iconWrapper, classes.fail)}>
+                                <Box className={cx(classes.iconWrapper, classes.fail)}>
                                     <UnCheckIcon fontSize="small" style={{ color: '#ff4e59' }} />
                                 </Box>
                             ) : null

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/ITO.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/ITO.tsx
@@ -12,7 +12,6 @@ import { Box, Card, Link, Typography } from '@mui/material'
 import { makeStyles, ActionButton } from '@masknet/theme'
 import { OpenInNew as OpenInNewIcon } from '@mui/icons-material'
 import { BigNumber } from 'bignumber.js'
-import classNames from 'classnames'
 import formatDateTime from 'date-fns/format'
 import { startCase } from 'lodash-unified'
 import { EnhanceableSite, NetworkPluginID } from '@masknet/shared-base'
@@ -232,7 +231,7 @@ export function ITO(props: ITO_Props) {
 
     const title = message.split(MSG_DELIMITER)[1] ?? message
     const regions = message.split(MSG_DELIMITER)[2] ?? defaultRegions
-    const { classes } = useStyles({
+    const { classes, cx } = useStyles({
         titleLength: getTextUILength(title),
         tokenNumber: exchange_tokens.length,
         snsId: activatedSocialNetworkUI.networkIdentifier,
@@ -518,7 +517,7 @@ export function ITO(props: ITO_Props) {
                             variant="roundedDark"
                             onClick={() => undefined}
                             disabled
-                            className={classNames(classes.actionButton, classes.textInOneLine)}>
+                            className={cx(classes.actionButton, classes.textInOneLine)}>
                             {t('plugin_ito_claim')}
                         </ActionButton>
                     )
@@ -798,11 +797,11 @@ export function ITO(props: ITO_Props) {
 export function ITO_Loading() {
     const { t } = useI18N()
     const PoolBackground = getAssetAsBlobURL(new URL('../assets/pool-loading-background.jpg', import.meta.url))
-    const { classes } = useStyles({})
+    const { classes, cx } = useStyles({})
     return (
         <div style={{ width: '100%' }}>
             <Card
-                className={classNames(classes.root, classes.loadingWrap)}
+                className={cx(classes.root, classes.loadingWrap)}
                 elevation={0}
                 style={{ backgroundImage: `url(${PoolBackground})` }}>
                 <Typography variant="body1" className={classes.loadingITO}>
@@ -815,11 +814,11 @@ export function ITO_Loading() {
 
 export function ITO_Error({ retryPoolPayload }: { retryPoolPayload: () => void }) {
     const { t } = useI18N()
-    const { classes } = useStyles({})
+    const { classes, cx } = useStyles({})
     const PoolBackground = getAssetAsBlobURL(new URL('../assets/pool-loading-background.jpg', import.meta.url))
     return (
         <Card
-            className={classNames(classes.root, classes.loadingWrap)}
+            className={cx(classes.root, classes.loadingWrap)}
             elevation={0}
             style={{ backgroundImage: `url(${PoolBackground})` }}>
             <Typography variant="body1" className={classes.loadingITO}>

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/ITO_Card.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/ITO_Card.tsx
@@ -57,7 +57,7 @@ export interface ITO_CardProps extends withClasses<never> {
 export function ITO_Card(props: ITO_CardProps) {
     const { token, onUpdateAmount, onUpdateBalance } = props
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { value: packet, loading: packetLoading, error: packetError, retry: packetRetry } = useMaskITO_Packet()
 
     // #region claim

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/RemindDialog.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/RemindDialog.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
-import classNames from 'classnames'
 import { Checkbox, FormControlLabel, Link, Typography } from '@mui/material'
-import { makeStyles, useStylesExtends, ActionButton } from '@masknet/theme'
+import { makeStyles, ActionButton } from '@masknet/theme'
 import { FormattedAddress, TokenIcon } from '@masknet/shared'
 import { useI18N } from '../../../utils/index.js'
 import { ChainId, formatEthereumAddress, explorerResolver, networkResolver, SchemaType } from '@masknet/web3-shared-evm'
@@ -76,14 +75,14 @@ export function RemindDialog(props: RemindDialogProps) {
     const { token, chainId, setStatus } = props
 
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes, cx } = useStyles()
     const [agreeReminder, setAgreeReminder] = useState(false)
     const { networkType } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
 
     return (
         <>
             <section className={classes.wrapper}>
-                <Typography variant="body1" className={classNames(classes.reminderText, classes.reminderTextFirst)}>
+                <Typography variant="body1" className={cx(classes.reminderText, classes.reminderTextFirst)}>
                     {t('plugin_ito_dialog_claim_reminder_text1', {
                         networkType: networkResolver.networkName(networkType),
                     })}
@@ -94,11 +93,11 @@ export function RemindDialog(props: RemindDialogProps) {
                 <Typography variant="body1" className={classes.reminderText}>
                     {t('plugin_ito_dialog_claim_reminder_text3')}
                 </Typography>
-                <Typography variant="body1" className={classNames(classes.reminderText, classes.reminderTextLast)}>
+                <Typography variant="body1" className={cx(classes.reminderText, classes.reminderTextLast)}>
                     {t('plugin_ito_dialog_claim_reminder_text4')}
                 </Typography>
             </section>
-            <section className={classNames(classes.wrapper, classes.tokenWrapper)}>
+            <section className={cx(classes.wrapper, classes.tokenWrapper)}>
                 <TokenIcon
                     className={classes.tokenIcon}
                     chainId={token.chainId}

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/ShareDialog.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/ShareDialog.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, useStylesExtends, ActionButton } from '@masknet/theme'
+import { makeStyles, ActionButton } from '@masknet/theme'
 import { FungibleToken, formatBalance, isZero } from '@masknet/web3-shared-base'
 import type { ChainId, SchemaType } from '@masknet/web3-shared-evm'
 import { Box, Typography } from '@mui/material'
@@ -63,7 +63,7 @@ export interface ShareDialogProps extends withClasses<'root'> {
 export function ShareDialog(props: ShareDialogProps) {
     const ShareBackground = getAssetAsBlobURL(new URL('../assets/share-background.jpg', import.meta.url))
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes } = useStyles()
     const { token, actualSwapAmount, shareSuccessText, onClose } = props
     const amount = formatBalance(actualSwapAmount, token.decimals)
 

--- a/packages/mask/src/plugins/ITO/SNSAdaptor/SwapDialog.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/SwapDialog.tsx
@@ -93,7 +93,7 @@ export function SwapDialog(props: SwapDialogProps) {
 
     const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const { Token } = useWeb3State(NetworkPluginID.PLUGIN_EVM)
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { NATIVE_TOKEN_ADDRESS } = useTokenConstants()
     const [ratio, setRatio] = useState<BigNumber>(
         new BigNumber(payload.exchange_amounts[0 * 2]).dividedBy(payload.exchange_amounts[0 * 2 + 1]),

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/Animate.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/Animate.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { makeStyles, useStylesExtends } from '@masknet/theme'
+import { makeStyles } from '@masknet/theme'
 import { useValueRef } from '@masknet/shared-base-ui'
 import { useEssay, useDefaultEssay, useCurrentVisitingUser } from '../hooks/index.js'
 import { ModelNFT } from './ModelNFT.js'
@@ -17,7 +17,7 @@ const useStyles = makeStyles()(() => ({
 }))
 
 const AnimatePic = () => {
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes } = useStyles()
 
     const petShow = useValueRef<boolean>(petShowSettings)
 

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/ModelNFT.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/ModelNFT.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react'
-import { makeStyles, useStylesExtends } from '@masknet/theme'
+import { makeStyles } from '@masknet/theme'
 import { Box } from '@mui/material'
-import classNames from 'classnames'
 import Drag from './Drag.js'
 import ModelView from './ModelView.js'
-import { useStyles as boxUseStyles } from './PreviewBox.js'
+import { useStyles as useBoxStyles } from './PreviewBox.js'
 import { DragIcon } from '../constants.js'
 import type { ShowMeta } from '../types.js'
 import RightMenu from './RightMenu.js'
@@ -54,8 +53,8 @@ interface ModelNFTProps {
 
 export function ModelNFT(props: ModelNFTProps) {
     const { start, showMeta } = props
-    const classes = useStylesExtends(useStyles(), {})
-    const boxClasses = useStylesExtends(boxUseStyles(), {})
+    const { classes, cx } = useStyles()
+    const { classes: boxClasses } = useBoxStyles()
     const [position, setPosition] = useState({ x: 50, y: 150 })
     const moveHandle = (x: number, y: number) => {
         setPosition({ x, y })
@@ -95,9 +94,7 @@ export function ModelNFT(props: ModelNFTProps) {
                 </div>
                 {start && showMeta?.word ? (
                     <Box className={classes.wordContent}>
-                        <Box className={classNames(classes.word, boxClasses.msgBox, boxClasses.wordShow)}>
-                            {showMeta?.word}
-                        </Box>
+                        <Box className={cx(classes.word, boxClasses.msgBox, boxClasses.wordShow)}>{showMeta?.word}</Box>
                     </Box>
                 ) : null}
             </Drag>

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/NormalNFT.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/NormalNFT.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
-import { makeStyles, useStylesExtends } from '@masknet/theme'
+import { makeStyles } from '@masknet/theme'
 import { Box } from '@mui/material'
 import { useStyles as useBoxStyles } from './PreviewBox.js'
-import classNames from 'classnames'
 import Drag from './Drag.js'
 import type { ShowMeta } from '../types.js'
 import { CloseIcon } from '../constants.js'
@@ -55,8 +54,8 @@ interface NormalNFTProps {
 
 export function NormalNFT(props: NormalNFTProps) {
     const { start, infoShow, showMeta, handleClose } = props
-    const classes = useStylesExtends(useStyles(), {})
-    const boxClasses = useStylesExtends(useBoxStyles(), {})
+    const { classes, cx } = useStyles()
+    const { classes: boxClasses } = useBoxStyles()
 
     const [isMenuShow, setMenuShow] = useState(false)
     const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
@@ -81,7 +80,7 @@ export function NormalNFT(props: NormalNFTProps) {
             {start && showMeta?.word ? (
                 <Box className={classes.wordContent}>
                     <Box
-                        className={classNames(
+                        className={cx(
                             {
                                 [boxClasses.msgBox]: true,
                                 [boxClasses.wordShow]: true,

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/PetSetDialog.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/PetSetDialog.tsx
@@ -2,14 +2,7 @@ import { useState, useMemo, ReactNode } from 'react'
 import { useTimeout } from 'react-use'
 import type { Constant } from '@masknet/web3-shared-base'
 import { NetworkPluginID } from '@masknet/shared-base'
-import {
-    makeStyles,
-    useStylesExtends,
-    useCustomSnackbar,
-    ShadowRootPopper,
-    ActionButton,
-    LoadingBase,
-} from '@masknet/theme'
+import { makeStyles, useCustomSnackbar, ShadowRootPopper, ActionButton, LoadingBase } from '@masknet/theme'
 import { useValueRef } from '@masknet/shared-base-ui'
 import {
     Typography,
@@ -112,7 +105,7 @@ interface PetSetDialogProps {
 
 export function PetSetDialog({ configNFTs, onClose }: PetSetDialogProps) {
     const t = useI18N()
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes } = useStyles()
     const theme = useTheme()
     const { showSnackbar } = useCustomSnackbar()
     const [loading, setLoading] = useState(false)

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/PreviewBox.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/PreviewBox.tsx
@@ -1,6 +1,5 @@
-import { makeStyles, useStylesExtends } from '@masknet/theme'
+import { makeStyles } from '@masknet/theme'
 import { Typography } from '@mui/material'
-import classNames from 'classnames'
 import { useI18N } from '../locales/index.js'
 import type { OwnerERC721TokenInfo } from '../types.js'
 import { ImageLoader } from './ImageLoader.js'
@@ -121,7 +120,7 @@ interface Props {
 }
 
 export function PreviewBox(props: Props) {
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes, cx } = useStyles()
     const t = useI18N()
 
     const renderPreview = (mediaUrl: string, imageUrl: string) => {
@@ -143,7 +142,7 @@ export function PreviewBox(props: Props) {
         <div className={classes.box}>
             {props.message && (
                 <div
-                    className={classNames({
+                    className={cx({
                         [classes.msgBox]: true,
                         [classes.wordShow]: true,
                     })}>

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/RightMenu.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/RightMenu.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
 import { makeStyles } from '@masknet/theme'
-import classNames from 'classnames'
 import { useRemoteControlledDialog } from '@masknet/shared-base-ui'
 import { Typography } from '@mui/material'
 import { PluginPetMessages } from '../messages.js'
@@ -67,7 +66,7 @@ const useStyles = makeStyles()(() => ({
 
 function RightMenu(props: Props) {
     const t = useI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const refMenuDom = useRef<HTMLDivElement>(null)
     const visitor = useCurrentVisitingUser(0)
     const whoAmI = useLastRecognizedIdentity()
@@ -124,7 +123,7 @@ function RightMenu(props: Props) {
             ref={refMenuDom}
             onMouseDown={stopPop}
             onMouseUp={stopPop}
-            className={classNames(classes.menu, {
+            className={cx(classes.menu, {
                 [classes.show]: props.isShow,
             })}
             style={{

--- a/packages/mask/src/plugins/PoolTogether/UI/CountdownView.tsx
+++ b/packages/mask/src/plugins/PoolTogether/UI/CountdownView.tsx
@@ -47,7 +47,7 @@ interface CountdownProps extends withClasses<'digit' | 'separator'> {
 }
 
 export const CountdownView = (props: CountdownProps) => {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const { secondsRemaining, msgOnEnd } = props
     const [secs, setSecs] = useState(secondsRemaining)

--- a/packages/mask/src/plugins/PoolTogether/UI/NetworkView.tsx
+++ b/packages/mask/src/plugins/PoolTogether/UI/NetworkView.tsx
@@ -22,7 +22,7 @@ interface NetworkViewProps extends withClasses<never> {
 }
 
 export const NetworkView = (props: NetworkViewProps) => {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { chainId = ChainId.Mainnet } = props
     const networkProvider = useNetworkDescriptor(NetworkPluginID.PLUGIN_EVM)
     return (

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftList.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftList.tsx
@@ -1,7 +1,6 @@
 import { makeStyles, MaskColorVar } from '@masknet/theme'
 import { ChainId, formatTokenId, SchemaType } from '@masknet/web3-shared-evm'
 import { List, ListItem, ListProps, Typography } from '@mui/material'
-import classnames from 'classnames'
 import { FC, HTMLProps, useState } from 'react'
 import { NFTCardStyledAssetPlayer } from '@masknet/shared'
 import type { NonFungibleTokenContract } from '@masknet/web3-shared-base'
@@ -89,11 +88,11 @@ interface NftItemProps extends HTMLProps<HTMLDivElement> {
 
 export const NftItem: FC<NftItemProps> = ({ contract, tokenId, className, claimed, renderOrder, ...rest }) => {
     const t = useI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const [name, setName] = useState(formatTokenId(tokenId, 2))
 
     return (
-        <div className={classnames(className, classes.nft)} {...rest}>
+        <div className={cx(className, classes.nft)} {...rest}>
             <NFTCardStyledAssetPlayer
                 classes={{
                     fallbackImage: classes.fallbackImage,
@@ -117,9 +116,9 @@ interface NftListProps extends ListProps {
 }
 
 export const NftList: FC<NftListProps> = ({ contract, statusList, tokenIds, className, ...rest }) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     return (
-        <List className={classnames(className, classes.list)} {...rest}>
+        <List className={cx(className, classes.list)} {...rest}>
             {tokenIds.map((tokenId, index) => (
                 <ListItem className={classes.listItem} key={tokenId}>
                     <NftItem contract={contract} claimed={statusList[index]} tokenId={tokenId} renderOrder={index} />

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryItem.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryItem.tsx
@@ -1,5 +1,4 @@
 import { FC, memo, MouseEventHandler, useCallback } from 'react'
-import classNames from 'classnames'
 import { fill } from 'lodash-unified'
 import { TokenIcon } from '@masknet/shared'
 import { useRemoteControlledDialog } from '@masknet/shared-base-ui'
@@ -131,7 +130,7 @@ export const NftRedPacketHistoryItem: FC<NftRedPacketHistoryItemProps> = memo(
     ({ history, onSend, onShowPopover, onHidePopover }) => {
         const { account } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
         const t = useI18N()
-        const { classes } = useStyles()
+        const { classes, cx } = useStyles()
         const {
             computed: { canSend, isPasswordValid },
         } = useNftAvailabilityComputed(account, history.payload)
@@ -180,10 +179,10 @@ export const NftRedPacketHistoryItem: FC<NftRedPacketHistoryItemProps> = memo(
                             <div>
                                 <Typography
                                     variant="body1"
-                                    className={classNames(classes.title, classes.message, classes.ellipsis)}>
+                                    className={cx(classes.title, classes.message, classes.ellipsis)}>
                                     {history.message === '' ? t.best_wishes() : history.message}
                                 </Typography>
-                                <Typography variant="body1" className={classNames(classes.info, classes.message)}>
+                                <Typography variant="body1" className={cx(classes.info, classes.message)}>
                                     {t.history_duration({
                                         startTime: dateTimeFormat(new Date(history.creation_time)),
                                         endTime: dateTimeFormat(
@@ -198,10 +197,7 @@ export const NftRedPacketHistoryItem: FC<NftRedPacketHistoryItemProps> = memo(
                                     onMouseEnter={handleMouseEnter}
                                     onMouseLeave={onHidePopover}
                                     onClick={handleSend}
-                                    className={classNames(
-                                        classes.actionButton,
-                                        isPasswordValid ? '' : classes.disabledButton,
-                                    )}
+                                    className={cx(classes.actionButton, isPasswordValid ? '' : classes.disabledButton)}
                                     size="large">
                                     {t.send()}
                                 </ActionButton>

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryList.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryList.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from 'react'
-import classNames from 'classnames'
 import { useScrollBottomEvent } from '@masknet/shared-base-ui'
 import { makeStyles, LoadingBase } from '@masknet/theme'
 import type { NetworkPluginID } from '@masknet/shared-base'
@@ -89,7 +88,7 @@ interface Props {
 }
 
 export function NftRedPacketHistoryList({ onSend }: Props) {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const t = useI18N()
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const { histories, fetchMore, loading } = useNftRedPacketHistory(account, chainId)
@@ -158,9 +157,7 @@ export function NftRedPacketHistoryList({ onSend }: Props) {
                     return (
                         <div className={classes.popperContent}>
                             <Typography className={classes.popperText}>{popperText}</Typography>
-                            <div
-                                className={classNames(classes.arrow, placement === 'bottom' ? classes.atBottom : '')}
-                            />
+                            <div className={cx(classes.arrow, placement === 'bottom' ? classes.atBottom : '')} />
                         </div>
                     )
                 }}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacket/index.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacket/index.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { useCallback, useMemo } from 'react'
 import { Card, keyframes, Typography } from '@mui/material'
 import { ChainId, chainResolver, networkResolver } from '@masknet/web3-shared-evm'
@@ -248,7 +247,7 @@ export function RedPacket(props: RedPacketProps) {
 
     return (
         <>
-            <Card className={classNames(classes.root)} component="article" elevation={0}>
+            <Card className={classes.root} component="article" elevation={0}>
                 <div className={classes.header}>
                     {/* it might be fontSize: 12 on twitter based on theme? */}
                     {canFetch && listOfStatus.length ? (
@@ -257,7 +256,7 @@ export function RedPacket(props: RedPacketProps) {
                         </Typography>
                     ) : null}
                 </div>
-                <div className={classNames(classes.content)}>
+                <div className={classes.content}>
                     <div className={classes.fullWidthBox}>
                         <Typography className={classes.words} variant="h6">
                             {payload.sender.message}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketConfirmDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketConfirmDialog.tsx
@@ -1,5 +1,4 @@
 import { BigNumber } from 'bignumber.js'
-import classNames from 'classnames'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useChainContext, useBalance, useWeb3, useNativeToken, useNativeTokenAddress } from '@masknet/web3-hooks-base'
 import { chainResolver, explorerResolver, isNativeTokenAddress, useRedPacketConstants } from '@masknet/web3-shared-evm'
@@ -57,7 +56,7 @@ export interface ConfirmRedPacketFormProps {
 export function RedPacketConfirmDialog(props: ConfirmRedPacketFormProps) {
     const t = useI18N()
     const { onBack, settings, onCreated, onClose } = props
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { value: balance = '0', loading: loadingBalance } = useBalance(NetworkPluginID.PLUGIN_EVM)
     const { account, chainId, networkType } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     useEffect(() => {
@@ -162,7 +161,7 @@ export function RedPacketConfirmDialog(props: ConfirmRedPacketFormProps) {
 
     return (
         <>
-            <Grid container spacing={2} className={classNames(classes.grid, classes.gridWrapper)}>
+            <Grid container spacing={2} className={cx(classes.grid, classes.gridWrapper)}>
                 <Grid item xs={12}>
                     <Typography variant="h4" color="textPrimary" align="center" className={classes.ellipsis}>
                         {settings?.message}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC20Form.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC20Form.tsx
@@ -66,7 +66,7 @@ export interface RedPacketFormProps extends withClasses<never> {
 export function RedPacketERC20Form(props: RedPacketFormProps) {
     const t = useI18N()
     const { t: tr } = useBaseI18n()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { onChange, onNext, origin } = props
     // context
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC721Form.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC721Form.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect, useMemo } from 'react'
-import classNames from 'classnames'
 import { Box, Typography, List, ListItem } from '@mui/material'
 import { makeStyles, ActionButton, LoadingBase } from '@masknet/theme'
 import { Check as CheckIcon, Close as CloseIcon, AddCircleOutline as AddCircleOutlineIcon } from '@mui/icons-material'
@@ -215,7 +214,7 @@ export function RedPacketERC721Form(props: RedPacketERC721FormProps) {
         openSelectNFTDialog,
         setOpenSelectNFTDialog,
     } = props
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const [balance, setBalance] = useState(0)
     const [selectOption, setSelectOption] = useState<NFTSelectOption | undefined>(undefined)
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
@@ -326,7 +325,7 @@ export function RedPacketERC721Form(props: RedPacketERC721FormProps) {
                         // TODO: replace to radio
                         <Box className={classes.selectWrapper}>
                             <div
-                                className={classNames(
+                                className={cx(
                                     classes.optionLeft,
                                     classes.option,
                                     tokenDetailedOwnerList.length === 0 ? classes.disabledSelector : null,
@@ -336,7 +335,7 @@ export function RedPacketERC721Form(props: RedPacketERC721FormProps) {
                                     setAllTokenDetailedList(tokenDetailedOwnerList.slice(0, maxSelectShares))
                                 }}>
                                 <div
-                                    className={classNames(
+                                    className={cx(
                                         classes.checkIconWrapper,
                                         selectOption === NFTSelectOption.All ? classes.checked : '',
                                     )}>
@@ -355,7 +354,7 @@ export function RedPacketERC721Form(props: RedPacketERC721FormProps) {
                             </div>
                             <div className={classes.option} onClick={() => setSelectOption(NFTSelectOption.Partial)}>
                                 <div
-                                    className={classNames(
+                                    className={cx(
                                         classes.checkIconWrapper,
                                         selectOption === NFTSelectOption.Partial ? classes.checked : '',
                                     )}>
@@ -376,7 +375,7 @@ export function RedPacketERC721Form(props: RedPacketERC721FormProps) {
                             ))}
                             <ListItem
                                 onClick={() => setOpenSelectNFTDialog(true)}
-                                className={classNames(classes.tokenSelectorWrapper, classes.addWrapper)}>
+                                className={cx(classes.tokenSelectorWrapper, classes.addWrapper)}>
                                 <AddCircleOutlineIcon className={classes.addIcon} onClick={() => void 0} />
                             </ListItem>
                         </List>
@@ -427,10 +426,10 @@ interface NFTCardProps {
 
 function NFTCard(props: NFTCardProps) {
     const { token, removeToken, renderOrder } = props
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const [name, setName] = useState(formatTokenId(token.tokenId, 2))
     return (
-        <ListItem className={classNames(classes.tokenSelectorWrapper)}>
+        <ListItem className={cx(classes.tokenSelectorWrapper)}>
             <NFTCardStyledAssetPlayer
                 contractAddress={token.contract?.address}
                 chainId={token.chainId}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketInHistoryList.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketInHistoryList.tsx
@@ -2,7 +2,6 @@ import { MouseEvent, useCallback, useState, useMemo } from 'react'
 import { useAsync } from 'react-use'
 import { Interface } from '@ethersproject/abi'
 import { BigNumber } from 'bignumber.js'
-import classNames from 'classnames'
 import { Box, ListItem, Typography, Popper, useMediaQuery, Theme } from '@mui/material'
 import { makeStyles, ActionButton } from '@masknet/theme'
 import { TokenIcon } from '@masknet/shared'
@@ -167,7 +166,7 @@ export interface RedPacketInHistoryListProps {
 export function RedPacketInHistoryList(props: RedPacketInHistoryListProps) {
     const { history, onSelect } = props
     const t = useI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const connection = useWeb3Connection(NetworkPluginID.PLUGIN_EVM)
     const { HAPPY_RED_PACKET_ADDRESS_V4 } = useRedPacketConstants(chainId)
@@ -260,25 +259,25 @@ export function RedPacketInHistoryList(props: RedPacketInHistoryListProps) {
                     <section className={classes.section}>
                         <div className={classes.div}>
                             <div className={classes.fullWidthBox}>
-                                <Typography variant="body1" className={classNames(classes.title, classes.message)}>
+                                <Typography variant="body1" className={cx(classes.title, classes.message)}>
                                     {patchedHistory.sender.message === ''
                                         ? t.best_wishes()
                                         : patchedHistory.sender.message}
                                 </Typography>
                             </div>
-                            <Typography variant="body1" className={classNames(classes.info, classes.message)}>
+                            <Typography variant="body1" className={cx(classes.info, classes.message)}>
                                 {t.history_duration({
                                     startTime: dateTimeFormat(new Date(creation_time)),
                                     endTime: dateTimeFormat(new Date(creation_time + patchedHistory.duration), false),
                                 })}
                             </Typography>
-                            <Typography variant="body1" className={classNames(classes.info, classes.message)}>
+                            <Typography variant="body1" className={cx(classes.info, classes.message)}>
                                 {t.history_total_amount({
                                     amount: formatBalance(patchedHistory.total, historyToken?.decimals, 6),
                                     symbol: historyToken?.symbol,
                                 })}
                             </Typography>
-                            <Typography variant="body1" className={classNames(classes.info, classes.message)}>
+                            <Typography variant="body1" className={cx(classes.info, classes.message)}>
                                 {t.history_split_mode({
                                     mode: patchedHistory.is_random ? t.random() : t.average(),
                                 })}
@@ -297,7 +296,7 @@ export function RedPacketInHistoryList(props: RedPacketInHistoryListProps) {
                                         canSend && !isPasswordValid ? setAnchorEl(null) : undefined
                                     }}
                                     disabled={listOfStatus.includes(RedPacketStatus.empty) || refunded || isRefunding}
-                                    className={classNames(
+                                    className={cx(
                                         classes.actionButton,
                                         canSend && !isPasswordValid ? classes.disabledButton : '',
                                     )}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketNft.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketNft.tsx
@@ -9,7 +9,6 @@ import { WalletConnectedBoundary, NFTCardStyledAssetPlayer, ChainBoundary } from
 import type { RedPacketNftJSONPayload } from '../types.js'
 import { useClaimNftRedpacketCallback } from './hooks/useClaimNftRedpacketCallback.js'
 import { useAvailabilityNftRedPacket } from './hooks/useAvailabilityNftRedPacket.js'
-import classNames from 'classnames'
 import { usePostLink } from '../../../components/DataSource/usePostInfo.js'
 import { activatedSocialNetworkUI } from '../../../social-network/index.js'
 import { isTwitter } from '../../../social-network-adaptor/twitter.com/base.js'
@@ -191,7 +190,7 @@ export interface RedPacketNftProps {
 export function RedPacketNft({ payload }: RedPacketNftProps) {
     const { t: i18n } = useBaseI18N()
     const t = useI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const web3 = useWeb3(NetworkPluginID.PLUGIN_EVM)
     const { account, networkType } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
 
@@ -252,14 +251,14 @@ export function RedPacketNft({ payload }: RedPacketNftProps) {
     if (availabilityError)
         return (
             <div className={classes.root}>
-                <Card className={classNames(classes.card, classes.errorCard)} component="article" elevation={0}>
+                <Card className={cx(classes.card, classes.errorCard)} component="article" elevation={0}>
                     <img className={classes.errImage} src={rpNftImg} />
                     <Typography className={classes.whiteText} variant="h5">
                         {i18n('loading_failed')}
                     </Typography>
                     <Button
                         onClick={retryAvailability}
-                        className={classNames(classes.errorButton, classes.whiteText)}
+                        className={cx(classes.errorButton, classes.whiteText)}
                         variant="outlined">
                         {i18n('try_again')}
                     </Button>
@@ -279,12 +278,10 @@ export function RedPacketNft({ payload }: RedPacketNftProps) {
         <div className={classes.root}>
             <Card className={classes.card} component="article" elevation={0}>
                 <CardHeader
-                    className={classNames(classes.title, availability.isEnd ? classes.hide : '', classes.whiteText)}
+                    className={cx(classes.title, availability.isEnd ? classes.hide : '', classes.whiteText)}
                     title={<Typography className={classes.ellipsis}>{payload.message}</Typography>}
                     subheader={
-                        <span
-                            className={classNames(classes.link, classes.whiteText)}
-                            onClick={openAddressLinkOnExplorer}>
+                        <span className={cx(classes.link, classes.whiteText)} onClick={openAddressLinkOnExplorer}>
                             <Typography variant="body2">{payload.contractName}</Typography>
                             <LaunchIcon fontSize="small" className={classes.dimWhiteText} />
                         </span>
@@ -299,7 +296,7 @@ export function RedPacketNft({ payload }: RedPacketNftProps) {
                             tokenId={availability.claimed_id}
                             setSourceType={setSourceType}
                             classes={{
-                                iframe: classNames(
+                                iframe: cx(
                                     classes.assetPlayerIframe,
                                     sourceType === 'video' ? classes.assetPlayerVideoIframe : '',
                                 ),
@@ -338,18 +335,18 @@ export function RedPacketNft({ payload }: RedPacketNftProps) {
             {availability.isEnd ? (
                 <Card className={classes.coverCard}>
                     <CardHeader
-                        className={classNames(classes.title, classes.dim, classes.dimWhiteText)}
+                        className={cx(classes.title, classes.dim, classes.dimWhiteText)}
                         title={<Typography className={classes.ellipsis}>{payload.message}</Typography>}
                         subheader={
                             <span
-                                className={classNames(classes.link, classes.dimWhiteText)}
+                                className={cx(classes.link, classes.dimWhiteText)}
                                 onClick={openAddressLinkOnExplorer}>
                                 <Typography variant="body2">{payload.contractName}</Typography>
                                 <LaunchIcon fontSize="small" className={classes.dimWhiteText} />
                             </span>
                         }
                     />
-                    <div className={classNames(classes.badge, classes.whiteText)}>
+                    <div className={cx(classes.badge, classes.whiteText)}>
                         <Typography variant="body2" className={classes.badgeText}>
                             {availability.expired ? t.expired() : t.completed()}
                         </Typography>

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketMessagePanel.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketMessagePanel.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { Box, InputBase, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { useI18N } from '../locales/index.js'
@@ -31,7 +30,7 @@ export interface RedpacketMessagePanelProps {
 }
 export function RedpacketMessagePanel(props: RedpacketMessagePanelProps) {
     const { onChange, message } = props
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const t = useI18N()
 
     return (
@@ -39,7 +38,7 @@ export function RedpacketMessagePanel(props: RedpacketMessagePanelProps) {
             <div className={classes.wrapper}>
                 <Typography>{t.message_label()}</Typography>
             </div>
-            <div className={classNames(classes.wrapper)}>
+            <div className={cx(classes.wrapper)}>
                 <InputBase
                     className={classes.input}
                     onChange={(e) => onChange(e.target.value)}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketNftConfirmDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedpacketNftConfirmDialog.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useCallback, useState } from 'react'
 import { useAsync } from 'react-use'
-import classNames from 'classnames'
 import { makeStyles, ActionButton } from '@masknet/theme'
 import {
     formatEthereumAddress,
@@ -133,7 +132,7 @@ export interface RedpacketNftConfirmDialogProps {
     message: string
 }
 export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps) {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { onClose, message, contract, tokenList } = props
     const wallet = useWallet(NetworkPluginID.PLUGIN_EVM)
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
@@ -222,7 +221,7 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
                         color="textPrimary"
                         variant="body1"
                         align="right"
-                        className={classNames(classes.account, classes.bold, classes.text)}>
+                        className={cx(classes.account, classes.bold, classes.text)}>
                         {formatEthereumAddress(account, 4)}
                         {isNativeTokenAddress(wallet?.address) ? null : (
                             <Link
@@ -238,7 +237,7 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
                     </Typography>
                 </Grid>
                 <Grid item xs={6}>
-                    <Typography variant="body1" color="textPrimary" className={classNames(classes.text)}>
+                    <Typography variant="body1" color="textPrimary" className={cx(classes.text)}>
                         {t.nft_attached_message()}
                     </Typography>
                 </Grid>
@@ -247,12 +246,12 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
                         variant="body1"
                         color="textPrimary"
                         align="right"
-                        className={classNames(classes.text, classes.bold, classes.ellipsis)}>
+                        className={cx(classes.text, classes.bold, classes.ellipsis)}>
                         {message}
                     </Typography>
                 </Grid>
                 <Grid item xs={6}>
-                    <Typography variant="body1" color="textPrimary" className={classNames(classes.text)}>
+                    <Typography variant="body1" color="textPrimary" className={cx(classes.text)}>
                         {t.collections()}
                     </Typography>
                 </Grid>
@@ -263,7 +262,7 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
                             variant="body1"
                             color="textPrimary"
                             align="right"
-                            className={classNames(classes.text, classes.bold)}>
+                            className={cx(classes.text, classes.bold)}>
                             {contract.name}
                         </Typography>
                     </div>
@@ -279,12 +278,12 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
                 </Grid>
 
                 <Grid item xs={6}>
-                    <Typography color="textPrimary" variant="body1" className={classNames(classes.text)}>
+                    <Typography color="textPrimary" variant="body1" className={cx(classes.text)}>
                         {t.nft_total_amount()}
                     </Typography>
                 </Grid>
                 <Grid item xs={6}>
-                    <Typography color="textPrimary" align="right" className={classNames(classes.text, classes.bold)}>
+                    <Typography color="textPrimary" align="right" className={cx(classes.text, classes.bold)}>
                         {tokenList.length}
                     </Typography>
                 </Grid>
@@ -294,15 +293,15 @@ export function RedpacketNftConfirmDialog(props: RedpacketNftConfirmDialogProps)
                     <ChainBoundary expectedPluginID={NetworkPluginID.PLUGIN_EVM} expectedChainId={chainId}>
                         <WalletConnectedBoundary
                             classes={{
-                                connectWallet: classNames(classes.button, classes.sendButton),
-                                unlockMetaMask: classNames(classes.button, classes.sendButton),
+                                connectWallet: cx(classes.button, classes.sendButton),
+                                unlockMetaMask: cx(classes.button, classes.sendButton),
                             }}>
                             <ActionButton
                                 size="medium"
                                 loading={isSending}
                                 disabled={isSending}
                                 onClick={onSendTx}
-                                className={classNames(classes.button, classes.sendButton)}
+                                className={cx(classes.button, classes.sendButton)}
                                 fullWidth>
                                 {t.send_symbol({
                                     count: tokenList.length,
@@ -323,10 +322,10 @@ interface NFTCardProps {
 
 function NFTCard(props: NFTCardProps) {
     const { token, renderOrder } = props
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const [name, setName] = useState(formatTokenId(token.tokenId, 2))
     return (
-        <ListItem className={classNames(classes.tokenSelectorWrapper)}>
+        <ListItem className={cx(classes.tokenSelectorWrapper)}>
             <NFTCardStyledAssetPlayer
                 contractAddress={token.contract?.address}
                 chainId={token.contract?.chainId}

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/SelectNftTokenDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/SelectNftTokenDialog.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState, useEffect } from 'react'
 import { useUpdate } from 'react-use'
 import { findLastIndex, uniq } from 'lodash-unified'
-import classNames from 'classnames'
 import { AssetPreviewer } from '@masknet/shared'
 import { NetworkPluginID } from '@masknet/shared-base'
 import { isSameAddress, NonFungibleToken, NonFungibleTokenContract } from '@masknet/web3-shared-base'
@@ -276,7 +275,7 @@ export function SelectNftTokenDialog(props: SelectNftTokenDialogProps) {
     const isSelectSharesExceed =
         (tokenDetailedOwnerList.length === 0 ? NFT_RED_PACKET_MAX_SHARES - 1 : NFT_RED_PACKET_MAX_SHARES) <
         tokenDetailedSelectedList.length
-    const { classes } = useStyles({ isSelectSharesExceed })
+    const { classes, cx } = useStyles({ isSelectSharesExceed })
     const [selectAll, setSelectAll] = useState(false)
     const selectAllHandler = useCallback(() => {
         setTokenDetailedSelectedList(selectAll ? [] : tokenDetailedOwnerList)
@@ -491,7 +490,7 @@ export function SelectNftTokenDialog(props: SelectNftTokenDialogProps) {
             </Button>
         </DialogContent>
     ) : (
-        <DialogContent className={classNames(classes.dialogContent, classes.dialogContentFixedHeight)}>
+        <DialogContent className={cx(classes.dialogContent, classes.dialogContentFixedHeight)}>
             <div className={classes.searchWrapper}>
                 <InputBase
                     startAdornment={<Icons.Search className={classes.iconButton} />}
@@ -523,14 +522,11 @@ export function SelectNftTokenDialog(props: SelectNftTokenDialogProps) {
                             <div className={classes.selectBar}>
                                 <div className={classes.selectAll}>
                                     <div
-                                        className={classNames(
-                                            classes.selectAllCheckBox,
-                                            selectAll ? classes.checked : '',
-                                        )}
+                                        className={cx(classes.selectAllCheckBox, selectAll ? classes.checked : '')}
                                         onClick={selectAllHandler}>
                                         {selectAll ? <CheckIcon className={classes.checkIcon} /> : null}
                                     </div>
-                                    <Typography className={classNames(classes.selectAllCheckBoxText)}>
+                                    <Typography className={cx(classes.selectAllCheckBoxText)}>
                                         {tr('select_all')}
                                     </Typography>
                                 </div>
@@ -572,7 +568,7 @@ export function SelectNftTokenDialog(props: SelectNftTokenDialogProps) {
                                     )
                                 })}
                                 {loadingOwnerList ? (
-                                    <ListItem className={classNames(classes.selectWrapper, classes.loadingWrapper)}>
+                                    <ListItem className={cx(classes.selectWrapper, classes.loadingWrapper)}>
                                         <LoadingBase size={25} />
                                     </ListItem>
                                 ) : null}
@@ -644,7 +640,7 @@ interface NFTCardProps {
 
 function NFTCard(props: NFTCardProps) {
     const { findToken, token, isSelectSharesExceed, renderOrder, selectToken } = props
-    const { classes } = useStyles({ isSelectSharesExceed })
+    const { classes, cx } = useStyles({ isSelectSharesExceed })
     return (
         <ListItem className={classes.selectWrapper}>
             <AssetPreviewer
@@ -660,7 +656,7 @@ function NFTCard(props: NFTCardProps) {
             </div>
 
             <div
-                className={classNames(classes.checkbox, findToken ? classes.checked : '')}
+                className={cx(classes.checkbox, findToken ? classes.checked : '')}
                 onClick={(event) => selectToken(token, findToken, event.shiftKey, token.index)}>
                 {findToken ? <CheckIcon className={classes.checkIcon} /> : null}
             </div>

--- a/packages/mask/src/plugins/Referral/SNSAdaptor/shared-ui/FungibleTokenList/FungibleTokenItem.tsx
+++ b/packages/mask/src/plugins/Referral/SNSAdaptor/shared-ui/FungibleTokenList/FungibleTokenItem.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from 'react'
-import classNames from 'classnames'
 import { ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material'
 import type { FungibleToken } from '@masknet/web3-shared-base'
 import type { NetworkPluginID } from '@masknet/shared-base'
@@ -100,7 +99,7 @@ export const getFungibleTokenItem =
     ) =>
     ({ data, index, style }: any) => {
         const t = useSharedI18N()
-        const { classes } = useStyles()
+        const { classes, cx } = useStyles()
 
         const token = data.dataSet[index]
         const onSelect = data.onSelect
@@ -160,7 +159,7 @@ export const getFungibleTokenItem =
                     </ListItemIcon>
                     <ListItemText classes={{ primary: classes.text }}>
                         <Typography
-                            className={classNames(classes.primary, source === 'external' ? classes.import : '')}
+                            className={cx(classes.primary, source === 'external' ? classes.import : '')}
                             color="textPrimary"
                             component="span">
                             <div className={classes.metaInfo}>

--- a/packages/mask/src/plugins/Snapshot/SNSAdaptor/InformationCard.tsx
+++ b/packages/mask/src/plugins/Snapshot/SNSAdaptor/InformationCard.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles()((theme) => {
 })
 
 export function InfoField(props: InfoFieldProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return (
         <div className={classes.field}>
             <Typography className={classes.title}>{props.title}</Typography>

--- a/packages/mask/src/plugins/Snapshot/SNSAdaptor/ResultCard.tsx
+++ b/packages/mask/src/plugins/Snapshot/SNSAdaptor/ResultCard.tsx
@@ -1,5 +1,4 @@
 import { useContext, useRef, useEffect, useState, useMemo } from 'react'
-import classNames from 'classnames'
 import { Box, List, ListItem, Typography, LinearProgress, styled, Button, linearProgressClasses } from '@mui/material'
 import { makeStyles, ShadowRootTooltip } from '@masknet/theme'
 import { useI18N } from '../../../utils/index.js'
@@ -91,7 +90,7 @@ function Content() {
     const {
         payload: { results },
     } = useResults(identifier)
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { t } = useI18N()
     const listRef = useRef<HTMLSpanElement[]>([])
     const [tooltipsVisible, setTooltipsVisible] = useState<readonly boolean[]>(
@@ -135,7 +134,7 @@ function Content() {
                                     ref={(ref) => {
                                         listRef.current[i] = ref!
                                     }}
-                                    className={classNames(classes.choice, classes.ellipsisText)}>
+                                    className={cx(classes.choice, classes.ellipsisText)}>
                                     {result.choice}
                                 </Typography>
                             </ShadowRootTooltip>

--- a/packages/mask/src/plugins/Snapshot/SNSAdaptor/VotesCard.tsx
+++ b/packages/mask/src/plugins/Snapshot/SNSAdaptor/VotesCard.tsx
@@ -1,5 +1,4 @@
 import { useContext } from 'react'
-import classNames from 'classnames'
 import millify from 'millify'
 import { formatEthereumAddress, explorerResolver, formatPercentage } from '@masknet/web3-shared-evm'
 import { Avatar, Badge, Box, Link, List, ListItem, Typography } from '@mui/material'
@@ -92,7 +91,7 @@ function Content() {
     const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const identifier = useContext(SnapshotContext)
     const { payload: votes } = useVotes(identifier)
-    const { classes, theme } = useStyles()
+    const { classes, cx, theme } = useStyles()
     const { t } = useI18N()
 
     return (
@@ -118,7 +117,7 @@ function Content() {
                     return (
                         <ListItem className={classes.listItem} key={v.address}>
                             <Link
-                                className={classNames(classes.link, classes.ellipsisText)}
+                                className={cx(classes.link, classes.ellipsisText)}
                                 target="_blank"
                                 rel="noopener"
                                 href={explorerResolver.addressLink(chainId, v.address)}>

--- a/packages/mask/src/plugins/Snapshot/SNSAdaptor/VotingCard.tsx
+++ b/packages/mask/src/plugins/Snapshot/SNSAdaptor/VotingCard.tsx
@@ -1,5 +1,4 @@
 import { useContext, useState, useEffect, useMemo } from 'react'
-import classNames from 'classnames'
 import { toChecksumAddress } from 'web3-utils'
 import { Box, Button, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
@@ -51,7 +50,7 @@ const useStyles = makeStyles()((theme) => {
 
 export function VotingCard() {
     const { t } = useI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const identifier = useContext(SnapshotContext)
     const connection = useWeb3Connection(NetworkPluginID.PLUGIN_EVM)
     const { payload: proposal } = useProposal(identifier.id)
@@ -154,7 +153,7 @@ export function VotingCard() {
                         fullWidth
                         key={i}
                         onClick={() => onClick(i + 1)}
-                        className={classNames([
+                        className={cx([
                             classes.button,
                             classes.choiceButton,
                             ...(choices_.includes(i + 1) ? [classes.buttonActive] : []),
@@ -171,7 +170,7 @@ export function VotingCard() {
                 <Button
                     variant="roundedContained"
                     fullWidth
-                    className={classNames(classes.button, disabled ? '' : classes.buttonActive)}
+                    className={cx(classes.button, disabled ? '' : classes.buttonActive)}
                     disabled={disabled}
                     onClick={() => setOpen(true)}>
                     <Typography fontWeight={700} fontSize={16}>

--- a/packages/mask/src/plugins/Tips/components/Guide.tsx
+++ b/packages/mask/src/plugins/Tips/components/Guide.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, usePortalShadowRoot } from '@masknet/theme'
 import { Box, Typography, Portal, Button } from '@mui/material'
-import classNames from 'classnames'
 import { PropsWithChildren, useRef, cloneElement, useEffect, ReactElement, useState } from 'react'
 import { activatedSocialNetworkUI } from '../../../social-network/index.js'
 import { useI18N } from '../locales/index.js'
@@ -155,7 +154,7 @@ export default function Guide({ children, arrow = true, disabled = false, onComp
                                     }}>
                                     <div
                                         onClick={(e) => e.stopPropagation()}
-                                        className={classNames(
+                                        className={cx(
                                             classes.card,
                                             arrow ? (bottomAvailable ? 'arrow-top' : 'arrow-bottom') : '',
                                         )}

--- a/packages/mask/src/plugins/Tips/components/NFTSection/NFTList.tsx
+++ b/packages/mask/src/plugins/Tips/components/NFTSection/NFTList.tsx
@@ -1,5 +1,4 @@
 import { FC, useCallback } from 'react'
-import classnames from 'classnames'
 import { LoadingBase, makeStyles } from '@masknet/theme'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { ElementAnchor, AssetPreviewer, RetryHint } from '@masknet/shared'
@@ -102,7 +101,7 @@ export const NFTList: FC<Props> = ({
     loadFinish,
     loadError,
 }) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { pluginID } = useNetworkContext()
 
     const isRadio = limit === 1
@@ -127,7 +126,7 @@ export const NFTList: FC<Props> = ({
     const { Others } = useWeb3State()
 
     return (
-        <List className={classnames(classes.list, className)}>
+        <List className={cx(classes.list, className)}>
             {tokens.map((token) => {
                 const selected = includes(selectedPairs, [token.contract?.address!, token.tokenId])
                 const disabled = !isRadio && reachedLimit && !selected
@@ -148,7 +147,7 @@ export const NFTList: FC<Props> = ({
                         }}
                         arrow>
                         <ListItem
-                            className={classnames(classes.nftItem, {
+                            className={cx(classes.nftItem, {
                                 [classes.disabled]: disabled,
                                 [classes.selected]: selected,
                                 [classes.unselected]: selectedPairs.length > 0 && !selected,

--- a/packages/mask/src/plugins/Tips/components/NFTSection/index.tsx
+++ b/packages/mask/src/plugins/Tips/components/NFTSection/index.tsx
@@ -1,6 +1,5 @@
 import { FC, HTMLProps, useCallback, useMemo } from 'react'
 import { useBoolean } from 'react-use'
-import classnames from 'classnames'
 import { uniqWith } from 'lodash-unified'
 import { Icons } from '@masknet/icons'
 import { useChainContext, useNonFungibleAssets, useNetworkContext } from '@masknet/web3-hooks-base'
@@ -121,7 +120,7 @@ export const NFTSection: FC<Props> = ({ className, onEmpty, ...rest }) => {
     }, [])
 
     return (
-        <div className={classnames(classes.root, className)} {...rest}>
+        <div className={cx(classes.root, className)} {...rest}>
             <FormControl className={classes.header}>
                 {isEvm ? (
                     <Typography className={classes.addButton} onClick={() => openAddTokenDialog(true)}>

--- a/packages/mask/src/plugins/Tips/components/NFTSection/index.tsx
+++ b/packages/mask/src/plugins/Tips/components/NFTSection/index.tsx
@@ -86,7 +86,7 @@ export const NFTSection: FC<Props> = ({ className, onEmpty, ...rest }) => {
         setNonFungibleTokenId,
         setNonFungibleTokenAddress,
     } = useTip()
-    const { classes, theme } = useStyles()
+    const { classes, theme, cx } = useStyles()
     const t = useI18N()
     const [addTokenDialogIsOpen, openAddTokenDialog] = useBoolean(false)
     const selectedKey = tokenAddress || tokenId ? `${tokenAddress}_${tokenId}` : undefined

--- a/packages/mask/src/plugins/Tips/components/RecipientSection/RecipientSelect.tsx
+++ b/packages/mask/src/plugins/Tips/components/RecipientSection/RecipientSelect.tsx
@@ -76,7 +76,7 @@ const useStyles = makeStyles<void, 'icon' | 'pluginIcon' | 'text'>()((theme, _, 
 })
 
 const PluginIcon = ({ pluginID }: { pluginID: NetworkPluginID }) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const mapping = {
         [NetworkPluginID.PLUGIN_EVM]: (
             <Icons.ETH

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/Gas1559Settings.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/Gas1559Settings.tsx
@@ -3,7 +3,6 @@ import { isEmpty } from 'lodash-unified'
 import { Accordion, AccordionDetails, AccordionSummary, Box, TextField, Typography } from '@mui/material'
 import { makeStyles, MaskColorVar, ActionButton } from '@masknet/theme'
 import { formatGweiToWei, GasOptionConfig } from '@masknet/web3-shared-evm'
-import classnames from 'classnames'
 import { z as zod } from 'zod'
 import { BigNumber } from 'bignumber.js'
 import { useForm, Controller } from 'react-hook-form'
@@ -136,7 +135,7 @@ export const Gas1559Settings = memo<Gas1559SettingsProps>(
     ({ onCancel, onSave: onSave_, gasConfig, onSaveSlippage }) => {
         const { t } = useI18N()
         const isDashboard = isDashboardPage()
-        const { classes } = useStyles({ isDashboard })
+        const { classes, cx } = useStyles({ isDashboard })
         const [selected, setOption] = useState<number | null>(1)
 
         const { value: gasOptions, loading: getGasOptionsLoading } = useGasOptions(NetworkPluginID.PLUGIN_EVM)
@@ -267,14 +266,14 @@ export const Gas1559Settings = memo<Gas1559SettingsProps>(
                             <Box display="flex" justifyContent="space-around" alignItems="center">
                                 {options.map((option, index) => (
                                     <Box
-                                        className={classnames(
+                                        className={cx(
                                             classes.option,
                                             selected === index ? classes.selected : undefined,
                                         )}
                                         key={index}
                                         onClick={() => setOption(index)}>
                                         <Box
-                                            className={classnames(
+                                            className={cx(
                                                 classes.pointer,
                                                 selected === index ? classes.selectedPointer : undefined,
                                             )}

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/GasPrior1559Settings.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/GasPrior1559Settings.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useUpdateEffect } from 'react-use'
-import classnames from 'classnames'
 import { toHex } from 'web3-utils'
 import { BigNumber } from 'bignumber.js'
 import { formatGweiToEther, formatGweiToWei, formatWeiToGwei, GasOptionConfig } from '@masknet/web3-shared-evm'
@@ -98,7 +97,7 @@ export const GasPrior1559Settings = memo<GasPrior1559SettingsProps>(
         const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
         const { value: gasOptions_ } = useGasOptions(NetworkPluginID.PLUGIN_EVM)
         const isDashboard = isDashboardPage()
-        const { classes } = useStyles({ isDashboard })
+        const { classes, cx } = useStyles({ isDashboard })
         const { t } = useI18N()
         const [selected, setOption] = useState<number>(1)
         const [customGasPrice, setCustomGasPrice] = useState('0')
@@ -178,10 +177,7 @@ export const GasPrior1559Settings = memo<GasPrior1559SettingsProps>(
                                 <Box
                                     key={index}
                                     onClick={() => setOption(index)}
-                                    className={classnames(
-                                        classes.option,
-                                        selected === index ? classes.selected : undefined,
-                                    )}>
+                                    className={cx(classes.option, selected === index ? classes.selected : undefined)}>
                                     <Box
                                         width="100%"
                                         display="flex"
@@ -190,7 +186,7 @@ export const GasPrior1559Settings = memo<GasPrior1559SettingsProps>(
                                         mb={1.5}>
                                         <Typography className={classes.optionTitle}>{option.title}</Typography>
                                         <Box
-                                            className={classnames(
+                                            className={cx(
                                                 classes.pointer,
                                                 selected === index ? classes.selectedPointer : undefined,
                                             )}

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeForm.tsx
@@ -20,7 +20,6 @@ import { TokenPanelType, TradeInfo } from '../../types/index.js'
 import { BigNumber } from 'bignumber.js'
 import { first, noop } from 'lodash-unified'
 import { Icons } from '@masknet/icons'
-import classnames from 'classnames'
 import { isNativeTokenWrapper } from '../../helpers/index.js'
 import { DefaultTraderPlaceholder, TraderInfo } from './TraderInfo.js'
 import { MINIMUM_AMOUNT, MIN_GAS_LIMIT } from '../../constants/index.js'
@@ -237,7 +236,7 @@ export const TradeForm = memo<AllTradeFormProps>(
         const isPopup = isPopupPage()
         const { t } = useI18N()
         const styles = useStyles({ isDashboard, isPopup })
-        const classes = useStylesExtends(styles, props)
+        const { classes, cx } = useStylesExtends(styles, props)
         const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
         const { isSwapping, allTradeComputed } = AllProviderTradeContext.useContainer()
         const [isExpand, setExpand] = useState(false)
@@ -513,10 +512,7 @@ export const TradeForm = memo<AllTradeFormProps>(
                                 {trades.filter((x) => !!x.value).length > 1 ? (
                                     <Box width="100%" display="flex" justifyContent="center" marginTop={1.5}>
                                         <Icons.ChevronUp
-                                            className={classnames(
-                                                classes.chevron,
-                                                isExpand ? classes.reverseChevron : null,
-                                            )}
+                                            className={cx(classes.chevron, isExpand ? classes.reverseChevron : null)}
                                             onClick={() => setExpand(!isExpand)}
                                         />
                                     </Box>

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeView.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/TradeView.tsx
@@ -34,7 +34,7 @@ export function TradeView(props: TradeViewProps) {
         TraderProps.defaultInputCoin,
         { chainId },
     )
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return (
         <div className={classes.root}>
             <AllProviderTradeContext.Provider>

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trader/components/TraderInfoUI.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trader/components/TraderInfoUI.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react'
-import classNames from 'classnames'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { isDashboardPage } from '@masknet/shared-base'
 import { makeStyles, MaskColorVar, LoadingBase } from '@masknet/theme'
@@ -111,7 +110,7 @@ export const TraderInfoUI = memo<TraderInfoUIProps>(
         const isDashboard = isDashboardPage()
 
         const { t } = useI18N()
-        const { classes } = useStyles({ isDashboard })
+        const { classes, cx } = useStyles({ isDashboard })
 
         if (loading)
             return (
@@ -129,7 +128,7 @@ export const TraderInfoUI = memo<TraderInfoUIProps>(
                 onClick={onClick}
                 value={balance}
                 InputProps={{
-                    className: classNames(classes.trade, isFocus ? classes.focus : null),
+                    className: cx(classes.trade, isFocus ? classes.focus : null),
                     disableUnderline: true,
                     startAdornment: (
                         <Box
@@ -192,7 +191,7 @@ export const DefaultTraderPlaceholderUI = memo<DefaultTraderPlaceholderUIProps>(
     const isDashboard = isDashboardPage()
 
     const { t } = useI18N()
-    const { classes } = useStyles({ isDashboard })
+    const { classes, cx } = useStyles({ isDashboard })
 
     return (
         <TextField
@@ -201,7 +200,7 @@ export const DefaultTraderPlaceholderUI = memo<DefaultTraderPlaceholderUIProps>(
             variant="filled"
             value={0}
             InputProps={{
-                className: classNames(classes.trade, classes.focus),
+                className: cx(classes.trade, classes.focus),
                 disableUnderline: true,
                 startAdornment: (
                     <Box

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/PriceChart.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/PriceChart.tsx
@@ -53,7 +53,7 @@ export interface PriceChartProps extends withClasses<'root'> {
 
 export function PriceChart(props: PriceChartProps) {
     const { t } = useI18N()
-    const classes = useStylesExtends(useStyles(props), props)
+    const { classes } = useStylesExtends(useStyles(props), props)
     const colors = useTheme().palette.maskColor
     const rootRef = useRef<HTMLDivElement>(null)
     const svgRef = useRef<SVGSVGElement>(null)

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/PriceChartDaysControl.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/PriceChartDaysControl.tsx
@@ -1,7 +1,6 @@
 import { Link, Stack, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { resolveDaysName } from '../../pipes.js'
-import classNames from 'classnames'
 import { TrendingAPI } from '@masknet/web3-providers'
 
 const useStyles = makeStyles()((theme) => ({
@@ -42,12 +41,12 @@ export function PriceChartDaysControl({
     days,
     onDaysChange,
 }: PriceChartDaysControlProps) {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     return (
         <Stack className={classes.root} direction="row" gap={2}>
             {rangeOptions.map((daysOption) => (
                 <Link
-                    className={classNames(classes.link, days === daysOption ? classes.active : '')}
+                    className={cx(classes.link, days === daysOption ? classes.active : '')}
                     key={daysOption}
                     onClick={() => onDaysChange?.(daysOption)}>
                     <Typography sx={{ ':hover': { fontWeight: 700 } }} component="span">

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/TrendingCard.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/TrendingCard.tsx
@@ -20,7 +20,7 @@ export interface TrendingCardProps extends withClasses<'root'> {
 
 export function TrendingCard(props: TrendingCardProps) {
     const { children } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return (
         <Card className={classes.root} elevation={0} component="article">
             {children}

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/TrendingViewDeck.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/TrendingViewDeck.tsx
@@ -140,7 +140,7 @@ export function TrendingViewDeck(props: TrendingViewDeckProps) {
 
     const { t } = useI18N()
     const theme = useTheme()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const isNFT = coin.type === TokenType.NonFungible
 

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/TrendingViewSkeleton.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/TrendingViewSkeleton.tsx
@@ -22,7 +22,7 @@ export interface TrendingViewSkeletonProps extends withClasses<'content' | 'foot
 
 export function TrendingViewSkeleton(props: TrendingViewSkeletonProps) {
     const { TrendingCardProps } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { t } = useI18N()
 
     return (

--- a/packages/mask/src/plugins/Transak/SNSAdaptor/BuyTokenDialog.tsx
+++ b/packages/mask/src/plugins/Transak/SNSAdaptor/BuyTokenDialog.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles()((theme) => ({
 export interface BuyTokenDialogProps extends withClasses<never | 'root'> {}
 
 export function BuyTokenDialog(props: BuyTokenDialogProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const [code, setCode] = useState('ETH')
     const [address, setAddress] = useState('')

--- a/packages/mask/src/plugins/UnlockProtocol/SNSAdaptor/LockInList.tsx
+++ b/packages/mask/src/plugins/UnlockProtocol/SNSAdaptor/LockInList.tsx
@@ -1,6 +1,5 @@
 import { ListItem, ListItemText, Checkbox } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
-import classNames from 'classnames'
 import { MouseEvent, useCallback } from 'react'
 import type { DefaultComponentProps } from '@mui/material/OverridableComponent'
 import type { CheckboxProps } from '@mui/material/Checkbox'
@@ -38,7 +37,7 @@ export interface LockInListProps {
 }
 
 export function LockInList(props: LockInListProps) {
-    const { classes } = useStyle()
+    const { classes, cx } = useStyle()
     const lock = props.item
     const name = lock.lock.name
     const secondary = lock.lock.address
@@ -50,7 +49,7 @@ export function LockInList(props: LockInListProps) {
             onClick={onClick}
             disabled={props.disabled}
             {...props.ListItemProps}
-            className={classNames(classes.root, props.ListItemProps?.className)}>
+            className={cx(classes.root, props.ListItemProps?.className)}>
             <Checkbox checked={props.checked} color="primary" {...props.CheckboxProps} />
             <ListItemText
                 classes={{

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/ConnectWalletDialog/ConnectionProgress.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/ConnectWalletDialog/ConnectionProgress.tsx
@@ -75,7 +75,10 @@ export function ConnectionProgress(props: ConnectionProgressProps) {
     const { Others } = useWeb3State(pluginID)
     const providerDescriptor = useProviderDescriptor(pluginID, providerType)
     const networkDescriptor = useNetworkDescriptor(pluginID, networkType)
-    const classes = useStylesExtends(useStyles({ contentBackground: providerDescriptor?.backgroundGradient }), props)
+    const { classes } = useStylesExtends(
+        useStyles({ contentBackground: providerDescriptor?.backgroundGradient }),
+        props,
+    )
     if (!Others) return null
 
     return (

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/Provider.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/Provider.tsx
@@ -40,7 +40,7 @@ export interface ProviderProps
 }
 
 export function Provider(props: ProviderProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return (
         <Card className={classes.root} elevation={0} style={{ opacity: props.ButtonBaseProps?.disabled ? 0.5 : 1 }}>
             <ButtonBase

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/RiskWarningDialog/index.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/RiskWarningDialog/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react'
-import classnames from 'classnames'
 import { Trans } from 'react-i18next'
 import { InjectedDialog, ActionButtonPromise } from '@masknet/shared'
 import { useRemoteControlledDialog } from '@masknet/shared-base-ui'
@@ -51,7 +50,7 @@ const useStyles = makeStyles()((theme) => ({
 
 export function WalletRiskWarningDialog() {
     const { t } = useI18N()
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const { showSnackbar } = useCustomSnackbar()
     const isMobile = useMatchXS()
 
@@ -109,7 +108,7 @@ export function WalletRiskWarningDialog() {
             </DialogContent>
             <DialogActions className={classes.buttons}>
                 <ActionButton
-                    className={classnames(classes.button, classes.cancel)}
+                    className={cx(classes.button, classes.cancel)}
                     fullWidth
                     variant="outlined"
                     color="secondary"

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/SelectProviderDialog/ProviderIcon.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/SelectProviderDialog/ProviderIcon.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@masknet/theme'
 import { Typography, Card, ButtonBase, ButtonBaseProps, CardProps } from '@mui/material'
-import classnames from 'classnames'
 
 const useStyles = makeStyles()((theme) => ({
     root: {
@@ -42,9 +41,9 @@ export interface ProviderIconProps extends CardProps {
 }
 
 export function ProviderIcon({ icon, name, onClick, iconFilterColor, className, ButtonBaseProps }: ProviderIconProps) {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     return (
-        <Card className={classnames(classes.root, className)} elevation={0} onClick={onClick}>
+        <Card className={cx(classes.root, className)} elevation={0} onClick={onClick}>
             <ButtonBase className={`${classes.content} dashboard-style`} {...ButtonBaseProps}>
                 <img
                     src={icon.toString()}

--- a/packages/plugins/CrossChainBridge/src/SNSAdaptor/CrossChainBridgeDialog.tsx
+++ b/packages/plugins/CrossChainBridge/src/SNSAdaptor/CrossChainBridgeDialog.tsx
@@ -52,7 +52,7 @@ export interface CrossChainBridgeDialogProps extends withClasses<never | 'root'>
 
 export function CrossChainBridgeDialog(props: CrossChainBridgeDialogProps) {
     const t = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { open, onClose } = props
     // @ts-ignore
     const bridges = getCrossChainBridge(t)

--- a/packages/plugins/RSS3/package.json
+++ b/packages/plugins/RSS3/package.json
@@ -20,7 +20,6 @@
     "@masknet/web3-shared-evm": "workspace:*",
     "@types/use-subscription": "^1.0.0",
     "bignumber.js": "9.1.0",
-    "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "react-use": "^17.4.0",
     "urlcat": "^2.0.4",

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/DonationCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/DonationCard.tsx
@@ -1,5 +1,4 @@
 import { HTMLProps, memo } from 'react'
-import classnames from 'classnames'
 import formatDateTime from 'date-fns/format'
 import { useReverseAddress, useWeb3State } from '@masknet/web3-hooks-base'
 import { AssetPreviewer } from '@masknet/shared'
@@ -69,7 +68,7 @@ const useStyles = makeStyles()((theme) => ({
 }))
 
 export const DonationCard = memo(({ donation, socialAccount, onSelect, className, ...rest }: DonationCardProps) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const t = useI18N()
     const { value: domain } = useReverseAddress(socialAccount.pluginID, socialAccount.address)
     const { Others } = useWeb3State(socialAccount.pluginID)
@@ -82,7 +81,7 @@ export const DonationCard = memo(({ donation, socialAccount, onSelect, className
     const action = donation.actions[0]
 
     return (
-        <div onClick={() => onSelect(donation)} className={classnames(classes.card, className)} {...rest}>
+        <div onClick={() => onSelect(donation)} className={cx(classes.card, className)} {...rest}>
             <Card className={classes.img}>
                 <AssetPreviewer
                     url={action.metadata?.logo || RSS3_DEFAULT_IMAGE}

--- a/packages/plugins/Web3Profile/package.json
+++ b/packages/plugins/Web3Profile/package.json
@@ -23,7 +23,6 @@
       "react-use": "^17.3.2",
       "use-subscription": "1.7.0",
       "react-feather": "^2.0.9",
-      "classnames": "^2.3.1",
       "urlcat": "^2.0.4",
       "@types/use-subscription": "^1.0.0",
       "date-fns":"2.28.0"

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/CollectionItem.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/CollectionItem.tsx
@@ -29,7 +29,7 @@ interface CollectionItemProps extends withClasses<never | 'root' | 'list' | 'col
 }
 export function CollectionItem(props: CollectionItemProps) {
     const { title, walletsNum, collectionNum, onClick } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const t = useI18N()
 
     return (

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/CollectionList.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/CollectionList.tsx
@@ -16,7 +16,7 @@ export interface CollectionListProps extends withClasses<never | 'root' | 'list'
 
 export function CollectionList(props: CollectionListProps) {
     const { collections, onList, size = 64, showNetwork = false } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <List className={classes.list}>

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/ImageList.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/ImageList.tsx
@@ -5,7 +5,6 @@ import { makeStyles, useStylesExtends } from '@masknet/theme'
 import { isSameAddress, NonFungibleToken } from '@masknet/web3-shared-base'
 import { ChainId, SchemaType, ZERO_ADDRESS } from '@masknet/web3-shared-evm'
 import { Box, Button, DialogActions, DialogContent, Typography } from '@mui/material'
-import classNames from 'classnames'
 import { isEqual, sortBy } from 'lodash-unified'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { PLUGIN_ID } from '../../constants.js'
@@ -133,7 +132,7 @@ export function ImageListDialog(props: ImageListDialogProps) {
     } = props
     const t = useI18N()
     const { Storage } = useWeb3State()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
     const [addNFTOpen, setAddNFTOpen] = useState(false)
 
     const [pendingUnlistedKeys, setPendingUnlistedKeys] = useState(unlistedKeys)
@@ -209,7 +208,7 @@ export function ImageListDialog(props: ImageListDialogProps) {
                         }}>
                         <Typography sx={{ fontSize: '16px', fontWeight: 700 }}>{t.listed()}</Typography>
                     </Box>
-                    <Box className={classNames(classes.listedBox, classes.scrollBar)}>
+                    <Box className={cx(classes.listedBox, classes.scrollBar)}>
                         {listedCollections?.length > 0 ? (
                             <CollectionList
                                 classes={{ list: classes.list, collectionWrap: classes.collectionWrap }}
@@ -227,7 +226,7 @@ export function ImageListDialog(props: ImageListDialogProps) {
                     <Box>
                         <Typography sx={{ fontSize: '16px', fontWeight: 700, padding: 2 }}>{t.unlisted()}</Typography>
                     </Box>
-                    <Box className={classNames(classes.unlistedBox, classes.scrollBar)}>
+                    <Box className={cx(classes.unlistedBox, classes.scrollBar)}>
                         {unListedCollections.length > 0 ? (
                             <CollectionList
                                 classes={{ list: classes.list, collectionWrap: classes.collectionWrap }}

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/PlatformCard.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/PlatformCard.tsx
@@ -57,7 +57,7 @@ export interface PlatformCardProps extends withClasses<never | 'root'> {
 export function PlatformCard(props: PlatformCardProps) {
     const { account, openImageSetting, isCurrent, currentPersona } = props
     const t = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const walletsCount = account.walletList.NFTs.length
 

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/WalletAssets.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/WalletAssets.tsx
@@ -109,7 +109,7 @@ export interface WalletAssetsCardProps extends withClasses<never | 'root'> {
 export function WalletAssetsCard(props: WalletAssetsCardProps) {
     const { wallet, onSetting, collections: collectionList = EMPTY_LIST, collectionName, hasUnlisted } = props
     const t = useI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const chainId = ChainId.Mainnet
 
     const [loadAll, setLoadAll] = useState(false)

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/Web3ProfileDialog.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/Web3ProfileDialog.tsx
@@ -1,7 +1,7 @@
 import { Icons } from '@masknet/icons'
 import { InjectedDialog, PersonaAction, WalletTypes } from '@masknet/shared'
 import { CrossIsolationMessages, EMPTY_LIST, NetworkPluginID, NextIDPlatform, PopupRoutes } from '@masknet/shared-base'
-import { makeStyles, useStylesExtends } from '@masknet/theme'
+import { makeStyles } from '@masknet/theme'
 import { useChainContext } from '@masknet/web3-hooks-base'
 import { NextIDProof } from '@masknet/web3-providers'
 import { ChainId } from '@masknet/web3-shared-evm'
@@ -40,7 +40,7 @@ const useStyles = makeStyles()((theme) => ({
 
 export function Web3ProfileDialog() {
     const t = useI18N()
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes } = useStyles()
     const [scene, setScene] = useState<Scene>()
     const [accountId, setAccountId] = useState<string>()
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,7 +29,6 @@
     "@types/qrcode": "^1.5.0",
     "anchorme": "^2.1.2",
     "bignumber.js": "9.1.0",
-    "classnames": "^2.3.1",
     "date-fns": "2.28.0",
     "iframe-resizer-react": "^1.1.0",
     "lodash-es": "^4.17.21",

--- a/packages/shared/src/UI/components/ActionButton/index.tsx
+++ b/packages/shared/src/UI/components/ActionButton/index.tsx
@@ -5,7 +5,6 @@ import { makeStyles, ActionButton } from '@masknet/theme'
 import type { ButtonProps } from '@mui/material/Button'
 import { Check as CheckIcon, Error as ErrorIcon } from '@mui/icons-material'
 import { red, green } from '@mui/material/colors'
-import classNames from 'classnames'
 import { useDebounce, useAsyncFn, useUpdateEffect } from 'react-use'
 
 const useErrorStyles = makeStyles()((theme) => {
@@ -97,7 +96,7 @@ export interface ActionButtonPromiseProps extends ButtonProps {
 }
 type ActionButtonPromiseState = 'init' | 'complete' | 'wait' | 'fail'
 export function ActionButtonPromise(props: ActionButtonPromiseProps) {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const {
         executor,
         complete,
@@ -117,8 +116,8 @@ export function ActionButtonPromise(props: ActionButtonPromiseProps) {
     } = props
 
     const [state, setState] = useState<ActionButtonPromiseState>('init')
-    const completeClass = classNames(classes.success, b.className)
-    const failClass = classNames(classes.failed, b.className)
+    const completeClass = cx(classes.success, b.className)
+    const failClass = cx(classes.failed, b.className)
 
     const run = () => {
         setState('wait')

--- a/packages/shared/src/UI/components/ApplicationEntry/index.tsx
+++ b/packages/shared/src/UI/components/ApplicationEntry/index.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import type { Plugin } from '@masknet/plugin-infra'
 import { makeStyles, ShadowRootTooltip } from '@masknet/theme'
 import { Typography } from '@mui/material'
@@ -104,13 +103,13 @@ export function ApplicationEntry(props: ApplicationEntryProps) {
         iconFilterColor,
         popperBoundary,
     } = props
-    const { classes } = useStyles({ disabled, iconFilterColor })
+    const { classes, cx } = useStyles({ disabled, iconFilterColor })
     const jsx = recommendFeature ? (
         <div
             style={{
                 background: recommendFeature.backgroundGradient,
             }}
-            className={classNames(
+            className={cx(
                 classes.recommendFeatureApplicationBox,
                 disabled ? classes.disabled : classes.applicationBoxHover,
             )}
@@ -125,7 +124,7 @@ export function ApplicationEntry(props: ApplicationEntryProps) {
         </div>
     ) : (
         <div
-            className={classNames(classes.applicationBox, disabled ? classes.disabled : classes.applicationBoxHover)}
+            className={cx(classes.applicationBox, disabled ? classes.disabled : classes.applicationBoxHover)}
             onClick={disabled ? () => {} : onClick}>
             <div className={classes.iconWrapper}>{icon}</div>
             <Typography className={classes.title} color="textPrimary">
@@ -149,7 +148,7 @@ export function ApplicationEntry(props: ApplicationEntryProps) {
                 ],
             }}
             classes={{
-                arrow: classNames(classes.arrow, recommendFeature?.isFirst ? classes.firstAreaArrow : ''),
+                arrow: cx(classes.arrow, recommendFeature?.isFirst ? classes.firstAreaArrow : ''),
             }}
             placement={recommendFeature ? 'bottom' : 'top'}
             arrow

--- a/packages/shared/src/UI/components/AssetPlayer/index.tsx
+++ b/packages/shared/src/UI/components/AssetPlayer/index.tsx
@@ -64,7 +64,7 @@ enum AssetPlayerState {
 export const AssetPlayer = memo<AssetPlayerProps>((props) => {
     const ref = useRef<IFrameComponent | null>(null)
     const { url, type, options, iconProps, isFixedIframeSize = true, showNetwork = false, networkIcon } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const [hidden, setHidden] = useState(Boolean(props.renderTimeout))
     const { RPC_URLS } = getRPCConstants(props.erc721Token?.chainId)
     const rpc = first(RPC_URLS)

--- a/packages/shared/src/UI/components/AssetPreviewer/index.tsx
+++ b/packages/shared/src/UI/components/AssetPreviewer/index.tsx
@@ -31,7 +31,7 @@ const ASSET_PLAYER_FALLBACK_LIGHT = new URL('../Image/mask-light.png', import.me
 export function AssetPreviewer(props: AssetPreviewerProps) {
     const { fallbackImage, url, icon } = props
 
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const theme = useTheme()
 
     return (

--- a/packages/shared/src/UI/components/ChainBoundary/index.tsx
+++ b/packages/shared/src/UI/components/ChainBoundary/index.tsx
@@ -69,7 +69,7 @@ export function ChainBoundary<T extends NetworkPluginID>(props: ChainBoundaryPro
     } = props
 
     const t = useSharedI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const { pluginID: actualPluginID } = useNetworkContext()
     const plugin = useActivatedPlugin(actualPluginID, 'any')

--- a/packages/shared/src/UI/components/ChainIcon/index.tsx
+++ b/packages/shared/src/UI/components/ChainIcon/index.tsx
@@ -16,7 +16,7 @@ export interface ChainIconProps extends withClasses<'point'> {
 }
 
 export const ChainIcon = memo<ChainIconProps>(({ color, size = 12.5, ...props }) => {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <div

--- a/packages/shared/src/UI/components/ERC721ContractSelectPanel/index.tsx
+++ b/packages/shared/src/UI/components/ERC721ContractSelectPanel/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import classNames from 'classnames'
 import { ChainId, SchemaType } from '@masknet/web3-shared-evm'
 import { Box, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
@@ -71,7 +70,7 @@ export interface ERC721TokenSelectPanelProps {
 export function ERC721ContractSelectPanel(props: ERC721TokenSelectPanelProps) {
     const { onContractChange, onBalanceChange, contract, label, chainId = ChainId.Mainnet, balance } = props
     const t = useSharedI18N()
-    const { classes } = useStyles({ hasIcon: Boolean(contract?.logoURL) })
+    const { classes, cx } = useStyles({ hasIcon: Boolean(contract?.logoURL) })
     const { Others } = useWeb3State()
 
     const { setDialog: setNftContractDialog } = useRemoteControlledDialog(
@@ -106,7 +105,7 @@ export function ERC721ContractSelectPanel(props: ERC721TokenSelectPanelProps) {
                     </Typography>
                 )}
             </div>
-            <div className={classNames(classes.wrapper, classes.pointer)} onClick={openDialog}>
+            <div className={cx(classes.wrapper, classes.pointer)} onClick={openDialog}>
                 <div className={classes.tokenWrapper}>
                     {contract?.logoURL ? <img className={classes.icon} src={contract?.logoURL} /> : null}
                     {contract?.name ? (

--- a/packages/shared/src/UI/components/EthereumBlockie/index.tsx
+++ b/packages/shared/src/UI/components/EthereumBlockie/index.tsx
@@ -19,7 +19,7 @@ export interface EthereumBlockieProps extends withClasses<never> {
 
 export function EthereumBlockie(props: EthereumBlockieProps) {
     const { address, name } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const blockie = useBlockie(address)
 
     return (

--- a/packages/shared/src/UI/components/EthereumERC20TokenApprovedBoundary/index.tsx
+++ b/packages/shared/src/UI/components/EthereumERC20TokenApprovedBoundary/index.tsx
@@ -53,7 +53,7 @@ export function EthereumERC20TokenApprovedBoundary(props: EthereumERC20TokenAppr
     } = props
 
     const t = useSharedI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     const [{ type: approveStateType, allowance }, transactionState, approveCallback, resetApproveCallback] =
         useERC20TokenApproveCallback(token?.address ?? '', amount, spender ?? '', noop, expectedChainId)

--- a/packages/shared/src/UI/components/EthereumERC721TokenApprovedBoundary/index.tsx
+++ b/packages/shared/src/UI/components/EthereumERC721TokenApprovedBoundary/index.tsx
@@ -21,7 +21,7 @@ export function EthereumERC721TokenApprovedBoundary(props: EthereumERC712TokenAp
     const { owner, contractDetailed, operator, children, validationMessage: _validationMessage } = props
     const t = useSharedI18N()
     const { Others } = useWeb3State()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const { value, loading, retry } = useERC721ContractIsApproveForAll(contractDetailed?.address, owner, operator)
     const [approveState, approveCallback] = useERC721ContractSetApproveForAllCallback(
         contractDetailed?.address,

--- a/packages/shared/src/UI/components/Image/index.tsx
+++ b/packages/shared/src/UI/components/Image/index.tsx
@@ -1,5 +1,4 @@
 import { ImgHTMLAttributes, useState } from 'react'
-import classNames from 'classnames'
 import { LoadingBase, makeStyles, useStylesExtends } from '@masknet/theme'
 import { Box, useTheme } from '@mui/material'
 import { useImageURL } from '../../../hooks/useImageURL.js'
@@ -59,7 +58,7 @@ export function Image({
     onClick,
     ...rest
 }: ImageProps) {
-    const classes = useStylesExtends(useStyles({ size, rounded }), { classes: externalClasses })
+    const { classes, cx } = useStylesExtends(useStyles({ size, rounded }), { classes: externalClasses })
     const theme = useTheme()
     const [failed, setFailed] = useState(false)
 
@@ -93,7 +92,7 @@ export function Image({
     }
     if (fallback && !(fallback instanceof URL) && typeof fallback !== 'string') {
         return (
-            <Box className={classNames(classes.container, classes.failed)}>
+            <Box className={cx(classes.container, classes.failed)}>
                 <Box className={classes.floatingContainer}>{fallback}</Box>
             </Box>
         )
@@ -106,7 +105,7 @@ export function Image({
             : new URL('./mask-light.png', import.meta.url).toString())
 
     return (
-        <Box className={classNames(classes.container, classes.failed)} onClick={onClick}>
+        <Box className={cx(classes.container, classes.failed)} onClick={onClick}>
             <Box className={classes.floatingContainer}>
                 <img
                     loading="lazy"
@@ -115,7 +114,7 @@ export function Image({
                     height={size}
                     {...rest}
                     src={fallbackImageURL}
-                    className={classNames(classes.image, classes.failImage, classes.fallbackImage)}
+                    className={cx(classes.image, classes.failImage, classes.fallbackImage)}
                 />
             </Box>
         </Box>

--- a/packages/shared/src/UI/components/ImageIcon/index.tsx
+++ b/packages/shared/src/UI/components/ImageIcon/index.tsx
@@ -14,7 +14,7 @@ export interface ImageIconProps extends withClasses<'icon'> {
 
 export function ImageIcon(props: ImageIconProps) {
     const { size = 48, icon, iconFilterColor } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <img

--- a/packages/shared/src/UI/components/Markdown/index.tsx
+++ b/packages/shared/src/UI/components/Markdown/index.tsx
@@ -33,7 +33,7 @@ export interface MarkdownProps extends withClasses<'root'> {
 }
 
 export function Markdown(props: MarkdownProps) {
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     const html = purify(useRemarkable(props.content))
     return <div dangerouslySetInnerHTML={{ __html: html }} className={classes.root} />
 }

--- a/packages/shared/src/UI/components/NFTCard/index.tsx
+++ b/packages/shared/src/UI/components/NFTCard/index.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { Icons } from '@masknet/icons'
 import { ImageIcon, useIsImageURL } from '@masknet/shared'
 import { NetworkPluginID } from '@masknet/shared-base'
@@ -161,7 +160,7 @@ export function NFTImage(props: NFTImageProps) {
         size = 126,
         showNetwork = false,
     } = props
-    const { classes } = useStyles({ networkPluginID: pluginID })
+    const { classes, cx } = useStyles({ networkPluginID: pluginID })
     const iconURL = NETWORK_DESCRIPTORS.find((network) => network?.chainId === token.chainId)?.icon
 
     return (
@@ -171,7 +170,7 @@ export function NFTImage(props: NFTImageProps) {
                     onClick={() => onChange?.(token)}
                     src={token.metadata?.imageURL}
                     style={{ width: size, height: size }}
-                    className={classNames(
+                    className={cx(
                         classes.itemImage,
                         isSameNFT(pluginID, token, selectedToken) ? classes.itemSelected : '',
                     )}

--- a/packages/shared/src/UI/components/NFTCardStyledAssetPlayer/index.tsx
+++ b/packages/shared/src/UI/components/NFTCardStyledAssetPlayer/index.tsx
@@ -4,7 +4,6 @@ import type { Web3Helper } from '@masknet/web3-helpers'
 import { NetworkPluginID } from '@masknet/shared-base'
 import { NETWORK_DESCRIPTORS } from '@masknet/web3-shared-evm'
 import { useTheme } from '@mui/material'
-import classNames from 'classnames'
 import { useMemo } from 'react'
 import { useIsImageURL } from '../../../hooks/index.js'
 import { AssetPlayer } from '../AssetPlayer/index.js'
@@ -75,7 +74,7 @@ export function NFTCardStyledAssetPlayer(props: Props) {
         setSourceType,
         showNetwork = false,
     } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
     const theme = useTheme()
     const { value: tokenDetailed } = useNonFungibleToken<'all'>(
         NetworkPluginID.PLUGIN_EVM,
@@ -141,7 +140,7 @@ export function NFTCardStyledAssetPlayer(props: Props) {
             renderTimeout={renderOrder ? 20000 * Math.floor(renderOrder / 100) : undefined}
             fallbackImage={fallbackImageURL}
             classes={{
-                iframe: classNames(classes.wrapper, classes.iframe),
+                iframe: cx(classes.wrapper, classes.iframe),
                 errorPlaceholder: classes.wrapper,
                 loadingPlaceholder: classes.wrapper,
                 fallbackImage: classes.fallbackImage,

--- a/packages/shared/src/UI/components/NFTList/index.tsx
+++ b/packages/shared/src/UI/components/NFTList/index.tsx
@@ -1,6 +1,5 @@
 import { FC, useCallback } from 'react'
 import { noop } from 'lodash-unified'
-import classnames from 'classnames'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { ElementAnchor, Linking, AssetPreviewer, RetryHint } from '@masknet/shared'
 import { LoadingBase, makeStyles } from '@masknet/theme'
@@ -105,7 +104,7 @@ const useStyles = makeStyles<{ columns?: number; gap?: number }>()((theme, { col
 })
 
 export const NFTItem: FC<NFTItemProps> = ({ token }) => {
-    const { classes } = useStyles({})
+    const { classes, cx } = useStyles({})
     const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const { Others } = useWeb3State(NetworkPluginID.PLUGIN_EVM)
     const fullCaption = token.metadata?.name || token.tokenId
@@ -138,7 +137,7 @@ export const NFTList: FC<Props> = ({
     finished,
     hasError,
 }) => {
-    const { classes } = useStyles({ columns, gap })
+    const { classes, cx } = useStyles({ columns, gap })
 
     const isRadio = limit === 1
     const reachedLimit = selectedPairs && selectedPairs.length >= limit
@@ -165,7 +164,7 @@ export const NFTList: FC<Props> = ({
 
     return (
         <>
-            <List className={classnames(classes.list, className)}>
+            <List className={cx(classes.list, className)}>
                 {tokens.map((token) => {
                     const selected = selectedPairs
                         ? includes(selectedPairs, [token.contract?.address!, token.tokenId])
@@ -182,7 +181,7 @@ export const NFTList: FC<Props> = ({
                     return (
                         <ListItem
                             key={token.tokenId + token.id}
-                            className={classnames(classes.nftItem, {
+                            className={cx(classes.nftItem, {
                                 [classes.disabled]: disabled,
                                 [classes.selected]: selected,
                                 [classes.inactive]: inactive,

--- a/packages/shared/src/UI/components/PersonaAction/PersonaAction.tsx
+++ b/packages/shared/src/UI/components/PersonaAction/PersonaAction.tsx
@@ -1,4 +1,4 @@
-import { useStylesExtends, makeStyles, ShadowRootTooltip } from '@masknet/theme'
+import { makeStyles, ShadowRootTooltip } from '@masknet/theme'
 import { Box, Typography } from '@mui/material'
 import { useCopyToClipboard } from 'react-use'
 import { PlatformAvatar } from './PlatformAvatar.js'
@@ -36,7 +36,7 @@ interface PersonaActionProps {
 }
 
 export function PersonaAction(props: PersonaActionProps) {
-    const classes = useStylesExtends(useStyles(), {})
+    const { classes } = useStyles()
     const { currentPersona, avatar } = props
     const t = useSharedI18N()
 

--- a/packages/shared/src/UI/components/PersonaAction/PersonaImageIcon.tsx
+++ b/packages/shared/src/UI/components/PersonaAction/PersonaImageIcon.tsx
@@ -16,6 +16,6 @@ export interface PersonaImageIconProps extends withClasses<'icon'> {
 
 export function PersonaImageIcon(props: PersonaImageIconProps) {
     const { size = 48, icon, borderRadius = '50%' } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
     return <img height={size} width={size} src={icon?.toString()} className={classes.icon} style={{ borderRadius }} />
 }

--- a/packages/shared/src/UI/components/PersonaAction/PlatformAvatar.tsx
+++ b/packages/shared/src/UI/components/PersonaAction/PlatformAvatar.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { makeStyles, useStylesExtends } from '@masknet/theme'
 import { Icons } from '@masknet/icons'
 import { PersonaImageIcon } from './PersonaImageIcon.js'
@@ -39,7 +38,7 @@ interface PlatformAvatarProps extends withClasses<'networkIcon' | 'providerIcon'
 
 export const PlatformAvatar = (props: PlatformAvatarProps) => {
     const { size = 24, badgeSize = 14, inverse = false, networkIcon, providerIcon } = props
-    const classes = useStylesExtends(
+    const { classes, cx } = useStylesExtends(
         useStyles({
             size: badgeSize > size ? badgeSize : size,
             isBorderColorNotDefault: props.isBorderColorNotDefault,
@@ -49,8 +48,8 @@ export const PlatformAvatar = (props: PlatformAvatarProps) => {
 
     // #region icon names
     const names = inverse
-        ? [classNames(classes.badgeIcon, classes.providerIcon), classNames(classes.mainIcon, classes.networkIcon)]
-        : [classNames(classes.mainIcon, classes.networkIcon), classNames(classes.badgeIcon, classes.providerIcon)]
+        ? [cx(classes.badgeIcon, classes.providerIcon), cx(classes.mainIcon, classes.networkIcon)]
+        : [cx(classes.mainIcon, classes.networkIcon), cx(classes.badgeIcon, classes.providerIcon)]
     // #endregion
 
     return (

--- a/packages/shared/src/UI/components/SelectTokenChip/index.tsx
+++ b/packages/shared/src/UI/components/SelectTokenChip/index.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { noop } from 'lodash-unified'
 import { Chip, ChipProps } from '@mui/material'
 import { LoadingBase, makeStyles, useStylesExtends } from '@masknet/theme'
@@ -44,11 +43,11 @@ export interface SelectTokenChipProps extends withClasses<'chip' | 'tokenIcon' |
 export function SelectTokenChip(props: SelectTokenChipProps) {
     const t = useSharedI18N()
     const { token, error, loading = false, readonly = false, ChipProps, chainId } = props
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
     if (loading)
         return (
             <Chip
-                className={classNames(classes.chip, classes.loadingChip)}
+                className={cx(classes.chip, classes.loadingChip)}
                 icon={<LoadingBase size={16} />}
                 size="small"
                 clickable={false}
@@ -58,7 +57,7 @@ export function SelectTokenChip(props: SelectTokenChipProps) {
     if (!token)
         return (
             <Chip
-                className={classNames(classes.chip, classes.noToken)}
+                className={cx(classes.chip, classes.noToken)}
                 label={t.select_token()}
                 size="small"
                 clickable={!readonly}

--- a/packages/shared/src/UI/components/SourceSwitcher/index.tsx
+++ b/packages/shared/src/UI/components/SourceSwitcher/index.tsx
@@ -35,7 +35,7 @@ export interface SourceSwitcherProps extends withClasses<'source' | 'sourceNote'
 export function SourceSwitcher(props: SourceSwitcherProps) {
     const { sourceType, sourceTypes = [], onSourceTypeChange } = props
     const t = useSharedI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     return (
         <Box className={classes.source}>

--- a/packages/shared/src/UI/components/TokenAmountPanel/index.tsx
+++ b/packages/shared/src/UI/components/TokenAmountPanel/index.tsx
@@ -1,5 +1,4 @@
 import { ChangeEvent, useCallback, useMemo } from 'react'
-import classNames from 'classnames'
 import { BigNumber } from 'bignumber.js'
 import { Box, Chip, ChipProps, InputProps, StandardTextFieldProps, Typography } from '@mui/material'
 import { makeStyles, MaskTextField, useStylesExtends } from '@masknet/theme'
@@ -81,7 +80,7 @@ export function TokenAmountPanel(props: TokenAmountPanelProps) {
         MaxChipProps,
     } = props
     const t = useSharedI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
 
     // #region update amount by self
     const { RE_MATCH_WHOLE_AMOUNT, RE_MATCH_FRACTION_AMOUNT } = useMemo(
@@ -157,7 +156,7 @@ export function TokenAmountPanel(props: TokenAmountPanelProps) {
                             {balance !== '0' && !disableBalance ? (
                                 <Chip
                                     classes={{
-                                        root: classNames(classes.max, MaxChipProps?.classes?.root),
+                                        root: cx(classes.max, MaxChipProps?.classes?.root),
                                         ...MaxChipProps?.classes,
                                     }}
                                     size="small"

--- a/packages/shared/src/UI/components/WalletConnectedBoundary/index.tsx
+++ b/packages/shared/src/UI/components/WalletConnectedBoundary/index.tsx
@@ -1,5 +1,4 @@
 import { makeStyles, useStylesExtends, ActionButton, ActionButtonProps } from '@masknet/theme'
-import classNames from 'classnames'
 import { useRemoteControlledDialog } from '@masknet/shared-base-ui'
 import { WalletMessages } from '@masknet/plugin-wallet'
 import { useSharedI18N } from '../../../locales/index.js'
@@ -30,7 +29,7 @@ export function WalletConnectedBoundary(props: WalletConnectedBoundaryProps) {
     const { children = null, offChain = false, hideRiskWarningConfirmed = false } = props
 
     const t = useSharedI18N()
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes, cx } = useStylesExtends(useStyles(), props)
 
     const { pluginID } = useNetworkContext()
     const { account, chainId: chainIdValid } = useChainContext()
@@ -44,7 +43,7 @@ export function WalletConnectedBoundary(props: WalletConnectedBoundaryProps) {
         WalletMessages.events.selectProviderDialogUpdated,
     )
 
-    const buttonClass = classNames(classNames(classes.button, classes.connectWallet))
+    const buttonClass = cx(classes.button, classes.connectWallet)
 
     if (!account)
         return (

--- a/packages/shared/src/contexts/components/InjectedDialog.tsx
+++ b/packages/shared/src/contexts/components/InjectedDialog.tsx
@@ -2,7 +2,7 @@
 import { EnhanceableSite, isDashboardPage, CrossIsolationMessages } from '@masknet/shared-base'
 import { ErrorBoundary, useValueRef } from '@masknet/shared-base-ui'
 import { omit } from 'lodash-unified'
-import { makeStyles, mergeClasses, useDialogStackActor, usePortalShadowRoot, useStylesExtends } from '@masknet/theme'
+import { Cx, makeStyles, useDialogStackActor, usePortalShadowRoot, useStylesExtends } from '@masknet/theme'
 import {
     Dialog,
     DialogActions,
@@ -21,7 +21,6 @@ import { Children, cloneElement, useCallback } from 'react'
 import { useSharedI18N } from '../../locales/index.js'
 import { sharedUIComponentOverwrite, sharedUINetworkIdentifier } from '../base/index.js'
 import { DialogDismissIcon } from './DialogDismissIcon.js'
-import classnames from 'classnames'
 
 interface StyleProps {
     clean: boolean
@@ -107,17 +106,20 @@ export function InjectedDialog(props: InjectedDialogProps) {
     props = overwrite.InjectedDialog?.props?.(props) ?? props
     const clean = snsId === EnhanceableSite.Minds || snsId === EnhanceableSite.Facebook
     const {
-        dialogActions,
-        dialogCloseButton,
-        dialogContent,
-        dialogTitle,
-        dialogTitleEndingContent,
-        dialogTitleTabs,
-        dialogTitleWithTabs,
-        dialogTitleTypography,
-        dialogBackdropRoot,
-        container,
-        ...dialogClasses
+        classes: {
+            dialogActions,
+            dialogCloseButton,
+            dialogContent,
+            dialogTitle,
+            dialogTitleEndingContent,
+            dialogTitleTabs,
+            dialogTitleWithTabs,
+            dialogTitleTypography,
+            dialogBackdropRoot,
+            container,
+            ...dialogClasses
+        },
+        cx,
     } = useStylesExtends(useStyles({ clean }), props, overwrite.InjectedDialog?.classes)
 
     const t = useSharedI18N()
@@ -136,8 +138,8 @@ export function InjectedDialog(props: InjectedDialogProps) {
         isOpenFromApplicationBoard,
         ...rest
     } = props
-    const actions = CopyElementWithNewProps(children, DialogActions, { root: dialogActions })
-    const content = CopyElementWithNewProps(children, DialogContent, { root: dialogContent })
+    const actions = CopyElementWithNewProps(children, DialogActions, { root: dialogActions }, cx)
+    const content = CopyElementWithNewProps(children, DialogContent, { root: dialogContent }, cx)
     const { extraProps, shouldReplaceExitWithBack, TrackDialogHierarchy } = useDialogStackActor(open)
 
     const closeBothCompositionDialog = useCallback(() => {
@@ -181,7 +183,7 @@ export function InjectedDialog(props: InjectedDialogProps) {
                 <ErrorBoundary>
                     {title ? (
                         <DialogTitle
-                            className={classnames('dashboard-dialog-title-hook', titleTabs ? dialogTitleWithTabs : '')}
+                            className={cx('dashboard-dialog-title-hook', titleTabs ? dialogTitleWithTabs : '')}
                             classes={{ root: dialogTitle }}
                             style={{
                                 border: isDashboard || disableTitleBorder ? 'none' : undefined,
@@ -223,12 +225,13 @@ function CopyElementWithNewProps<T>(
     children: React.ReactNode,
     Target: React.ComponentType<T>,
     extraClasses: T extends { classes?: infer Q } ? Q : never,
+    cx: Cx,
 ) {
     return (
         Children.map(children, (child: any) =>
             child?.type === Target
                 ? cloneElement(child, {
-                      classes: mergeClasses(extraClasses as any, child.props.classes),
+                      classes: cx(extraClasses as any, child.props.classes),
                   } as DialogContentProps)
                 : null,
         ) || []

--- a/packages/shared/src/wallet/FormattedBalance.tsx
+++ b/packages/shared/src/wallet/FormattedBalance.tsx
@@ -24,7 +24,7 @@ export const FormattedBalance: FC<FormattedBalanceProps> = (props) => {
     if (minimumBalance && value && !isZero(formatted) && isLessThan(value, minimumBalance)) {
         formatted = '<' + formatter(minimumBalance, decimals, significant)
     }
-    const classes = useStylesExtends(useStyles(), props)
+    const { classes } = useStylesExtends(useStyles(), props)
 
     if (symbol)
         return (

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -33,7 +33,6 @@
     "@masknet/storybook-shared": "workspace:*",
     "@types/qrcode": "^1.5.0",
     "@types/tinycolor2": "^1.4.3",
-    "classnames": "^2.3.1",
     "fuse.js": "^6.6.2",
     "notistack": "2.0.5",
     "react-use": "^17.4.0",

--- a/packages/theme/src/Components/FolderTabs/index.tsx
+++ b/packages/theme/src/Components/FolderTabs/index.tsx
@@ -1,5 +1,4 @@
 import { Children, FC, useState, HTMLProps, ReactElement } from 'react'
-import classnames from 'classnames'
 import { makeStyles } from '../../UIHelper/makeStyles.js'
 import { MaskColorVar } from '../../CSSVariables/index.js'
 
@@ -63,8 +62,8 @@ interface TabPanelProps extends HTMLProps<HTMLDivElement> {
 }
 
 export const FolderTabPanel: FC<TabPanelProps> = ({ className, ...rest }) => {
-    const { classes } = useStyles()
-    return <div className={classnames(classes.tabPanel, className)} role="tabpanel" {...rest} />
+    const { classes, cx } = useStyles()
+    return <div className={cx(classes.tabPanel, className)} role="tabpanel" {...rest} />
 }
 
 type TabPanelReactElement = ReactElement<TabPanelProps, FC<TabPanelProps>>
@@ -72,7 +71,7 @@ type TabPanelReactElement = ReactElement<TabPanelProps, FC<TabPanelProps>>
 interface FolderTabsProps extends HTMLProps<HTMLDivElement> {}
 
 export const FolderTabs: FC<FolderTabsProps> = ({ children: childNodes, defaultValue = 0, ...rest }) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     const [value, setValue] = useState(defaultValue)
     const tabs = Children.map(childNodes as TabPanelReactElement[], (child, index) => {
         const label = child.props.label
@@ -83,7 +82,7 @@ export const FolderTabs: FC<FolderTabsProps> = ({ children: childNodes, defaultV
                 key={label}
                 tabIndex={index === 0 ? 0 : -1}
                 role="tab"
-                className={classnames(classes.tab, selected ? classes.selected : null)}
+                className={cx(classes.tab, selected ? classes.selected : null)}
                 onClick={() => setValue(childValue)}>
                 {label}
             </button>

--- a/packages/theme/src/Components/Snackbar/PopupSnackbar.tsx
+++ b/packages/theme/src/Components/Snackbar/PopupSnackbar.tsx
@@ -10,7 +10,6 @@ import {
     useSnackbar,
 } from 'notistack'
 import { makeStyles } from '../../UIHelper/index.js'
-import classnames from 'classnames'
 import type { ShowSnackbarOptions } from './index.js'
 
 const useStyles = makeStyles()(() => ({
@@ -50,7 +49,7 @@ const useStyles = makeStyles()(() => ({
 
 export const PopupSnackbarProvider = memo<SnackbarProviderProps>(({ ...rest }) => {
     const ref = useRef<SnackbarProvider>(null)
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
 
     return (
         <SnackbarProvider
@@ -79,10 +78,10 @@ export interface PopupSnackbarContentProps {
 }
 
 export const PopupSnackbarContent = forwardRef<HTMLDivElement, PopupSnackbarContentProps>((props, ref) => {
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
 
     return (
-        <SnackbarContent key={props.id} className={classnames(classes.content, classes[props.variant!])} ref={ref}>
+        <SnackbarContent key={props.id} className={cx(classes.content, classes[props.variant!])} ref={ref}>
             <Typography className={classes.title}>{props.title}</Typography>
         </SnackbarContent>
     )

--- a/packages/theme/src/Components/Snackbar/index.tsx
+++ b/packages/theme/src/Components/Snackbar/index.tsx
@@ -11,7 +11,6 @@ import {
     SnackbarAction,
     OptionsObject,
 } from 'notistack'
-import classnames from 'classnames'
 import { Typography, IconButton, alpha } from '@mui/material'
 import { Close as CloseIcon, Warning as WarningIcon, Info as InfoIcon } from '@mui/icons-material'
 import { Icons } from '@masknet/icons'
@@ -217,7 +216,7 @@ const IconMap: Record<VariantType, React.ReactNode> = {
 }
 
 export const CustomSnackbarContent = forwardRef<HTMLDivElement, CustomSnackbarContentProps>((props, ref) => {
-    const classes = useStylesExtends(useStyles({ offsetY: props.offsetY }), props)
+    const { classes, cx } = useStylesExtends(useStyles({ offsetY: props.offsetY }), props)
     const snackbar = useSnackbar()
     const loadingIcon = <Icons.CircleLoading className={classes.spinning} />
     const variantIcon = props.processing ? loadingIcon : props.variant ? IconMap[props.variant] : null
@@ -230,7 +229,7 @@ export const CustomSnackbarContent = forwardRef<HTMLDivElement, CustomSnackbarCo
         renderedAction = typeof props.action === 'function' ? props.action(props.id) : props.action
     }
     return (
-        <SnackbarContent ref={ref} className={classnames(classes.content, classes[props.variant!])}>
+        <SnackbarContent ref={ref} className={cx(classes.content, classes[props.variant!])}>
             {variantIcon && <div className={classes.icon}>{variantIcon}</div>}
             <div className={classes.texts}>
                 <Typography className={classes.title} variant="h2">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,9 +362,6 @@ importers:
       bignumber.js:
         specifier: 9.1.0
         version: 9.1.0
-      classnames:
-        specifier: ^2.3.1
-        version: 2.3.1
       color:
         specifier: ^4.2.3
         version: 4.2.3
@@ -782,9 +779,6 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
-      classnames:
-        specifier: ^2.3.1
-        version: 2.3.1
       clipboard-polyfill:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1650,9 +1644,6 @@ importers:
       bignumber.js:
         specifier: 9.1.0
         version: 9.1.0
-      classnames:
-        specifier: ^2.3.1
-        version: 2.3.1
       date-fns:
         specifier: ^2.28.0
         version: 2.28.0
@@ -1873,9 +1864,6 @@ importers:
       '@types/use-subscription':
         specifier: ^1.0.0
         version: 1.0.0
-      classnames:
-        specifier: ^2.3.1
-        version: 2.3.1
       date-fns:
         specifier: 2.28.0
         version: 2.28.0
@@ -2127,9 +2115,6 @@ importers:
       bignumber.js:
         specifier: 9.1.0
         version: 9.1.0
-      classnames:
-        specifier: ^2.3.1
-        version: 2.3.1
       date-fns:
         specifier: 2.28.0
         version: 2.28.0
@@ -2305,9 +2290,6 @@ importers:
       '@types/tinycolor2':
         specifier: ^1.4.3
         version: 1.4.3
-      classnames:
-        specifier: ^2.3.1
-        version: 2.3.1
       fuse.js:
         specifier: ^6.6.2
         version: 6.6.2
@@ -15489,10 +15471,6 @@ packages:
       define-property: 0.2.5
       isobject: 3.0.1
       static-extend: 0.1.2
-
-  /classnames/2.3.1:
-    resolution: {integrity: sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==}
-    dev: false
 
   /clean-css/4.2.4:
     resolution: {integrity: sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==}


### PR DESCRIPTION
-   Migrate `useStyleExtends` to the same API shape with `useStyles`
-   Use `cx` in `useStyleExtends`
-   Migrate all use of `classnames` package to `cx`
