### PR TITLE
refactor: stale HTTP cache

### DIFF
--- a/packages/mask/src/extension/popups/pages/Wallet/ContractInteraction/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/ContractInteraction/index.tsx
@@ -200,7 +200,7 @@ const ContractInteraction = memo(() => {
             case TransactionDescriptorType.DEPLOYMENT:
             case TransactionDescriptorType.RETRY:
             case TransactionDescriptorType.CANCEL:
-                throw new Error('To be implemented.')
+                throw new Error('Method not implemented.')
             default:
                 unreachable(type)
         }

--- a/packages/mask/src/extension/popups/pages/Wallet/ContractInteraction/index.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/ContractInteraction/index.tsx
@@ -200,7 +200,7 @@ const ContractInteraction = memo(() => {
             case TransactionDescriptorType.DEPLOYMENT:
             case TransactionDescriptorType.RETRY:
             case TransactionDescriptorType.CANCEL:
-                throw new Error('To be implemented')
+                throw new Error('To be implemented.')
             default:
                 unreachable(type)
         }

--- a/packages/plugins/EVM/src/state/Connection/interceptors/SCWallet.ts
+++ b/packages/plugins/EVM/src/state/Connection/interceptors/SCWallet.ts
@@ -20,7 +20,7 @@ export class SCWallet implements Middleware<Context> {
     }
 
     private createUserOperation(context: Context): UserOperation {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
 
     private sendUserOperation(context: Context, userOperation: UserOperation): Promise<string> {

--- a/packages/plugins/EVM/src/state/Connection/interceptors/SCWallet.ts
+++ b/packages/plugins/EVM/src/state/Connection/interceptors/SCWallet.ts
@@ -3,18 +3,11 @@ import { BundlerAPI, SmartPayBundler } from '@masknet/web3-providers'
 import { ChainId, createContract, EthereumMethodType, ProviderType, UserOperation } from '@masknet/web3-shared-evm'
 import WalletABI from '@masknet/web3-contracts/abis/Wallet.json'
 import type { Wallet as WalletContract } from '@masknet/web3-contracts/types/Wallet.js'
-import { SharedContextSettings, Web3StateSettings } from '../../../settings/index.js'
+import { Web3StateSettings } from '../../../settings/index.js'
 import type { Middleware, Context } from '../types.js'
 
 export class SCWallet implements Middleware<Context> {
     constructor(protected bundler: BundlerAPI.Provider) {}
-
-    get storage() {
-        const KVStorage = SharedContextSettings?.value.createKVStorage('memory', {
-            name: 'string',
-        })
-        return KVStorage.storage
-    }
 
     private async createWeb3(context: Context) {
         const web3 = await Web3StateSettings.value.Connection?.getWeb3?.({
@@ -27,7 +20,7 @@ export class SCWallet implements Middleware<Context> {
     }
 
     private createUserOperation(context: Context): UserOperation {
-        throw new Error('To be implemented')
+        throw new Error('To be implemented.')
     }
 
     private sendUserOperation(context: Context, userOperation: UserOperation): Promise<string> {

--- a/packages/plugins/EVM/src/state/Connection/providers/Base.ts
+++ b/packages/plugins/EVM/src/state/Connection/providers/Base.ts
@@ -30,6 +30,10 @@ export class BaseProvider implements EVM_Provider {
         return Promise.resolve()
     }
 
+    async switchAccount(account?: string | undefined): Promise<void> {
+        throw new Error('To be implemented.')
+    }
+
     // Switch chain with RPC calls by default
     async switchChain(chainId?: ChainId): Promise<void> {
         if (!chainId) throw new Error('Unknown chain id.')

--- a/packages/plugins/EVM/src/state/Connection/providers/Base.ts
+++ b/packages/plugins/EVM/src/state/Connection/providers/Base.ts
@@ -31,7 +31,7 @@ export class BaseProvider implements EVM_Provider {
     }
 
     async switchAccount(account?: string | undefined): Promise<void> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
 
     // Switch chain with RPC calls by default

--- a/packages/plugins/EVM/src/state/Connection/providers/BaseHosted.ts
+++ b/packages/plugins/EVM/src/state/Connection/providers/BaseHosted.ts
@@ -9,13 +9,11 @@ import { BaseProvider } from './Base.js'
 import { MaskWalletProvider } from './MaskWallet.js'
 
 export class BaseHostedProvider extends BaseProvider implements EVM_Provider {
-    private mask = new MaskWalletProvider()
-    private storageObject:
-        | StorageObject<{
-              account: string
-              chainId: ChainId
-          }>
-        | undefined
+    private provider = new MaskWalletProvider()
+    private storageObject?: StorageObject<{
+        account: string
+        chainId: ChainId
+    }>
 
     constructor(
         protected override providerType: ProviderType,
@@ -45,7 +43,7 @@ export class BaseHostedProvider extends BaseProvider implements EVM_Provider {
 
         const { storage } = SharedContextSettings.value
             .createKVStorage('memory', {})
-            .createSubScope(this.providerType, {
+            .createSubScope(`${this.providerType}_hosted`, {
                 account: this.options.getDefaultAccount(),
                 chainId: this.options.getDefaultChainId(),
             })
@@ -89,7 +87,7 @@ export class BaseHostedProvider extends BaseProvider implements EVM_Provider {
         })
     }
 
-    async switchAccount(account: string) {
+    override async switchAccount(account?: string) {
         if (isValidAddress(account) && (await this.options.isSupportedAccount(account)))
             this.storage.account.setValue(account)
     }
@@ -107,7 +105,7 @@ export class BaseHostedProvider extends BaseProvider implements EVM_Provider {
         requestArguments: RequestArguments,
         options?: ProviderOptions<ChainId>,
     ): Promise<T> {
-        return this.mask.request<T>(requestArguments, {
+        return this.provider.request<T>(requestArguments, {
             account: this.account,
             chainId: this.chainId,
             ...options,

--- a/packages/plugins/Flow/src/state/Connection/providers/Base.ts
+++ b/packages/plugins/Flow/src/state/Connection/providers/Base.ts
@@ -16,6 +16,9 @@ export class BaseProvider implements FlowProvider {
         return Promise.resolve()
     }
 
+    switchAccount(account?: string): Promise<void> {
+        throw new Error('Method not implemented.')
+    }
     switchChain(chainId?: ChainId): Promise<void> {
         throw new Error('Method not implemented.')
     }

--- a/packages/plugins/Solana/src/state/Connection/providers/Base.ts
+++ b/packages/plugins/Solana/src/state/Connection/providers/Base.ts
@@ -21,10 +21,12 @@ export class BaseProvider implements SolanaProvider {
         return Promise.resolve()
     }
 
+    switchAccount(account?: string): Promise<void> {
+        throw new Error('Method not implemented.')
+    }
     switchChain(chainId?: ChainId): Promise<void> {
         throw new Error('Method not implemented.')
     }
-
     signMessage(dataToSign: string): Promise<string> {
         throw new Error('Method not implemented.')
     }

--- a/packages/web3-hooks/evm/src/useGasLimit.ts
+++ b/packages/web3-hooks/evm/src/useGasLimit.ts
@@ -41,7 +41,7 @@ export function useGasLimit(
                     from: account,
                 })
             case SchemaType.ERC1155:
-                throw new Error('To be implemented.')
+                throw new Error('Method not implemented.')
             default:
                 unreachable(type)
         }

--- a/packages/web3-hooks/evm/src/useGasLimit.ts
+++ b/packages/web3-hooks/evm/src/useGasLimit.ts
@@ -41,7 +41,7 @@ export function useGasLimit(
                     from: account,
                 })
             case SchemaType.ERC1155:
-                throw new Error('To be implemented')
+                throw new Error('To be implemented.')
             default:
                 unreachable(type)
         }

--- a/packages/web3-hooks/evm/src/useTokenTransferCallback.ts
+++ b/packages/web3-hooks/evm/src/useTokenTransferCallback.ts
@@ -18,7 +18,7 @@ export function useTokenTransferCallback(type: SchemaType, address: string) {
         case SchemaType.ERC721:
             return r3
         case SchemaType.ERC1155:
-            throw new Error('To be implemented')
+            throw new Error('To be implemented.')
         default:
             unreachable(type_)
     }

--- a/packages/web3-hooks/evm/src/useTokenTransferCallback.ts
+++ b/packages/web3-hooks/evm/src/useTokenTransferCallback.ts
@@ -18,7 +18,7 @@ export function useTokenTransferCallback(type: SchemaType, address: string) {
         case SchemaType.ERC721:
             return r3
         case SchemaType.ERC1155:
-            throw new Error('To be implemented.')
+            throw new Error('Method not implemented.')
         default:
             unreachable(type_)
     }

--- a/packages/web3-providers/src/NFTScan/apis/TrendingAPI.ts
+++ b/packages/web3-providers/src/NFTScan/apis/TrendingAPI.ts
@@ -227,6 +227,6 @@ export class NFTScanTrendingAPI implements TrendingAPI.Provider<ChainId> {
         }
     }
     getCoinMarketInfo(symbol: string): Promise<TrendingAPI.MarketInfo> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
 }

--- a/packages/web3-providers/src/NFTScan/helpers/EVM.ts
+++ b/packages/web3-providers/src/NFTScan/helpers/EVM.ts
@@ -18,7 +18,7 @@ import {
 import { ChainId, createContract, getRPCConstants, SchemaType, WNATIVE } from '@masknet/web3-shared-evm'
 import { NFTSCAN_BASE, NFTSCAN_LOGO_BASE, NFTSCAN_URL } from '../constants.js'
 import type { EVM } from '../types/EVM.js'
-import { getJSON, resolveNonFungibleTokenEventActivityType, getPaymentToken, getAssetFullName } from '../../helpers.js'
+import { parseJSON, resolveActivityType, getPaymentToken, getAssetFullName } from '../../helpers.js'
 
 type NFTScanChainId = ChainId.Mainnet | ChainId.Matic | ChainId.BSC | ChainId.Arbitrum | ChainId.Optimism
 
@@ -76,7 +76,7 @@ export function createNonFungibleAsset(
     asset: EVM.Asset,
     collection?: EVM.AssetsGroup,
 ): NonFungibleAsset<ChainId, SchemaType> {
-    const payload = getJSON<EVM.Payload>(asset.metadata_json)
+    const payload = parseJSON<EVM.Payload>(asset.metadata_json)
     const contractName = asset.contract_name
     const description = payload?.description
     const uri = asset.nftscan_uri ?? asset.image_uri
@@ -157,7 +157,7 @@ export function createNonFungibleCollectionFromGroup(
     group: EVM.AssetsGroup,
 ): NonFungibleCollection<ChainId, SchemaType> {
     const sample = first(group.assets)
-    const payload = getJSON<EVM.Payload>(sample?.metadata_json)
+    const payload = parseJSON<EVM.Payload>(sample?.metadata_json)
     return {
         chainId,
         schema: sample?.erc_type === 'erc1155' ? SchemaType.ERC1155 : SchemaType.ERC721,
@@ -216,7 +216,7 @@ export function createNonFungibleTokenEvent(
         id: transaction.hash,
         quantity: transaction.amount,
         timestamp: transaction.timestamp,
-        type: resolveNonFungibleTokenEventActivityType(transaction.event_type),
+        type: resolveActivityType(transaction.event_type),
         hash: transaction.hash,
         from: {
             address: transaction.from,

--- a/packages/web3-providers/src/NFTScan/helpers/Solana.ts
+++ b/packages/web3-providers/src/NFTScan/helpers/Solana.ts
@@ -14,7 +14,7 @@ import {
 } from '@masknet/web3-shared-base'
 import { NFTSCAN_BASE_SOLANA, NFTSCAN_URL } from '../constants.js'
 import type { Solana } from '../types/index.js'
-import { resolveNonFungibleTokenEventActivityType, getJSON, getAssetFullName } from '../../helpers.js'
+import { resolveActivityType, parseJSON, getAssetFullName } from '../../helpers.js'
 
 export function createPermalink(chainId: ChainId, address?: string) {
     if (!address) return
@@ -45,7 +45,7 @@ export async function fetchFromNFTScanV2<T>(chainId: ChainId, pathname: string, 
 }
 
 export function createNonFungibleAsset(chainId: ChainId, asset: Solana.Asset): NonFungibleAsset<ChainId, SchemaType> {
-    const payload = getJSON<Solana.Payload>(asset.metadata_json)
+    const payload = parseJSON<Solana.Payload>(asset.metadata_json)
     const name = payload?.name || asset.name || payload?.name || ''
     const description = payload?.description
     const mediaURL = resolveIPFS_URL(asset.image_uri ?? asset.content_uri)
@@ -160,7 +160,7 @@ export function createNonFungibleTokenEvent(
         id: transaction.hash,
         quantity: '1',
         timestamp: transaction.timestamp ?? 0,
-        type: resolveNonFungibleTokenEventActivityType(transaction.event_type),
+        type: resolveActivityType(transaction.event_type),
         hash: transaction.hash,
         from: transaction.source
             ? {

--- a/packages/web3-providers/src/Nomics/index.ts
+++ b/packages/web3-providers/src/Nomics/index.ts
@@ -5,13 +5,13 @@ import type { ChainId } from '@masknet/web3-shared-evm'
 
 export class NomicsAPI implements TrendingAPI.Provider<ChainId> {
     getAllCoins(): Promise<TrendingAPI.Coin[]> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
     getCoinsByKeyword(chainId: ChainId, keyword: string): Promise<TrendingAPI.Coin[]> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
     getCoinTrending(chainId: ChainId, id: string, currency: TrendingAPI.Currency): Promise<TrendingAPI.Trending> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
     getCoinPriceStats(
         chainId: ChainId,
@@ -19,7 +19,7 @@ export class NomicsAPI implements TrendingAPI.Provider<ChainId> {
         currency: TrendingAPI.Currency,
         days: number,
     ): Promise<TrendingAPI.Stat[]> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
     async getCoinMarketInfo(symbol: string): Promise<TrendingAPI.MarketInfo> {
         const response = await fetchJSON<{ items: TrendingAPI.MarketInfo[] } | undefined>(

--- a/packages/web3-providers/src/cmc/index.ts
+++ b/packages/web3-providers/src/cmc/index.ts
@@ -264,6 +264,6 @@ export class CoinMarketCapAPI implements TrendingAPI.Provider<ChainId> {
         return Object.entries(stats).map(([date, x]) => [date, x[currency.name.toUpperCase()][0]])
     }
     getCoinMarketInfo(symbol: string): Promise<TrendingAPI.MarketInfo> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
 }

--- a/packages/web3-providers/src/coingecko/apis/CoinGecko.ts
+++ b/packages/web3-providers/src/coingecko/apis/CoinGecko.ts
@@ -160,6 +160,6 @@ export class CoinGeckoTrending_API implements TrendingAPI.Provider<ChainId> {
     }
 
     getCoinMarketInfo(symbol: string): Promise<TrendingAPI.MarketInfo> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
 }

--- a/packages/web3-providers/src/helpers.ts
+++ b/packages/web3-providers/src/helpers.ts
@@ -59,7 +59,11 @@ export async function staleCache(info: RequestInfo, init?: RequestInit) {
 
     const { host } = new URL(request.url)
     const cache = await caches.open(host)
+    const hit = await cache.match(request)
+    if (!hit) return
+
     await cache.delete(request)
+    return hit
 }
 
 export function getAllEVMNativeAssets(): Array<FungibleAsset<ChainId, SchemaType>> {

--- a/packages/web3-providers/src/helpers.ts
+++ b/packages/web3-providers/src/helpers.ts
@@ -51,6 +51,17 @@ export async function fetchCache(info: RequestInfo, init?: RequestInit) {
     return response
 }
 
+export async function staleCache(info: RequestInfo, init?: RequestInit) {
+    const request = new Request(info, init)
+
+    if (request.method !== 'GET') return
+    if (!request.url.startsWith('http')) return
+
+    const { host } = new URL(request.url)
+    const cache = await caches.open(host)
+    await cache.delete(request)
+}
+
 export function getAllEVMNativeAssets(): Array<FungibleAsset<ChainId, SchemaType>> {
     return NETWORK_DESCRIPTORS.filter((x) => x.isMainnet).map((x) => ({
         ...createNativeToken(x.chainId),

--- a/packages/web3-providers/src/helpers.ts
+++ b/packages/web3-providers/src/helpers.ts
@@ -58,7 +58,7 @@ export function getAllEVMNativeAssets(): Array<FungibleAsset<ChainId, SchemaType
     }))
 }
 
-export function getJSON<T>(json?: string): T | undefined {
+export function parseJSON<T>(json?: string): T | undefined {
     if (!json) return
     try {
         return JSON.parse(json) as T
@@ -105,7 +105,7 @@ export function getAssetFullName(contract_address: string, contractName: string,
     return `${contractName} #${first}`
 }
 
-export const resolveNonFungibleTokenEventActivityType = (type?: string) => {
+export const resolveActivityType = (type?: string) => {
     if (!type) return ActivityType.Transfer
     const type_ = type.toLowerCase()
     if (['created', 'mint'].includes(type_)) return ActivityType.Mint

--- a/packages/web3-providers/src/looksrare/index.ts
+++ b/packages/web3-providers/src/looksrare/index.ts
@@ -19,7 +19,7 @@ import { EMPTY_LIST } from '@masknet/shared-base'
 import { ChainId, createERC20Token, formatWeiToEther, SchemaType, isValidChainId } from '@masknet/web3-shared-evm'
 import type { NonFungibleTokenAPI } from '../types/index.js'
 import type { Collection, Event, Order, Stats, Token } from './types.js'
-import { resolveNonFungibleTokenEventActivityType } from '../helpers.js'
+import { resolveActivityType } from '../helpers.js'
 import { LOOKSRARE_API_URL, LOOKSRARE_PAGE_SIZE } from './constants.js'
 
 async function fetchFromLooksRare<T>(chainId: ChainId, url: string) {
@@ -108,7 +108,7 @@ function createNonFungibleEventFromEvent(chainId: ChainId, event: Event): NonFun
     return {
         id: event.id.toString(),
         chainId,
-        type: resolveNonFungibleTokenEventActivityType(event.type),
+        type: resolveActivityType(event.type),
         assetPermalink: urlcat('https://looksrare.org/collections/:address/:tokenId', {
             address: event.token?.collectionAddress ?? event.collection?.address,
             tokenId: event.token?.tokenId,

--- a/packages/web3-providers/src/opensea/index.ts
+++ b/packages/web3-providers/src/opensea/index.ts
@@ -38,7 +38,7 @@ import {
 } from './types.js'
 import { getOrderUSDPrice } from './utils.js'
 import { OPENSEA_ACCOUNT_URL, OPENSEA_API_URL } from './constants.js'
-import { resolveNonFungibleTokenEventActivityType, getPaymentToken, getAssetFullName } from '../helpers.js'
+import { resolveActivityType, getPaymentToken, getAssetFullName } from '../helpers.js'
 
 async function fetchFromOpenSea<T>(url: string, chainId: ChainId, init?: RequestInit) {
     if (![ChainId.Mainnet, ChainId.Rinkeby, ChainId.Matic].includes(chainId)) return
@@ -209,7 +209,7 @@ function createEvent(chainId: ChainId, event: OpenSeaAssetEvent): NonFungibleTok
         to: createAccount(event.to_account ?? event.winner_account),
         id: event.id,
         chainId,
-        type: resolveNonFungibleTokenEventActivityType(event.event_type),
+        type: resolveActivityType(event.event_type),
         assetPermalink: event.asset.permalink,
         quantity: event.quantity,
         hash: event.transaction?.transaction_hash,

--- a/packages/web3-providers/src/rarible/index.ts
+++ b/packages/web3-providers/src/rarible/index.ts
@@ -19,7 +19,7 @@ import { ChainId, SchemaType, isValidChainId } from '@masknet/web3-shared-evm'
 import { RaribleEventType, RaribleOrder, RaribleHistory, RaribleNFTItemMapResponse } from './types.js'
 import { RaribleURL } from './constants.js'
 import type { NonFungibleTokenAPI } from '../types/index.js'
-import { resolveNonFungibleTokenEventActivityType, getPaymentToken, getAssetFullName } from '../helpers.js'
+import { resolveActivityType, getPaymentToken, getAssetFullName } from '../helpers.js'
 
 const resolveRaribleBlockchain = createLookupTableResolver<number, string>(
     {
@@ -136,7 +136,7 @@ function createEvent(chainId: ChainId, history: RaribleHistory): NonFungibleToke
         chainId,
         from: createAccount(history.from ?? history.seller ?? history.owner ?? history.maker),
         to: createAccount(history.buyer),
-        type: resolveNonFungibleTokenEventActivityType(history['@type']),
+        type: resolveActivityType(history['@type']),
         assetPermalink:
             history.nft?.type.contract && history.nft?.type.tokenId
                 ? createRaribleLink(history.nft.type.contract, history.nft.type.tokenId)

--- a/packages/web3-providers/src/uniswap/index.ts
+++ b/packages/web3-providers/src/uniswap/index.ts
@@ -72,6 +72,6 @@ export class UniSwapAPI implements TrendingAPI.Provider<ChainId> {
         )
     }
     getCoinMarketInfo(symbol: string): Promise<TrendingAPI.MarketInfo> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
 }

--- a/packages/web3-providers/src/x2y2/index.ts
+++ b/packages/web3-providers/src/x2y2/index.ts
@@ -17,7 +17,7 @@ import type { NonFungibleTokenAPI } from '../types/index.js'
 import { X2Y2_API_URL, X2Y2_PAGE_SIZE } from './constants.js'
 import type { Contract, Event, Order } from './types.js'
 import { first, last } from 'lodash-es'
-import { resolveNonFungibleTokenEventActivityType } from '../helpers.js'
+import { resolveActivityType } from '../helpers.js'
 
 async function fetchFromX2Y2<T>(pathname: string) {
     const response = await globalThis.fetch(urlcat(X2Y2_API_URL, pathname))
@@ -73,7 +73,7 @@ export class X2Y2API implements NonFungibleTokenAPI.Provider<ChainId, SchemaType
         return {
             id: event.id.toString(),
             chainId: ChainId.Mainnet,
-            type: resolveNonFungibleTokenEventActivityType(event.type),
+            type: resolveActivityType(event.type),
             assetPermalink: this.createPermalink(address, tokenId),
             quantity: '1',
             hash: event.order.item_hash,

--- a/packages/web3-providers/src/zerion/index.ts
+++ b/packages/web3-providers/src/zerion/index.ts
@@ -222,7 +222,7 @@ export class ZerionTrendingAPI implements TrendingAPI.Provider<ChainId> {
         throw new Error('Method not implemented.')
     }
     getCoinMarketInfo(symbol: string): Promise<TrendingAPI.MarketInfo> {
-        throw new Error('To be implemented.')
+        throw new Error('Method not implemented.')
     }
 }
 

--- a/packages/web3-providers/src/zora/index.ts
+++ b/packages/web3-providers/src/zora/index.ts
@@ -28,7 +28,7 @@ import {
     TransferEventProperty,
     V3AskEventProperty,
 } from './types.js'
-import { getAssetFullName, resolveNonFungibleTokenEventActivityType } from '../helpers.js'
+import { getAssetFullName, resolveActivityType } from '../helpers.js'
 import type { NonFungibleTokenAPI } from '../types/index.js'
 import { GetCollectionsByKeywordQuery, GetEventsQuery, GetTokenQuery } from './queries.js'
 import { ZORA_MAINNET_GRAPHQL_URL } from './constants.js'
@@ -175,7 +175,7 @@ export class ZoraAPI implements NonFungibleTokenAPI.Provider<ChainId, SchemaType
 
         return {
             id: event.transactionInfo.transactionHash ?? `${event.transactionInfo.blockNumber}_${event.tokenId}`,
-            type: resolveNonFungibleTokenEventActivityType(event.eventType),
+            type: resolveActivityType(event.eventType),
             chainId,
             quantity: '1',
             from: {

--- a/packages/web3-shared/base/src/specs/index.ts
+++ b/packages/web3-shared/base/src/specs/index.ts
@@ -742,6 +742,8 @@ export interface WalletProvider<ChainId, ProviderType, Web3Provider, Web3> {
     readonly ready: boolean
     /** Keep waiting until the provider is ready. */
     readonly readyPromise: Promise<void>
+    /** Switch to the designate account. */
+    switchAccount(account?: string): Promise<void>
     /** Switch to the designate chain. */
     switchChain(chainId?: ChainId): Promise<void>
     /** Create an instance from the network SDK. */

--- a/packages/web3-shared/evm/src/utils/userOperation.ts
+++ b/packages/web3-shared/evm/src/utils/userOperation.ts
@@ -5,14 +5,14 @@ import type { Transaction, UserOperation } from '../types/index.js'
  * @param transaction
  */
 export function encodeUserOperation(transaction: Transaction): UserOperation {
-    throw new Error('To be implemented.')
+    throw new Error('Method not implemented.')
 }
 
 /**
  * Decode UserOperation to a normal transaction (only in-memory transaction will not send as transaction)
  */
 export function decodeUserOperation(userOperation: UserOperation): Transaction {
-    throw new Error('To be implemented.')
+    throw new Error('Method not implemented.')
 }
 
 /**
@@ -20,5 +20,5 @@ export function decodeUserOperation(userOperation: UserOperation): Transaction {
  * @param transaction
  */
 export function decodeUserOperations(transaction: Transaction): UserOperation[] {
-    throw new Error('To be implemented.')
+    throw new Error('Method not implemented.')
 }

--- a/packages/web3-shared/evm/src/utils/userOperation.ts
+++ b/packages/web3-shared/evm/src/utils/userOperation.ts
@@ -5,14 +5,14 @@ import type { Transaction, UserOperation } from '../types/index.js'
  * @param transaction
  */
 export function encodeUserOperation(transaction: Transaction): UserOperation {
-    throw new Error('To be implemented')
+    throw new Error('To be implemented.')
 }
 
 /**
  * Decode UserOperation to a normal transaction (only in-memory transaction will not send as transaction)
  */
 export function decodeUserOperation(userOperation: UserOperation): Transaction {
-    throw new Error('To be implemented')
+    throw new Error('To be implemented.')
 }
 
 /**
@@ -20,5 +20,5 @@ export function decodeUserOperation(userOperation: UserOperation): Transaction {
  * @param transaction
  */
 export function decodeUserOperations(transaction: Transaction): UserOperation[] {
-    throw new Error('To be implemented')
+    throw new Error('To be implemented.')
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Usage

```ts
// cache response
await getUserByScreenName(screenName)

// stable the cache and return response if exists
await staleUserByScreenName(screenName)
```

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [x] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
