### PR TITLE
fix(FileService): mf-3269 tooltip doesn't show on production build

### DIFF
--- a/packages/shared/src/UI/components/MaskPluginWrapper/index.tsx
+++ b/packages/shared/src/UI/components/MaskPluginWrapper/index.tsx
@@ -151,7 +151,11 @@ export function MaskPostExtraInfoWrapper(props: PluginWrapperProps) {
                     <div className={classes.action}>{action}</div>
                 </>
             ) : null}
-            {children ? <div className={classes.body}>{children}</div> : null}
+            {children ? (
+                <div className={classes.body} key={open ? 'open' : 'close'}>
+                    {children}
+                </div>
+            ) : null}
         </div>
     )
 


### PR DESCRIPTION
plugin content inside post wrapper can't get element layout, like
offsetWidth, correctly 

https://mask.atlassian.net/browse/MF-3269