### PR TITLE
fix(ito): mf-2889 non-evm network tab display

### DIFF
--- a/packages/mask/src/plugins/ITO/SNSAdaptor/CompositionDialog.tsx
+++ b/packages/mask/src/plugins/ITO/SNSAdaptor/CompositionDialog.tsx
@@ -229,19 +229,19 @@ export function CompositionDialog(props: CompositionDialogProps) {
     // #endregion
 
     return (
-        <Web3ContextProvider value={{ pluginID: NetworkPluginID.PLUGIN_EVM, chainId: currentChainId }}>
-            <InjectedDialog
-                titleTail={
-                    step === ITOCreateFormPageStep.NewItoPage && !showHistory ? (
-                        <Icons.History onClick={() => setShowHistory((history) => !history)} className={classes.tail} />
-                    ) : null
-                }
-                isOpenFromApplicationBoard={props.isOpenFromApplicationBoard}
-                disableBackdropClick
-                isOnBack={showHistory || step === ITOCreateFormPageStep.ConfirmItoPage}
-                open={props.open}
-                title={t('plugin_ito_display_name')}
-                onClose={() => (showHistory ? setShowHistory(false) : onBack())}>
+        <InjectedDialog
+            titleTail={
+                step === ITOCreateFormPageStep.NewItoPage && !showHistory ? (
+                    <Icons.History onClick={() => setShowHistory((history) => !history)} className={classes.tail} />
+                ) : null
+            }
+            isOpenFromApplicationBoard={props.isOpenFromApplicationBoard}
+            disableBackdropClick
+            isOnBack={showHistory || step === ITOCreateFormPageStep.ConfirmItoPage}
+            open={props.open}
+            title={t('plugin_ito_display_name')}
+            onClose={() => (showHistory ? setShowHistory(false) : onBack())}>
+            <Web3ContextProvider value={{ pluginID: NetworkPluginID.PLUGIN_EVM, chainId: currentChainId }}>
                 <DialogContent className={classes.content}>
                     {step === ITOCreateFormPageStep.NewItoPage ? (
                         !showHistory ? (
@@ -269,7 +269,7 @@ export function CompositionDialog(props: CompositionDialogProps) {
                         />
                     ) : null}
                 </DialogContent>
-            </InjectedDialog>
-        </Web3ContextProvider>
+            </Web3ContextProvider>
+        </InjectedDialog>
     )
 }

--- a/packages/shared/src/UI/components/ReversedAddress/index.tsx
+++ b/packages/shared/src/UI/components/ReversedAddress/index.tsx
@@ -17,7 +17,7 @@ export const ReversedAddress = memo<ReverseAddressProps>(({ address, pluginID, s
     const { value: domain } = useReverseAddress(pluginID, address)
     const { Others } = useWeb3State(pluginID)
 
-    const showDomain = !!domain && !!Others?.formatDomainName
+    const showDomain = !!domain && !!Others?.formatDomainName && Others?.isValidDomain?.(domain)
     const uiLabel = showDomain ? Others.formatDomainName(domain) : Others?.formatAddress?.(address, size) ?? address
     const hasEllipsis = showDomain ? uiLabel !== domain : !isSameAddress(uiLabel, address)
 
@@ -27,5 +27,5 @@ export const ReversedAddress = memo<ReverseAddressProps>(({ address, pluginID, s
         </Typography>
     )
 
-    return hasEllipsis ? <ShadowRootTooltip title={domain || address}>{node}</ShadowRootTooltip> : node
+    return hasEllipsis ? <ShadowRootTooltip title={showDomain ? domain : address}>{node}</ShadowRootTooltip> : node
 })


### PR DESCRIPTION
## Description
https://mask.atlassian.net/browse/MF-2889
https://mask.atlassian.net/browse/MF-2924

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
