### PR TITLE
refactor: make useValueRef readonly

### DIFF
--- a/packages/base/src/Identifier/base.ts
+++ b/packages/base/src/Identifier/base.ts
@@ -3,8 +3,8 @@ import { type Option, None } from 'ts-results-es'
 export abstract class Identifier {
     abstract toText(): string
     abstract [Symbol.toStringTag]: string
-    /** We mark this as private because we encourage to use toText(). toString is for JavaScript runtime accidentally calling. */
-    private toString() {
+    /** @internal */
+    toString() {
         return this.toText()
     }
     static from(input: string | undefined | null): Option<Identifier> {

--- a/packages/mask/src/components/InjectedComponents/DisabledPluginSuggestion.tsx
+++ b/packages/mask/src/components/InjectedComponents/DisabledPluginSuggestion.tsx
@@ -25,7 +25,7 @@ function useDisabledPlugins() {
     return disabledPlugins
 }
 
-export function useDisabledPluginSuggestionFromPost(postContent: Option<string>, metaLinks: string[]) {
+export function useDisabledPluginSuggestionFromPost(postContent: Option<string>, metaLinks: readonly string[]) {
     const disabled = useDisabledPlugins().filter((x) => x.contribution?.postContent)
 
     const { some } = postContent

--- a/packages/mask/src/plugins/Collectible/src/helpers/url.ts
+++ b/packages/mask/src/plugins/Collectible/src/helpers/url.ts
@@ -152,7 +152,7 @@ const RULES = [
     },
 ]
 
-export function getPayloadFromURLs(urls: string[]): CollectiblePayload | undefined {
+export function getPayloadFromURLs(urls: readonly string[]): CollectiblePayload | undefined {
     for (const url of urls) {
         const payload = getPayloadFromURL(url)
         if (payload) return payload

--- a/packages/plugin-infra/src/sns-adaptor/PostContext.ts
+++ b/packages/plugin-infra/src/sns-adaptor/PostContext.ts
@@ -109,11 +109,13 @@ export function PostInfoProvider(props: React.PropsWithChildren<{ post: PostInfo
 export const usePostInfoDetails: {
     // Change to use* when https://github.com/microsoft/TypeScript/issues/44643 fixed
     [key in keyof PostInfo]: () => PostInfo[key] extends ValueRef<infer T>
-        ? Readonly<T>
+        ? T extends Function
+            ? T
+            : Readonly<T>
         : PostInfo[key] extends ObservableSet<infer T>
-        ? readonly T[]
+        ? ReadonlyArray<Readonly<T>>
         : PostInfo[key] extends ObservableMap<any, infer T>
-        ? readonly T[]
+        ? ReadonlyArray<Readonly<T>>
         : PostInfo[key] extends Subscription<infer T>
         ? Readonly<T>
         : PostInfo[key]

--- a/packages/plugin-infra/src/sns-adaptor/PostContext.ts
+++ b/packages/plugin-infra/src/sns-adaptor/PostContext.ts
@@ -109,13 +109,13 @@ export function PostInfoProvider(props: React.PropsWithChildren<{ post: PostInfo
 export const usePostInfoDetails: {
     // Change to use* when https://github.com/microsoft/TypeScript/issues/44643 fixed
     [key in keyof PostInfo]: () => PostInfo[key] extends ValueRef<infer T>
-        ? T
+        ? Readonly<T>
         : PostInfo[key] extends ObservableSet<infer T>
-        ? T[]
+        ? readonly T[]
         : PostInfo[key] extends ObservableMap<any, infer T>
-        ? T[]
+        ? readonly T[]
         : PostInfo[key] extends Subscription<infer T>
-        ? T
+        ? Readonly<T>
         : PostInfo[key]
 } = {
     __proto__: new Proxy(

--- a/packages/plugins/ScamWarning/src/SNSAdaptor/components/PreviewCard.tsx
+++ b/packages/plugins/ScamWarning/src/SNSAdaptor/components/PreviewCard.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { Stack, ThemeProvider, Typography } from '@mui/material'
 import { useAsync } from 'react-use'
 import { CryptoScamDB } from '@masknet/web3-providers'
@@ -8,7 +7,7 @@ import { makeStyles, MaskDarkTheme } from '@masknet/theme'
 import { usePluginWrapper } from '@masknet/plugin-infra/content-script'
 
 interface PreviewCardProps {
-    links: string[]
+    links: readonly string[]
 }
 
 const useStyles = makeStyles()((theme) => ({

--- a/packages/shared-base-ui/src/hooks/useValueRef.ts
+++ b/packages/shared-base-ui/src/hooks/useValueRef.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Subscription, useSubscription } from 'use-subscription'
 import type { ValueRef } from '@masknet/shared-base'
 
-export function useValueRef<T>(ref: ValueRef<T>) {
+export function useValueRef<T>(ref: ValueRef<T>): Readonly<T> {
     const subscription = useMemo<Subscription<T>>(
         () => ({
             getCurrentValue: () => ref.value,

--- a/packages/shared-base-ui/src/hooks/useValueRef.ts
+++ b/packages/shared-base-ui/src/hooks/useValueRef.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Subscription, useSubscription } from 'use-subscription'
 import type { ValueRef } from '@masknet/shared-base'
 
-export function useValueRef<T>(ref: ValueRef<T>): Readonly<T> {
+export function useValueRef<T>(ref: ValueRef<T>) {
     const subscription = useMemo<Subscription<T>>(
         () => ({
             getCurrentValue: () => ref.value,


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
