### PR TITLE
fix: mf-2876 images of some NFT are missing, fallback to media url

### DIFF
--- a/packages/mask/src/plugins/Collectible/src/SNSAdaptor/List/CollectibleCard.tsx
+++ b/packages/mask/src/plugins/Collectible/src/SNSAdaptor/List/CollectibleCard.tsx
@@ -64,7 +64,7 @@ export function CollectibleCard({ className, pluginID, asset }: CollectibleCardP
                     classes={{
                         fallbackImage: classes.fallbackImage,
                     }}
-                    url={asset.metadata?.imageURL}
+                    url={asset.metadata?.imageURL ?? asset.metadata?.mediaURL}
                     icon={pluginID ? <NetworkIcon pluginID={pluginID} chainId={asset.chainId} /> : null}
                 />
             </Card>


### PR DESCRIPTION
https://mask.atlassian.net/browse/MF-2876