### PR TITLE
refactor: make all subscriptions have stable reference

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -60,7 +60,7 @@
     "react-use": "^17.4.0",
     "unstated-next": "^1.1.0",
     "urlcat": "^2.0.4",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "uuid": "^9.0.0",
     "wallet.ts": "^1.0.1",
     "web3-core-helpers": "1.8.0",

--- a/packages/mask/package.json
+++ b/packages/mask/package.json
@@ -138,7 +138,7 @@
     "stream-http": "^2.8.3",
     "unstated-next": "^1.1.0",
     "urlcat": "^2.0.4",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "uuid": "^9.0.0",
     "wallet.ts": "^1.0.1",
     "web3": "1.8.0",

--- a/packages/mask/src/social-network/utils/create-post-context.ts
+++ b/packages/mask/src/social-network/utils/create-post-context.ts
@@ -164,12 +164,11 @@ export function createRefsForCreatePostContext() {
         snsID: createSubscriptionFromValueRef(postID),
         rawMessage: createSubscriptionFromValueRef(postMessage),
         postImagesProvider: debug({
-            getCurrentValue: () => (postMetadataImages.size ? [...postMetadataImages] : EMPTY_LIST),
+            getCurrentValue: () => postMetadataImages.asValues,
             subscribe: (sub) => postMetadataImages.event.on(ALL_EVENTS, sub),
         }),
         postMentionedLinksProvider: debug({
-            getCurrentValue: () =>
-                postMetadataMentionedLinks.size ? [...postMetadataMentionedLinks.values()] : EMPTY_LIST,
+            getCurrentValue: () => postMetadataMentionedLinks.asValues,
             subscribe: (sub) => postMetadataMentionedLinks.event.on(ALL_EVENTS, sub),
         }),
         coAuthors: createSubscriptionFromValueRef(postCoAuthors),

--- a/packages/plugin-infra/package.json
+++ b/packages/plugin-infra/package.json
@@ -72,7 +72,7 @@
     "react-use": "^17.4.0",
     "unstated-next": "^1.1.0",
     "urlcat": "^2.0.4",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "wallet.ts": "^1.0.1",
     "web3": "1.8.0",
     "web3-core": "1.8.0",

--- a/packages/plugin-infra/src/manager/dashboard.ts
+++ b/packages/plugin-infra/src/manager/dashboard.ts
@@ -5,15 +5,23 @@ import type { Plugin } from '../types.js'
 
 const { activated, startDaemon, events, minimalMode } = createManager((def) => def.Dashboard)
 
-const subscription: Subscription<Plugin.Dashboard.Definition[]> = {
-    getCurrentValue: () => [...activated.plugins],
-    subscribe: (f) => events.on(ALL_EVENTS, f),
-}
+const subscription: Subscription<Plugin.Dashboard.Definition[]> = (() => {
+    let value: any[] | undefined
+    events.on('activateChanged', () => (value = undefined))
+    return {
+        getCurrentValue: () => (value ??= [...activated.plugins]),
+        subscribe: (f) => events.on(ALL_EVENTS, f),
+    }
+})()
 
-const minimalModeSub: Subscription<string[]> = {
-    getCurrentValue: () => [...minimalMode],
-    subscribe: (f) => events.on('minimalModeChanged', f),
-}
+const minimalModeSub: Subscription<string[]> = (() => {
+    let value: any[] | undefined
+    events.on('minimalModeChanged', () => (value = undefined))
+    return {
+        getCurrentValue: () => (value ??= [...minimalMode]),
+        subscribe: (f) => events.on('minimalModeChanged', f),
+    }
+})()
 
 export function useIsMinimalModeDashBoard(pluginID: string) {
     return useSubscription(minimalModeSub).includes(pluginID)

--- a/packages/plugin-infra/src/manager/sns-adaptor.ts
+++ b/packages/plugin-infra/src/manager/sns-adaptor.ts
@@ -8,14 +8,22 @@ import type { CurrentSNSNetwork, Plugin } from '../types.js'
 
 const { events, activated, startDaemon, minimalMode } = createManager((def) => def.SNSAdaptor)
 
-const activatedSub: Subscription<Plugin.SNSAdaptor.Definition[]> = {
-    getCurrentValue: () => [...activated.plugins],
-    subscribe: (f) => events.on('activateChanged', f),
-}
-const minimalModeSub: Subscription<string[]> = {
-    getCurrentValue: () => [...minimalMode],
-    subscribe: (f) => events.on('minimalModeChanged', f),
-}
+const activatedSub: Subscription<Plugin.SNSAdaptor.Definition[]> = (() => {
+    let value: any[] | undefined
+    events.on('activateChanged', () => (value = undefined))
+    return {
+        getCurrentValue: () => (value ??= [...activated.plugins]),
+        subscribe: (f) => events.on('activateChanged', f),
+    }
+})()
+const minimalModeSub: Subscription<string[]> = (() => {
+    let value: any[] | undefined
+    events.on('minimalModeChanged', () => (value = undefined))
+    return {
+        getCurrentValue: () => (value ??= [...minimalMode]),
+        subscribe: (f) => events.on('minimalModeChanged', f),
+    }
+})()
 export function useActivatedPluginsSNSAdaptor(minimalModeEqualsTo: 'any' | boolean) {
     const minimalMode = useSubscription(minimalModeSub)
     const result = useSubscription(activatedSub)

--- a/packages/plugin-infra/src/manager/store.ts
+++ b/packages/plugin-infra/src/manager/store.ts
@@ -14,14 +14,18 @@ export function onNewPluginRegistered(f: onNewPluginRegisteredListener) {
     return () => listeners.delete(f)
 }
 
-export const registeredPlugins: Subscription<Array<[PluginID, Plugin.DeferredDefinition]>> = {
-    getCurrentValue() {
-        return Array.from(__registered.entries())
-    },
-    subscribe(callback) {
-        return onNewPluginRegistered(callback)
-    },
-}
+export const registeredPlugins: Subscription<Array<[PluginID, Plugin.DeferredDefinition]>> = (() => {
+    let value: any[] | undefined
+    onNewPluginRegistered(() => (value = undefined))
+    return {
+        getCurrentValue() {
+            return (value ??= [...__registered.entries()])
+        },
+        subscribe(callback) {
+            return onNewPluginRegistered(callback)
+        },
+    }
+})()
 
 export function getPluginDefine(id: PluginID | NetworkPluginID) {
     return __registered.get(id as unknown as PluginID)

--- a/packages/plugins/RSS3/package.json
+++ b/packages/plugins/RSS3/package.json
@@ -26,7 +26,7 @@
     "date-fns": "^2.29.3",
     "react-use": "^17.4.0",
     "urlcat": "^2.0.4",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "uuid": "^9.0.0",
     "web3-utils": "1.8.0"
   }

--- a/packages/plugins/ScamWarning/package.json
+++ b/packages/plugins/ScamWarning/package.json
@@ -17,6 +17,6 @@
     "@masknet/typed-message": "workspace:^",
     "@masknet/web3-providers": "workspace:^",
     "react-use": "^17.4.0",
-    "use-subscription": "1.6.0"
+    "use-subscription": "^1.8.0"
   }
 }

--- a/packages/plugins/Web3Profile/package.json
+++ b/packages/plugins/Web3Profile/package.json
@@ -26,6 +26,6 @@
         "react-feather": "^2.0.9",
         "react-use": "^17.3.2",
         "urlcat": "^2.0.4",
-        "use-subscription": "1.7.0"
+        "use-subscription": "^1.8.0"
     }
 }

--- a/packages/plugins/template/package.json
+++ b/packages/plugins/template/package.json
@@ -13,6 +13,6 @@
     "@masknet/shared": "workspace:^",
     "@masknet/shared-base": "workspace:^",
     "react-use": "^17.4.0",
-    "use-subscription": "1.6.0"
+    "use-subscription": "^1.8.0"
   }
 }

--- a/packages/shared-base-ui/package.json
+++ b/packages/shared-base-ui/package.json
@@ -16,7 +16,7 @@
     "@types/use-subscription": "^1.0.0",
     "@types/uuid": "^8.3.4",
     "react-use": "^17.4.0",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/packages/shared-base-ui/src/hooks/useObservableMapSet.ts
+++ b/packages/shared-base-ui/src/hooks/useObservableMapSet.ts
@@ -5,7 +5,7 @@ import { ALL_EVENTS, ObservableMap, ObservableSet } from '@masknet/shared-base'
 export function useObservableValues<T>(map: ObservableMap<any, T> | ObservableSet<T>) {
     const subscription = useMemo<Subscription<T[]>>(
         () => ({
-            getCurrentValue: () => [...map.values()],
+            getCurrentValue: () => map.asValues,
             subscribe: (callback) => {
                 return (map.event.on as any)(ALL_EVENTS, callback)
             },

--- a/packages/shared-base/src/collections/index.ts
+++ b/packages/shared-base/src/collections/index.ts
@@ -1,4 +1,5 @@
 import { Emitter } from '@servie/events'
+import { EMPTY_LIST } from '../index.js'
 export { ALL_EVENTS } from '@servie/events'
 
 function tick(callback: () => void) {
@@ -23,17 +24,24 @@ export class ObservableMap<K, V> extends Map<K, V> {
     declare __brand: 'Map'
 
     event = new Emitter<{ delete: [K]; set: [K, V]; clear: [] }>()
+    private _asValues: V[] | undefined
+    get asValues() {
+        return (this._asValues ??= this.size ? [...this.values()] : EMPTY_LIST)
+    }
     override clear() {
         super.clear()
-        this.size && tick(() => this.event.emit('clear'))
+        this._asValues = undefined
+        tick(() => this.event.emit('clear'))
     }
     override delete(key: K) {
         const _ = super.delete(key)
+        this._asValues = undefined
         tick(() => this.event.emit('delete', key))
         return _
     }
     override set(key: K, value: V) {
         const _ = super.set(key, value)
+        this._asValues = undefined
         tick(() => this.event.emit('set', key, value))
         this.event.emit('set', key, value)
         return _
@@ -43,17 +51,24 @@ export class ObservableSet<T> extends Set<T> {
     declare __brand: 'ObservableSet'
 
     event = new Emitter<{ delete: [T]; add: [T[]]; clear: [] }>()
+    private _asValues: T[] | undefined
+    get asValues() {
+        return (this._asValues ??= this.size ? [...this.values()] : EMPTY_LIST)
+    }
     override clear() {
         super.clear()
-        this.size && tick(() => this.event.emit('clear'))
+        this._asValues = undefined
+        tick(() => this.event.emit('clear'))
     }
     override delete(key: T) {
         const _ = super.delete(key)
+        this._asValues = undefined
         tick(() => this.event.emit('delete', key))
         return _
     }
     override add(...value: T[]) {
         value.forEach((x) => super.add(x))
+        this._asValues = undefined
         this.event.emit('add', value)
         tick(() => this.event.emit('add', value))
         return this

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,7 +46,7 @@
     "remarkable": "^2.0.1",
     "unstated-next": "^1.1.0",
     "urlcat": "^2.0.4",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "zod": "^3.16.0"
   },
   "devDependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -40,7 +40,7 @@
     "tinycolor2": "^1.4.2",
     "tss-react": "^4.4.4",
     "unstated-next": "^1.1.0",
-    "use-subscription": "1.6.0"
+    "use-subscription": "^1.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",

--- a/packages/typed-message/base/src/transformer/composed.ts
+++ b/packages/typed-message/base/src/transformer/composed.ts
@@ -15,21 +15,22 @@ export interface ComposedTransformers {
 export function composeTransformers(): ComposedTransformers {
     const event = new EventTarget()
     const onUpdate = () => {
-        composedResult = undefined
+        composedTransformer = undefined
         event.dispatchEvent(new Event('update'))
     }
     const transformers = new Set<readonly [Transformer, number]>()
 
-    let composedResult: TypedMessage | undefined
+    let composedTransformer: Transformer | undefined
     function composed(message: TypedMessage, context: TransformationContext) {
         // eslint-disable-next-line unicorn/no-array-reduce
         return [...transformers].sort((a, b) => b[1] - a[1]).reduce((p, [c]) => c(p, context), message)
     }
 
     const subscription = {
-        getCurrentValue: (): Transformer => (message, context) => {
-            return (composedResult ??= composed(message, context))
-        },
+        getCurrentValue: () =>
+            (composedTransformer ??= (message, context) => {
+                return composed(message, context)
+            }),
         subscribe(f: () => void) {
             event.addEventListener('update', f)
             return () => {

--- a/packages/typed-message/base/src/transformer/composed.ts
+++ b/packages/typed-message/base/src/transformer/composed.ts
@@ -14,16 +14,22 @@ export interface ComposedTransformers {
 }
 export function composeTransformers(): ComposedTransformers {
     const event = new EventTarget()
-    const onUpdate = () => event.dispatchEvent(new Event('update'))
+    const onUpdate = () => {
+        composedResult = undefined
+        event.dispatchEvent(new Event('update'))
+    }
     const transformers = new Set<readonly [Transformer, number]>()
 
+    let composedResult: TypedMessage | undefined
     function composed(message: TypedMessage, context: TransformationContext) {
         // eslint-disable-next-line unicorn/no-array-reduce
         return [...transformers].sort((a, b) => b[1] - a[1]).reduce((p, [c]) => c(p, context), message)
     }
 
     const subscription = {
-        getCurrentValue: (): Transformer => (message, context) => composed(message, context),
+        getCurrentValue: (): Transformer => (message, context) => {
+            return (composedResult ??= composed(message, context))
+        },
         subscribe(f: () => void) {
             event.addEventListener('update', f)
             return () => {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,6 +25,6 @@
     "date-fns": "^2.29.3",
     "react-use": "^17.4.0",
     "urlcat": "^2.0.4",
-    "use-subscription": "1.6.0"
+    "use-subscription": "^1.8.0"
   }
 }

--- a/packages/web3-hooks/base/package.json
+++ b/packages/web3-hooks/base/package.json
@@ -24,7 +24,7 @@
     "ethereum-blockies": "^0.1.1",
     "lru-cache": "^7.10.1",
     "react-use": "^17.4.0",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "web3": "1.8.0"
   }
 }

--- a/packages/web3-shared/evm/package.json
+++ b/packages/web3-shared/evm/package.json
@@ -28,7 +28,7 @@
     "react-use": "^17.4.0",
     "unstated-next": "^1.1.0",
     "urlcat": "^2.0.4",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "uuid": "^9.0.0",
     "wallet.ts": "^1.0.1",
     "web3": "1.8.0",

--- a/packages/web3-state/package.json
+++ b/packages/web3-state/package.json
@@ -18,7 +18,7 @@
     "@servie/events": "^3.0.0",
     "@types/use-subscription": "^1.0.0",
     "lru-cache": "^7.10.1",
-    "use-subscription": "1.6.0",
+    "use-subscription": "^1.8.0",
     "web3-core-helpers": "1.8.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,7 +347,7 @@ importers:
         version: link:../plugins/EVM
       '@masknet/plugin-example':
         specifier: workspace:^
-        version: link:../plugins/Example
+        version: link:../plugins/example
       '@masknet/plugin-flow':
         specifier: workspace:^
         version: link:../plugins/Flow
@@ -466,8 +466,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -647,7 +647,7 @@ importers:
         version: link:../plugins/EVM
       '@masknet/plugin-example':
         specifier: workspace:^
-        version: link:../plugins/Example
+        version: link:../plugins/example
       '@masknet/plugin-file-service':
         specifier: workspace:^
         version: link:../plugins/FileService
@@ -970,8 +970,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -1149,8 +1149,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       wallet.ts:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1546,18 +1546,6 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
 
-  packages/plugins/Example:
-    dependencies:
-      '@masknet/plugin-infra':
-        specifier: workspace:^
-        version: link:../../plugin-infra
-      '@masknet/shared-base':
-        specifier: workspace:^
-        version: link:../../shared-base
-      ts-results:
-        specifier: ^3.3.0
-        version: 3.3.0
-
   packages/plugins/FileService:
     dependencies:
       '@dimensiondev/common-protocols':
@@ -1835,8 +1823,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -1910,8 +1898,8 @@ importers:
         specifier: ^17.4.0
         version: 17.4.0
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
 
   packages/plugins/Solana:
     dependencies:
@@ -1962,7 +1950,7 @@ importers:
         version: 1.1.0
       '@metaplex/js':
         specifier: ^4.11.7
-        version: 4.11.7
+        version: 4.11.7_3hthoayrtz7bowcduhtflwhjdu
       '@project-serum/sol-wallet-adapter':
         specifier: ^0.2.6
         version: 0.2.6_dl5wqnnaxjm7biesxtvdpr7gpe_@solana+web3.js@1.44.2
@@ -2097,8 +2085,20 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.7.0
-        version: 1.7.0
+        specifier: ^1.8.0
+        version: 1.8.0
+
+  packages/plugins/example:
+    dependencies:
+      '@masknet/plugin-infra':
+        specifier: workspace:^
+        version: link:../../plugin-infra
+      '@masknet/shared-base':
+        specifier: workspace:^
+        version: link:../../shared-base
+      ts-results:
+        specifier: ^3.3.0
+        version: 3.3.0
 
   packages/plugins/template:
     dependencies:
@@ -2115,8 +2115,8 @@ importers:
         specifier: ^17.4.0
         version: 17.4.0
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
 
   packages/polyfills:
     dependencies:
@@ -2372,8 +2372,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       zod:
         specifier: ^3.16.0
         version: 3.16.0
@@ -2479,8 +2479,8 @@ importers:
         specifier: ^17.4.0
         version: 17.4.0
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -2544,8 +2544,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@babel/core':
         specifier: ^7.20.2
@@ -2647,8 +2647,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
 
   packages/web3-constants:
     dependencies:
@@ -2738,8 +2738,8 @@ importers:
         specifier: ^17.4.0
         version: 17.4.0
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       web3:
         specifier: 1.8.0
         version: 1.8.0_dcxxuqxbti2wcxbar42oow5yze
@@ -2835,7 +2835,7 @@ importers:
         version: 1.1.0
       '@metaplex/js':
         specifier: ^4.11.7
-        version: 4.11.7
+        version: 4.11.7_3hthoayrtz7bowcduhtflwhjdu
       '@siddomains/sidjs':
         specifier: ^0.1.16
         version: 0.1.16
@@ -3010,8 +3010,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4_fggwetex7eobhq3hztj4obsulu
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -3140,8 +3140,8 @@ importers:
         specifier: ^7.10.1
         version: 7.10.1
       use-subscription:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: ^1.8.0
+        version: 1.8.0
       web3-core-helpers:
         specifier: 1.8.0
         version: 1.8.0
@@ -6061,8 +6061,8 @@ packages:
       '@cspell/dict-docker': 1.1.3
       '@cspell/dict-dotnet': 3.0.1
       '@cspell/dict-elixir': 3.0.0
-      '@cspell/dict-en_us': 4.0.0
       '@cspell/dict-en-gb': 1.1.33
+      '@cspell/dict-en_us': 4.0.0
       '@cspell/dict-filetypes': 3.0.0
       '@cspell/dict-fonts': 3.0.0
       '@cspell/dict-fullstack': 3.0.0
@@ -6109,8 +6109,8 @@ packages:
       '@cspell/dict-docker': 1.1.1
       '@cspell/dict-dotnet': 2.0.1
       '@cspell/dict-elixir': 2.0.1
-      '@cspell/dict-en_us': 2.3.0
       '@cspell/dict-en-gb': 1.1.33
+      '@cspell/dict-en_us': 2.3.0
       '@cspell/dict-filetypes': 2.1.1
       '@cspell/dict-fonts': 2.0.1
       '@cspell/dict-fullstack': 2.0.6
@@ -6516,13 +6516,13 @@ packages:
     resolution: {integrity: sha512-4Qy4/JSzyk+f4LTsALERTwTjXGh2kRNHj+eVpLWF1oSJeTC2CQ8iZeKlQoIZa0zXcwbw/RYBpfiDJIXSqeI+Og==}
     hasBin: true
     dependencies:
+      3id-did-provider: 1.1.1
       '@3id/connect': 0.2.5
       '@ceramicnetwork/3id-did-resolver': 1.4.16
       '@ceramicnetwork/blockchain-utils-linking': 1.5.5
       '@ceramicnetwork/http-client': 1.5.7
       '@ceramicstudio/idx': 0.12.2
       '@stablelib/sha256': 1.0.1
-      3id-did-provider: 1.1.1
       bs58: 4.0.1
       idb: 7.1.1
       key-did-resolver: 1.4.4
@@ -8050,14 +8050,18 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@metaplex/js/4.11.7:
+  /@metaplex/js/4.11.7_3hthoayrtz7bowcduhtflwhjdu:
     resolution: {integrity: sha512-/8X04VEHMfWF84H2DZwLY3yg0xq75vgt/VtLuChTm8iUHkj99Whnq0NLTe0OqfhiEV0qFvT5dbLFh7x2CZqrEQ==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      '@metaplex-foundation/mpl-token-metadata': ^0.0.2
+      '@solana/spl-token': ^0.1.8
+      '@solana/web3.js': ^1.30.2
     dependencies:
       '@metaplex-foundation/mpl-auction': 0.0.2
       '@metaplex-foundation/mpl-core': 0.0.2
       '@metaplex-foundation/mpl-metaplex': 0.0.5
-      '@metaplex-foundation/mpl-token-metadata': 0.0.2
+      '@metaplex-foundation/mpl-token-metadata': 1.1.0
       '@metaplex-foundation/mpl-token-vault': 0.0.2
       '@solana/spl-token': 0.1.8
       '@solana/web3.js': 1.44.2
@@ -16442,8 +16446,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -20472,6 +20476,18 @@ packages:
       debug:
         optional: true
 
+  /follow-redirects/1.15.1_debug@4.3.4:
+    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4_supports-color@6.1.0
+    dev: false
+
   /follow-redirects/1.15.2:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -21948,7 +21964,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -23187,13 +23203,13 @@ packages:
       '@types/lodash': 4.14.188
       '@types/node': 18.11.9
       '@types/ws': 7.4.7
+      JSONStream: 1.3.5
       commander: 2.20.3
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
       isomorphic-ws: 4.0.1_ws@7.5.7
       json-stringify-safe: 5.0.1
-      JSONStream: 1.3.5
       lodash: 4.17.21
       uuid: 3.4.0
       ws: 7.5.7
@@ -23835,7 +23851,7 @@ packages:
     dev: false
 
   /level-ws/0.0.0:
-    resolution: {integrity: sha512-XUTaO/+Db51Uiyp/t7fCMGVFOTdtLS/NIACxE/GHsij15mKzxksZifKVjlXDF41JMUP/oM1Oc4YNGdKnc3dVLw==}
+    resolution: {integrity: sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=}
     dependencies:
       readable-stream: 1.0.34
       xtend: 2.1.2
@@ -24124,7 +24140,7 @@ packages:
     dev: true
 
   /lodash.unescape/4.0.1:
-    resolution: {integrity: sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg==}
+    resolution: {integrity: sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=}
     dev: false
 
   /lodash.uniq/4.5.0:
@@ -31747,17 +31763,8 @@ packages:
     dev: false
     patched: true
 
-  /use-subscription/1.6.0:
-    resolution: {integrity: sha512-0Y/cTLlZfw547tJhJMoRA16OUbVqRm6DmvGpiGbmLST6BIA5KU5cKlvlz8DVMrACnWpyEjCkgmhLatthP4jUbA==}
-    peerDependencies:
-      react: ^18.0.0 || 0.0.0-experimental-d1e35c703-20221110
-    peerDependenciesMeta:
-      react:
-        optional: true
-    dev: false
-
-  /use-subscription/1.7.0:
-    resolution: {integrity: sha512-87x6MjiIVE/BWqtxfiRvM6jfvGudN+UeVOnWi7qKYp2c0YJn5+Z5Jt0kZw6Tt+8hs7kw/BWo2WBhizJSAZsQJA==}
+  /use-subscription/1.8.0:
+    resolution: {integrity: sha512-LISuG0/TmmoDoCRmV5XAqYkd3UCBNM0ML3gGBndze65WITcsExCD3DTvXXTLyNcOC0heFQZzluW88bN/oC1DQQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || 0.0.0-experimental-d1e35c703-20221110
     peerDependenciesMeta:
@@ -33896,12 +33903,12 @@ packages:
     name: wyvern-js
     version: 3.2.0
     dependencies:
+      0x.js: 0.29.2
       '@0xproject/abi-gen': 0.1.2
       '@0xproject/assert': 0.0.11
       '@0xproject/json-schemas': 0.7.24
       '@0xproject/utils': 0.1.3
       '@0xproject/web3-wrapper': 0.1.14
-      0x.js: 0.29.2
       bn.js: 4.12.0
       ethereumjs-abi: github.com/ProjectWyvern/ethereumjs-abi/3d2d89641a6ad5984929b6ca4b646452ec74f73d
       ethereumjs-util: 5.2.1
@@ -33916,6 +33923,7 @@ packages:
     name: wyvern-js
     version: 3.2.0
     dependencies:
+      0x.js: 0.29.2
       '@0xproject/abi-gen': 0.1.7
       '@0xproject/assert': 0.0.11
       '@0xproject/json-schemas': 0.7.24
@@ -33924,7 +33932,6 @@ packages:
       '@0xproject/web3-wrapper': 0.1.14
       '@types/lodash': 4.14.188
       '@types/node': 18.11.9
-      0x.js: 0.29.2
       awesome-typescript-loader: 3.5.0_typescript@2.9.2
       bn.js: 4.12.0
       ethereumjs-abi: github.com/ProjectWyvern/ethereumjs-abi/3d2d89641a6ad5984929b6ca4b646452ec74f73d
@@ -33953,6 +33960,7 @@ packages:
     name: wyvern-js
     version: 3.2.0
     dependencies:
+      0x.js: 0.29.2
       '@0xproject/abi-gen': 0.1.7
       '@0xproject/assert': 0.0.11
       '@0xproject/json-schemas': 0.7.24
@@ -33961,7 +33969,6 @@ packages:
       '@0xproject/web3-wrapper': 0.1.14
       '@types/lodash': 4.14.188
       '@types/node': 18.11.9
-      0x.js: 0.29.2
       awesome-typescript-loader: 3.5.0_typescript@2.9.2
       bn.js: 4.12.0
       ethereumjs-abi: github.com/ProjectWyvern/ethereumjs-abi/3d2d89641a6ad5984929b6ca4b646452ec74f73d

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,7 +347,7 @@ importers:
         version: link:../plugins/EVM
       '@masknet/plugin-example':
         specifier: workspace:^
-        version: link:../plugins/example
+        version: link:../plugins/Example
       '@masknet/plugin-flow':
         specifier: workspace:^
         version: link:../plugins/Flow
@@ -647,7 +647,7 @@ importers:
         version: link:../plugins/EVM
       '@masknet/plugin-example':
         specifier: workspace:^
-        version: link:../plugins/example
+        version: link:../plugins/Example
       '@masknet/plugin-file-service':
         specifier: workspace:^
         version: link:../plugins/FileService
@@ -1546,6 +1546,18 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
 
+  packages/plugins/Example:
+    dependencies:
+      '@masknet/plugin-infra':
+        specifier: workspace:^
+        version: link:../../plugin-infra
+      '@masknet/shared-base':
+        specifier: workspace:^
+        version: link:../../shared-base
+      ts-results:
+        specifier: ^3.3.0
+        version: 3.3.0
+
   packages/plugins/FileService:
     dependencies:
       '@dimensiondev/common-protocols':
@@ -2087,18 +2099,6 @@ importers:
       use-subscription:
         specifier: ^1.8.0
         version: 1.8.0
-
-  packages/plugins/example:
-    dependencies:
-      '@masknet/plugin-infra':
-        specifier: workspace:^
-        version: link:../../plugin-infra
-      '@masknet/shared-base':
-        specifier: workspace:^
-        version: link:../../shared-base
-      ts-results:
-        specifier: ^3.3.0
-        version: 3.3.0
 
   packages/plugins/template:
     dependencies:


### PR DESCRIPTION
- refactor: make all subscriptions have stable reference when called multiple times
- upgrade use-subscription
- fix: stable ident

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
