### PR TITLE
[Release] Hotfix 2.15.4 => 2.15.5 (patch) (#7962)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "yarn": ">=999.0.0",
     "npm": ">=999.0.0"
   },
-  "version": "2.15.4",
+  "version": "2.15.5",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/packages/mask/src/manifest.json
+++ b/packages/mask/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Mask Network",
-    "version": "2.15.4",
+    "version": "2.15.5",
     "manifest_version": 2,
     "permissions": ["storage", "downloads", "webNavigation", "activeTab"],
     "optional_permissions": ["<all_urls>", "notifications", "clipboardRead"],

--- a/packages/mask/src/plugins/Tips/SNSAdaptor/components/TipsRealmContent/index.tsx
+++ b/packages/mask/src/plugins/Tips/SNSAdaptor/components/TipsRealmContent/index.tsx
@@ -8,75 +8,78 @@ import { useI18N } from '../../../locales/index.js'
 import { useTipsUserGuide } from '../../../storage/index.js'
 import { activatedSocialNetworkUI } from '../../../../../social-network/ui.js'
 
-const useStyles = makeStyles<{ iconSize: number }, 'postTipsButton'>()((theme, { iconSize }, refs) => ({
-    focusingPostButtonWrapper: {
-        height: 46,
-    },
-    postButtonWrapper: {
-        display: 'flex',
-        alignItems: 'center',
-        color: '#8899a6',
-        position: 'relative',
-        [`& .${refs.postTipsButton}::before`]: {
-            content: '""',
-            width: 34,
-            height: 34,
+const useStyles = makeStyles<{ iconSize: number; buttonSize: number }, 'postTipsButton'>()(
+    (theme, { iconSize, buttonSize }, refs) => ({
+        focusingPostButtonWrapper: {
+            height: 46,
+        },
+        postButtonWrapper: {
+            display: 'flex',
+            alignItems: 'center',
+            color: '#8899a6',
+            position: 'relative',
+            [`& .${refs.postTipsButton}::before`]: {
+                content: '""',
+                width: 34,
+                height: 34,
+                position: 'absolute',
+                borderRadius: '100%',
+                zIndex: 0,
+            },
+            [`&:hover .${refs.postTipsButton}::before`]: {
+                backgroundColor: 'rgba(20,155,240,0.1)',
+            },
+        },
+        mirrorEntryTipsButtonWrapper: {
+            justifyContent: 'flex-end',
+        },
+        postTipsButton: {},
+        roundButton: {
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: theme.palette.maskColor.borderSecondary,
+            verticalAlign: 'top',
+            color: theme.palette.text.primary,
+            '&:hover': {
+                backgroundColor: theme.palette.mode === 'dark' ? 'rgba(239,243,244,0.1)' : 'rgba(15,20,25,0.1)',
+            },
+        },
+        followTipsButton: {
             position: 'absolute',
+            width: '100%',
+            height: '100%',
+            left: 0,
+            top: 0,
             borderRadius: '100%',
-            zIndex: 0,
         },
-        [`&:hover .${refs.postTipsButton}::before`]: {
-            backgroundColor: 'rgba(20,155,240,0.1)',
+        profileTipsButton: {
+            position: 'absolute',
+            width: buttonSize,
+            height: buttonSize,
+            left: 0,
+            top: 0,
+            borderRadius: '100%',
         },
-    },
-    mirrorEntryTipsButtonWrapper: {
-        justifyContent: 'flex-end',
-    },
-    postTipsButton: {},
-    roundButton: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        borderWidth: 1,
-        borderStyle: 'solid',
-        borderColor: theme.palette.maskColor.borderSecondary,
-        verticalAlign: 'top',
-        color: theme.palette.text.primary,
-        '&:hover': {
-            backgroundColor: theme.palette.mode === 'dark' ? 'rgba(239,243,244,0.1)' : 'rgba(15,20,25,0.1)',
+        icon: {
+            width: iconSize,
+            height: iconSize,
         },
-    },
-    followTipsButton: {
-        position: 'absolute',
-        width: '100%',
-        height: '100%',
-        left: 0,
-        top: 0,
-        borderRadius: '100%',
-    },
-    profileTipsButton: {
-        position: 'absolute',
-        width: '100%',
-        height: '100%',
-        left: 0,
-        top: 0,
-        borderRadius: '100%',
-    },
-    icon: {
-        width: iconSize,
-        height: iconSize,
-    },
-}))
+    }),
+)
 
 export const TipsRealmContent: Plugin.InjectUI<Plugin.SNSAdaptor.TipsRealmOptions> = ({
     identity,
     slot,
     accounts,
     iconSize = 24,
+    buttonSize = 34,
     onStatusUpdate,
 }) => {
     const t = useI18N()
-    const { classes, cx } = useStyles({ iconSize })
+    const { classes, cx } = useStyles({ iconSize, buttonSize })
     const lastStep = useTipsUserGuide(activatedSocialNetworkUI.networkIdentifier as EnhanceableSite)
 
     if (!identity) return null

--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/ProfileTab.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/ProfileTab.tsx
@@ -20,6 +20,8 @@ function getStyleProps() {
     const EMPTY_STYLE = {} as CSSStyleDeclaration
     const eleTab = searchProfileTabSelector().evaluate()?.querySelector<Element>('div > div')
     const style = eleTab ? window.getComputedStyle(eleTab) : EMPTY_STYLE
+    const paddingEle = searchProfileTabSelector().evaluate()
+    const paddingCss = paddingEle ? window.getComputedStyle(paddingEle) : EMPTY_STYLE
     const eleNewTweetButton = searchNewTweetButtonSelector().evaluate()
     const newTweetButtonColorStyle = eleNewTweetButton ? window.getComputedStyle(eleNewTweetButton) : EMPTY_STYLE
     const eleBackButton = searchAppBarBackSelector().evaluate()
@@ -30,7 +32,7 @@ function getStyleProps() {
         font: style.font,
         fontSize: style.fontSize,
         padding: style.paddingBottom,
-        paddingX: style.paddingLeft || '16px',
+        paddingX: paddingCss.paddingLeft || '16px',
         height: style.height || '53px',
         hover: backButtonColorStyle.color,
         line: newTweetButtonColorStyle.backgroundColor,

--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/Tips/ProfileTipButton.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/Tips/ProfileTipButton.tsx
@@ -65,6 +65,14 @@ function ProfileTipsSlot() {
         const svgCss = window.getComputedStyle(svg)
         return Number.parseFloat(svgCss.width.replace('px', ''))
     }, [location])
+
+    const buttonSize = useMemo(() => {
+        const button = menuButtonSelector().querySelector('div').evaluate()
+        if (!button) return 34
+        const buttonCss = window.getComputedStyle(button)
+        const buttonSize = Number.parseFloat(buttonCss.height.replace('px', ''))
+        return buttonSize === 0 ? 34 : buttonSize - 2
+    }, [location])
     const component = useMemo(() => {
         const Component = createInjectHooksRenderer(
             useActivatedPluginsSNSAdaptor.visibility.useNotMinimalMode,
@@ -76,6 +84,7 @@ function ProfileTipsSlot() {
                 identity={visitingPersona.identifier}
                 slot={Plugin.SNSAdaptor.TipsSlot.Profile}
                 iconSize={iconSize}
+                buttonSize={buttonSize}
                 onStatusUpdate={setDisabled}
             />
         )

--- a/packages/plugin-infra/src/types.ts
+++ b/packages/plugin-infra/src/types.ts
@@ -691,6 +691,7 @@ export namespace Plugin.SNSAdaptor {
         slot: TipsSlot
         accounts?: SocialAccount[]
         iconSize?: number
+        buttonSize?: number
         onStatusUpdate?(disabled: boolean): void
     }
     export interface TipsRealm {

--- a/packages/plugins/Web3Profile/src/locales/en-US.json
+++ b/packages/plugins/Web3Profile/src/locales/en-US.json
@@ -27,7 +27,7 @@
     "listed": "Listed",
     "unlisted": "Unlisted",
     "add_wallet": "Add Wallet",
-    "add_wallet_to_connected": "No connected wallet, pleae add wallet.",
+    "add_wallet_to_connected": "No connected wallet. Please add wallet.",
     "open_wallet": "You’ve switched off all wallets. Please go to settings to active.",
     "tip_persona_sign_success": "Persona signed successfully.",
     "tip_wallet_sign_error": "Wallet connection failed.",


### PR DESCRIPTION
* chore: bump version to 2.15.5

* fix: mf-2732 web3 tab activation will hide twiter's own tabs (#7955)

* fix: web3 tab selector (#7950)

Co-authored-by: guanbinrui <52657989+guanbinrui@users.noreply.github.com>

* fix: typo

* fix: tips icon size (#7964) (#7971)

* fix: useI18N (#7973)

* fix: web3 tab padding (#7974)

* fix: tips button size (#7975)

* fix: adjust tip button size (#7977)

* fix: adjust tip button size

* fix: reply review

* fix: typo

Co-authored-by: UncleBill <billbill290@gmail.com>
Co-authored-by: lelenei <72531217+lelenei@users.noreply.github.com>

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
