### PR TITLE
fix: hide network tab at confirm page AND nftscan fallback

### DIFF
--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketDialog.tsx
@@ -233,19 +233,21 @@ export default function RedPacketDialog(props: RedPacketDialogProps) {
                     <DialogContent className={classes.dialogContent}>
                         {step === CreateRedPacketPageStep.NewRedPacketPage ? (
                             <>
-                                <div className={classes.abstractTabWrapper}>
-                                    <NetworkTab
-                                        classes={{
-                                            tab: classes.tab,
-                                            tabPanel: classes.tabPanel,
-                                            indicator: classes.indicator,
-                                            tabPaper: classes.tabPaper,
-                                        }}
-                                        chains={chainIdList}
-                                        hideArrowButton={currentTab === tabs.collectibles}
-                                        pluginID={NetworkPluginID.PLUGIN_EVM}
-                                    />
-                                </div>
+                                {openNFTConfirmDialog ? null : (
+                                    <div className={classes.abstractTabWrapper}>
+                                        <NetworkTab
+                                            classes={{
+                                                tab: classes.tab,
+                                                tabPanel: classes.tabPanel,
+                                                indicator: classes.indicator,
+                                                tabPaper: classes.tabPaper,
+                                            }}
+                                            chains={chainIdList}
+                                            hideArrowButton={currentTab === tabs.collectibles}
+                                            pluginID={NetworkPluginID.PLUGIN_EVM}
+                                        />
+                                    </div>
+                                )}
                                 <div
                                     style={{
                                         visibility: showHistory ? 'hidden' : 'visible',

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC721Form.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/RedPacketERC721Form.tsx
@@ -11,6 +11,7 @@ import {
     ChainBoundary,
     EthereumERC721TokenApprovedBoundary,
 } from '@masknet/shared'
+import { useNonFungibleOwnerTokens } from '@masknet/web3-hooks-evm'
 import { ChainId, SchemaType, useNftRedPacketConstants, formatTokenId } from '@masknet/web3-shared-evm'
 import { RedpacketMessagePanel } from './RedpacketMessagePanel.js'
 import { SelectNftTokenDialog, OrderedERC721Token } from './SelectNftTokenDialog.js'
@@ -221,7 +222,15 @@ export function RedPacketERC721Form(props: RedPacketERC721FormProps) {
     const tokenDetailedList =
         selectOption === NFTSelectOption.Partial ? manualSelectedTokenDetailedList : onceAllSelectedTokenDetailedList
     const [message, setMessage] = useState('Best Wishes!')
-    const tokenDetailedOwnerList = (collection?.assets ?? EMPTY_LIST).map(
+
+    const { value: _tokenDetailedOwnerList = EMPTY_LIST } = useNonFungibleOwnerTokens(
+        !collection || collection.assets?.length ? '' : collection?.address ?? '',
+        account,
+        chainId,
+        balance,
+    )
+
+    const tokenDetailedOwnerList = (collection?.assets ?? _tokenDetailedOwnerList ?? EMPTY_LIST).map(
         (v, index) => ({ ...v, index } as OrderedERC721Token),
     )
     const removeToken = useCallback(


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
