### PR TITLE
refactor: use mask-src instead of webpack in package.json

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -76,10 +76,19 @@ function assertInstallationSourceValid(parentPackage, dependedPackage, installat
 
 /* cspell:enable */
 
-function validatePackage({ dependencies, devDependencies, optionalDependencies, peerDependencies, name }) {
+function validatePackage({ dependencies, optionalDependencies, peerDependencies, name, exports }) {
+    if (
+        exports &&
+        !name.startsWith('@dimensiondev') &&
+        !name.startsWith('@masknet') &&
+        JSON.stringify(exports).includes('mask-src')
+    ) {
+        throw new Error(
+            'A package ' + name + ' out of @dimensiondev or @masknet scope using mask-src in exports field.',
+        )
+    }
     for (const [k, v] of notNormativeInstall(dependencies)) assertInstallationSourceValid(name, k, v)
     // devDependencies won't be installed for intermediate dependencies
-    // for (const [k, v] of notNormativeInstall(devDependencies)) assertInstallationSourceValid(name, k, v)
     for (const [k, v] of notNormativeInstall(optionalDependencies)) assertInstallationSourceValid(name, k, v)
     for (const [k, v] of notNormativeInstall(peerDependencies)) assertInstallationSourceValid(name, k, v)
 }

--- a/packages/backup-format/package.json
+++ b/packages/backup-format/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/configuration/package.json
+++ b/packages/configuration/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/entry.tsx",
+      "mask-src": "./src/entry.tsx",
       "default": "./dist/src/entry.js"
     }
   },

--- a/packages/empty/package.json
+++ b/packages/empty/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/external-plugin-previewer/package.json
+++ b/packages/external-plugin-previewer/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.tsx",
+      "mask-src": "./src/index.tsx",
       "default": "./dist/index.js"
     }
   },

--- a/packages/gun-utils/package.json
+++ b/packages/gun-utils/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/injected-script/package.json
+++ b/packages/injected-script/package.json
@@ -6,12 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/sdk/index.d.ts",
-      "webpack": "./sdk/index.ts",
+      "mask-src": "./sdk/index.ts",
       "default": "./dist/sdk/index.js"
     },
     "./shared": {
       "types": "./dist/shared/index.d.ts",
-      "webpack": "./shared/index.ts",
+      "mask-src": "./shared/index.ts",
       "default": "./dist/shared/index.js"
     }
   },

--- a/packages/mask-sdk/package.json
+++ b/packages/mask-sdk/package.json
@@ -6,7 +6,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./server/index.ts",
+      "mask-src": "./server/index.ts",
       "default": "./dist/server/index.js"
     }
   },

--- a/packages/mask/.webpack/config.ts
+++ b/packages/mask/.webpack/config.ts
@@ -76,6 +76,7 @@ export function createConfiguration(_inputFlags: BuildFlags): Configuration {
                 buffer: require.resolve('buffer'),
                 'text-encoding': require.resolve('@sinonjs/text-encoding'),
             },
+            conditionNames: ['mask-src', '...'],
         },
         module: {
             parser: {

--- a/packages/plugin-infra/package.json
+++ b/packages/plugin-infra/package.json
@@ -6,27 +6,27 @@
   "exports": {
     ".": {
       "types": "./dist/entry.d.ts",
-      "webpack": "./src/entry.ts",
+      "mask-src": "./src/entry.ts",
       "default": "./dist/entry.js"
     },
     "./dom": {
       "types": "./dist/entry-dom.d.ts",
-      "webpack": "./src/entry-dom.ts",
+      "mask-src": "./src/entry-dom.ts",
       "default": "./dist/entry-dom.js"
     },
     "./background-worker": {
       "types": "./dist/entry-background-worker.d.ts",
-      "webpack": "./src/entry-background-worker.ts",
+      "mask-src": "./src/entry-background-worker.ts",
       "default": "./dist/entry-background-worker.js"
     },
     "./dashboard": {
       "types": "./dist/entry-dashboard.d.ts",
-      "webpack": "./src/entry-dashboard.ts",
+      "mask-src": "./src/entry-dashboard.ts",
       "default": "./dist/entry-dashboard.js"
     },
     "./content-script": {
       "types": "./dist/entry-content-script.d.ts",
-      "webpack": "./src/entry-content-script.ts",
+      "mask-src": "./src/entry-content-script.ts",
       "default": "./dist/entry-content-script.js"
     }
   },

--- a/packages/plugins/Approval/package.json
+++ b/packages/plugins/Approval/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/CrossChainBridge/package.json
+++ b/packages/plugins/CrossChainBridge/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/CyberConnect/package.json
+++ b/packages/plugins/CyberConnect/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/Debugger/package.json
+++ b/packages/plugins/Debugger/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/ENS/package.json
+++ b/packages/plugins/ENS/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/EVM/package.json
+++ b/packages/plugins/EVM/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/FileService/package.json
+++ b/packages/plugins/FileService/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/Flow/package.json
+++ b/packages/plugins/Flow/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/GoPlusSecurity/package.json
+++ b/packages/plugins/GoPlusSecurity/package.json
@@ -4,12 +4,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./messages": {
       "types": "./dist/messages.d.ts",
-      "webpack": "./src/messages.ts",
+      "mask-src": "./src/messages.ts",
       "default": "./dist/messages.d.ts"
     }
   },

--- a/packages/plugins/RSS3/package.json
+++ b/packages/plugins/RSS3/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/ScamSniffer/package.json
+++ b/packages/plugins/ScamSniffer/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/Solana/package.json
+++ b/packages/plugins/Solana/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/Wallet/package.json
+++ b/packages/plugins/Wallet/package.json
@@ -5,12 +5,12 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./components": {
       "types": "./dist/components.d.ts",
-      "webpack": "./src/components.ts",
+      "mask-src": "./src/components.ts",
       "default": "./dist/components.js"
     }
   },

--- a/packages/plugins/Web3Profile/package.json
+++ b/packages/plugins/Web3Profile/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/example/package.json
+++ b/packages/plugins/example/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/template/package.json
+++ b/packages/plugins/template/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/public-api/package.json
+++ b/packages/public-api/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/sandboxed-plugin-runtime/package.json
+++ b/packages/sandboxed-plugin-runtime/package.json
@@ -10,17 +10,17 @@
     },
     "./background": {
       "types": "./dist/background/index.d.ts",
-      "webpack": "./src/background/index.ts",
+      "mask-src": "./src/background/index.ts",
       "default": "./dist/background/index.js"
     },
     "./site-adaptor": {
       "types": "./dist/site-adaptor/index.d.ts",
-      "webpack": "./src/site-adaptor/index.ts",
+      "mask-src": "./src/site-adaptor/index.ts",
       "default": "./dist/site-adaptor/index.js"
     },
     "./extension-page": {
       "types": "./dist/extension-page/index.d.ts",
-      "webpack": "./src/extension-page/index.ts",
+      "mask-src": "./src/extension-page/index.ts",
       "default": "./dist/extension-page/index.js"
     }
   },

--- a/packages/shared-base-ui/package.json
+++ b/packages/shared-base-ui/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/shared-base/package.json
+++ b/packages/shared-base/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/storybook-shared/package.json
+++ b/packages/storybook-shared/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./patch-webpack": "./patch-webpack.cjs",

--- a/packages/storybook-shared/patch-webpack.cjs
+++ b/packages/storybook-shared/patch-webpack.cjs
@@ -34,6 +34,7 @@ module.exports = async function (config) {
         http: false,
         https: false,
     }
+    config.resolve.conditionNames = ['mask-src', '...']
 
     config.module.rules.push({
         test: /\.m?js$/,

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -6,12 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/src/entry.d.ts",
-      "webpack": "./src/entry.ts",
+      "mask-src": "./src/entry.ts",
       "default": "./dist/src/entry.d.ts"
     },
     "./base": {
       "types": "./dist/src/entry-base.d.ts",
-      "webpack": "./src/entry-base.ts",
+      "mask-src": "./src/entry-base.ts",
       "default": "./dist/src/entry-base.js"
     }
   },

--- a/packages/typed-message/package.json
+++ b/packages/typed-message/package.json
@@ -5,12 +5,12 @@
   "exports": {
     ".": {
       "types": "./dist/base/index.d.ts",
-      "webpack": "./base/index.ts",
+      "mask-src": "./base/index.ts",
       "default": "./dist/base/index.js"
     },
     "./dom": {
       "types": "./dist/dom/index.d.ts",
-      "webpack": "./dom/index.ts",
+      "mask-src": "./dom/index.ts",
       "default": "./dist/dom/index.js"
     }
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-helpers/package.json
+++ b/packages/web3-helpers/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-hooks/base/package.json
+++ b/packages/web3-hooks/base/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-hooks/evm/package.json
+++ b/packages/web3-hooks/evm/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-providers/package.json
+++ b/packages/web3-providers/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-shared/base/package.json
+++ b/packages/web3-shared/base/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-shared/evm/package.json
+++ b/packages/web3-shared/evm/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-shared/flow/package.json
+++ b/packages/web3-shared/flow/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.js",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-shared/solana/package.json
+++ b/packages/web3-shared/solana/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.js",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/web3-state/package.json
+++ b/packages/web3-state/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "webpack": "./src/index.ts",
+      "mask-src": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
Reason:

we're going to release some packages on npm. if we still use 'webpack' as entry, the package consumers will have
troubles.
