### PR TITLE
Revert "refactor: squashed fetch (#7719)"

### DIFF
--- a/packages/mask/background/services/helper/r2d2Fetch.ts
+++ b/packages/mask/background/services/helper/r2d2Fetch.ts
@@ -36,59 +36,7 @@ const HOTFIX_RPC_URLS = [
     'evm.confluxrpc.com',
 ]
 
-enum CACHE_DURATION {
-    INSTANT = 3000, // 3 seconds
-    SHORT = 60000, // 1 min
-    LONG = 1800000, // 30 mins
-}
-
-const CACHE_RULES = {
-    'https://proof-service.nextnext.id/v1/proof': CACHE_DURATION.INSTANT,
-    // twitter shorten links
-    'https://t.co': CACHE_DURATION.LONG,
-    'https://gitcoin.co/grants/v1/api/grant': CACHE_DURATION.SHORT,
-    'https://vcent-agent.r2d2.to': CACHE_DURATION.SHORT,
-    'https://rss3.domains/name': CACHE_DURATION.SHORT,
-    // avatar on RSS3 kv queries
-    'https://kv.r2d2.to/api/com.maskbook.user_twitter.com': CACHE_DURATION.SHORT,
-    'https://discovery.attrace.com': CACHE_DURATION.SHORT,
-    // mask-x
-    '7x16bogxfb.execute-api.us-east-1.amazonaws.com': CACHE_DURATION.SHORT,
-}
-const CACHE_URLS = Object.keys(CACHE_RULES) as unknown as Array<keyof typeof CACHE_RULES>
-
 const { fetch: originalFetch } = globalThis
-
-async function squashedFetch(request: RequestInfo, init?: RequestInit): Promise<Response> {
-    // skip all side effect requests
-    if (typeof request !== 'string' && request.method !== 'GET') return originalFetch(request, init)
-
-    // skip all non-http requests
-    const url = typeof request === 'string' ? request : request.url
-    if (!url.startsWith('http')) return originalFetch(request, init)
-
-    // no need to cache
-    const rule = CACHE_URLS.find((x) => url.includes(x))
-    if (!rule) return originalFetch(request, init)
-
-    // hit a cached request
-    const cache = await caches.open(rule)
-    const hit = await cache.match(request)
-    if (hit) return hit
-
-    // send the request & cache the response
-    const response = await originalFetch(request, init)
-
-    if (response.ok && response.status === 200) {
-        await cache.put(request, response)
-
-        // stale the cache
-        setTimeout(async () => {
-            await cache.delete(request)
-        }, CACHE_RULES[rule])
-    }
-    return response
-}
 
 /**
  * Why use r2d2 fetch: some third api provider will be block in Firefox and protect api key
@@ -115,7 +63,7 @@ export async function r2d2Fetch(input: RequestInfo, init?: RequestInit): Promise
     }
 
     // r2d2
-    if (url.includes(R2D2_ROOT_URL)) return squashedFetch(request, init)
+    if (url.includes(R2D2_ROOT_URL)) return originalFetch(request, init)
 
     // infura ipfs
     if (url.includes(INFURA_IPFS_ROOT_URL)) return originalFetch(request, init)
@@ -125,7 +73,7 @@ export async function r2d2Fetch(input: RequestInfo, init?: RequestInit): Promise
         return originalFetch(request, { ...init, headers: { ...request?.headers, 'Content-Type': 'application/json' } })
 
     // fallback
-    return squashedFetch(request, init)
+    return originalFetch(request, init)
 }
 
 Reflect.set(globalThis, 'r2d2Fetch', r2d2Fetch)

--- a/packages/mask/src/plugins/VCent/SNSAdaptor/index.tsx
+++ b/packages/mask/src/plugins/VCent/SNSAdaptor/index.tsx
@@ -41,7 +41,7 @@ function Component() {
     const tweetAddress = usePostInfoDetails.snsID()
 
     if (!tweetAddress) return null
-    if (!location.href.includes(`/status/${tweetAddress}`)) return null
+
     return (
         <Web3ContextProvider value={{ pluginID: NetworkPluginID.PLUGIN_EVM, chainId: ChainId.Mainnet }}>
             <VCentDialog tweetAddress={tweetAddress} />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5390719/200111110-424e6f41-f0dc-495e-8efa-a779aff5f4d1.png)

cc @guanbinrui A `Response` object contains an internal stream, can be read by `.blob()`, `.text()`, `.json()`, `.body` (a `ReadableStream`), and it can _only be read once_. If you already consume the internal item, the second consumption will cause an error.

It seems like you reuse the `Response` in the wrong way. I guess, the first consume happens at: 

```js
await cache.put(request, response)
```

the second consumption is used as a return value. You may need to use `tee` https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/tee to copy the stream and construct a new Response.