### PR TITLE
fix(v.cent): eth icon

### DIFF
--- a/packages/mask/src/plugins/VCent/SNSAdaptor/TweetDialog.tsx
+++ b/packages/mask/src/plugins/VCent/SNSAdaptor/TweetDialog.tsx
@@ -3,6 +3,7 @@ import { alpha, Box, Button, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { useAsync } from 'react-use'
 import { PluginVCentRPC } from '../messages.js'
+import { ChainId } from '@masknet/web3-shared-evm'
 import { useI18N } from '../../../utils/index.js'
 import { usePluginWrapper } from '@masknet/plugin-infra/content-script'
 import { Icons } from '@masknet/icons'
@@ -53,7 +54,7 @@ export default function VCentDialog({ tweetAddress }: { tweetAddress: string }) 
     const { value: tweets } = useAsync(() => PluginVCentRPC.getTweetData(tweetAddress), [tweetAddress])
     const tweet = first(tweets)
     usePluginWrapper(tweet?.type === 'Offer')
-    const networkDescriptor = useNetworkDescriptor()
+    const networkDescriptor = useNetworkDescriptor(undefined, ChainId.Mainnet)
     // only offer tweets
     if (tweet?.type !== 'Offer') return null
 


### PR DESCRIPTION
Despite NFT metadata is stored at Polygon, price unit follows Mainnet.

https://mask.atlassian.net/browse/MF-2751

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
