### PR TITLE
refactor: turn on manifest v3 by default

### DIFF
--- a/.env/dev-preference.example
+++ b/.env/dev-preference.example
@@ -15,10 +15,10 @@
 ### Preferred Manifest Version
 
 # manifest=2
-# (default) Use Manifest V2 as default development target.
+# Use Manifest V2 as default development target.
 
 # manifest=3
-# Use Manifest V3 as default development target.
+# (default) Use Manifest V3 as default development target.
 
 ### Hot Module Reload
 

--- a/packages/scripts/src/extension/flags.ts
+++ b/packages/scripts/src/extension/flags.ts
@@ -35,7 +35,8 @@ export interface BuildFlagsExtended extends BuildFlags {
 export function getPreset(
     preset: Preset | undefined,
 ): Pick<BuildFlagsExtended, 'architecture' | 'engine' | 'manifest'> {
-    if (preset === Preset.Chromium || preset === undefined) return { architecture: 'web', engine: 'chromium' }
+    if (preset === Preset.Chromium || preset === undefined)
+        return { architecture: 'web', engine: 'chromium', manifest: 3 }
     else if (preset === Preset.Firefox) return { architecture: 'web', engine: 'firefox', manifest: 2 }
     else if (preset === Preset.Android) return { architecture: 'app', engine: 'firefox', manifest: 2 }
     else if (preset === Preset.iOS) return { architecture: 'app', engine: 'safari', manifest: 2 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [x] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
