### PR TITLE
fix: should use mainnet create native token when fetch asset

### DIFF
--- a/packages/dashboard/src/Dashboard.tsx
+++ b/packages/dashboard/src/Dashboard.tsx
@@ -1,10 +1,6 @@
-import { lazy, Suspense } from 'react'
+import { lazy } from 'react'
 
 const Dashboard = lazy(() => import(/* webpackPreload: true */ './initialization/Dashboard.js'))
 export function IntegratedDashboard() {
-    return (
-        <Suspense fallback="">
-            <Dashboard />
-        </Suspense>
-    )
+    return <Dashboard />
 }

--- a/packages/web3-providers/src/helpers/getNativeAssets.ts
+++ b/packages/web3-providers/src/helpers/getNativeAssets.ts
@@ -2,7 +2,7 @@ import type { FungibleAsset } from '@masknet/web3-shared-base'
 import { ChainId, createNativeToken, NETWORK_DESCRIPTORS, SchemaType } from '@masknet/web3-shared-evm'
 
 export function getNativeAssets(): Array<FungibleAsset<ChainId, SchemaType>> {
-    return NETWORK_DESCRIPTORS.map((x) => ({
+    return NETWORK_DESCRIPTORS.filter((x) => x.isMainnet).map((x) => ({
         ...createNativeToken(x.chainId),
         balance: '0',
     }))


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #mf-3178 #mf-3183 #mf-3185

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
