### PR TITLE
chore: nft rp hide some network tabs

### DIFF
--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
@@ -81,8 +81,11 @@ export default function RedPacketDialog(props: RedPacketDialogProps) {
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const chainIdValid = useChainIdValid(NetworkPluginID.PLUGIN_EVM, chainId)
     const approvalDefinition = useActivatedPlugin(PluginID.RedPacket, 'any')
+    const [currentTab, onChange, tabs] = useTabs('tokens', 'collectibles')
     const chainIdList = compact<ChainId>(
-        approvalDefinition?.enableRequirement.web3?.[NetworkPluginID.PLUGIN_EVM]?.supportedChainIds ?? [],
+        currentTab === tabs.tokens
+            ? approvalDefinition?.enableRequirement.web3?.[NetworkPluginID.PLUGIN_EVM]?.supportedChainIds ?? []
+            : [ChainId.Mainnet, ChainId.BSC, ChainId.Matic],
     )
     const networkTabChainId = chainIdValid && chainIdList.includes(chainId) ? chainId : ChainId.Mainnet
 
@@ -175,7 +178,6 @@ export default function RedPacketDialog(props: RedPacketDialogProps) {
         : isCreateStep
         ? t.display_name()
         : t.details()
-    const [currentTab, onChange, tabs] = useTabs('tokens', 'collectibles')
 
     return (
         <Web3ContextProvider value={{ pluginID: NetworkPluginID.PLUGIN_EVM, chainId: networkTabChainId }}>
@@ -212,6 +214,7 @@ export default function RedPacketDialog(props: RedPacketDialogProps) {
                                             tabPaper: classes.tabPaper,
                                         }}
                                         chains={chainIdList}
+                                        hideArrowButton={currentTab === tabs.collectibles}
                                     />
                                 </div>
                                 <div

--- a/packages/shared/src/UI/components/NetworkTab/index.tsx
+++ b/packages/shared/src/UI/components/NetworkTab/index.tsx
@@ -10,6 +10,7 @@ import { Stack, Tab, Typography } from '@mui/material'
 interface NetworkTabProps<T extends NetworkPluginID>
     extends withClasses<'tab' | 'tabs' | 'tabPanel' | 'indicator' | 'focusTab' | 'tabPaper'> {
     chains: Array<Web3Helper.Definition[T]['ChainId']>
+    hideArrowButton?: boolean
 }
 
 export function NetworkTab<T extends NetworkPluginID = NetworkPluginID.PLUGIN_EVM>(props: NetworkTabProps<T>) {
@@ -37,6 +38,7 @@ export function NetworkTab<T extends NetworkPluginID = NetworkPluginID.PLUGIN_EV
                     setChainId?.(Number.parseInt(v, 10))
                     setTab(v)
                 }}
+                hideArrowButton={props.hideArrowButton}
                 aria-label="Network Tabs">
                 {usedNetworks.map((x) => {
                     return (

--- a/packages/theme/src/Components/Tabs/index.tsx
+++ b/packages/theme/src/Components/Tabs/index.tsx
@@ -25,6 +25,7 @@ export interface MaskTabListProps
     onChange(event: object, value: string): void
     'aria-label': string
     variant?: MaskTabVariant
+    hideArrowButton?: boolean
 }
 
 const ArrowButtonWrap = styled(Button)(({ theme }) => ({
@@ -252,12 +253,12 @@ export const MaskTabList = forwardRef<HTMLDivElement, MaskTabListProps>((props, 
                     <FlexButtonGroupWrap
                         maskVariant={variant}
                         isOpen={open}
-                        isOverflow={isTabsOverflow}
+                        isOverflow={isTabsOverflow && !props.hideArrowButton}
                         {...rest}
                         ref={innerRef}
                         role="tablist">
                         {flexibleTabs}
-                        {isTabsOverflow && (
+                        {isTabsOverflow && !props.hideArrowButton && (
                             <ArrowButtonWrap
                                 variant="text"
                                 size="small"


### PR DESCRIPTION
## Description
https://mask.atlassian.net/browse/MF-2602

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
