### PR TITLE
fix: read theme from computing style

### DIFF
--- a/packages/web3-providers/src/Twitter/apis/getUserSettings.ts
+++ b/packages/web3-providers/src/Twitter/apis/getUserSettings.ts
@@ -1,4 +1,4 @@
-import { hexToRgb, rgbToHex } from '@mui/material'
+import { hexToRgb } from '@mui/material'
 import { getStore } from './getDatabase.js'
 import { TwitterBaseAPI } from '../../entry-types.js'
 

--- a/packages/web3-providers/src/Twitter/apis/getUserSettings.ts
+++ b/packages/web3-providers/src/Twitter/apis/getUserSettings.ts
@@ -1,3 +1,4 @@
+import { hexToRgb, rgbToHex } from '@mui/material'
 import { getStore } from './getDatabase.js'
 import { TwitterBaseAPI } from '../../entry-types.js'
 
@@ -31,5 +32,53 @@ export function getDefaultUserSettings(): TwitterBaseAPI.UserSettings {
         scale: TwitterBaseAPI.Scale.Normal,
         themeBackground: TwitterBaseAPI.ThemeMode.Light,
         themeColor: TwitterBaseAPI.ThemeColor.Blue,
+    }
+}
+
+export function getComputedUserSettings(): TwitterBaseAPI.UserSettings {
+    const getThemeBackground = () => {
+        const { backgroundColor } = getComputedStyle(document.body)
+        const rgb = backgroundColor.startsWith('#') ? hexToRgb(backgroundColor) : backgroundColor
+
+        switch (rgb.toLowerCase()) {
+            case 'rgb(255, 255, 255)':
+                return TwitterBaseAPI.ThemeMode.Light
+            case 'rgb(21, 32, 43)':
+                return TwitterBaseAPI.ThemeMode.Dim
+            case 'rgb(0, 0, 0)':
+                return TwitterBaseAPI.ThemeMode.Dark
+            default:
+                return
+        }
+    }
+
+    const getThemeColor = () => {
+        const tweetButton = document.querySelector('a[href="/compose/tweet"][data-testid="SideNav_NewTweet_Button"]')
+        if (!tweetButton) return
+
+        const { backgroundColor } = getComputedStyle(tweetButton)
+        const rgb = backgroundColor.startsWith('#') ? hexToRgb(backgroundColor) : backgroundColor
+
+        switch (rgb.toLowerCase()) {
+            case 'rgb(29, 155, 240)':
+                return TwitterBaseAPI.ThemeColor.Blue
+            case 'rgb(255, 212, 0)':
+                return TwitterBaseAPI.ThemeColor.Yellow
+            case 'rgb(120, 86, 255)':
+                return TwitterBaseAPI.ThemeColor.Purple
+            case 'rgb(249, 24, 128)':
+                return TwitterBaseAPI.ThemeColor.Magenta
+            case 'rgb(255, 122, 0)':
+                return TwitterBaseAPI.ThemeColor.Orange
+            case 'rgb(0, 186, 124)':
+                return TwitterBaseAPI.ThemeColor.Green
+            default:
+                return
+        }
+    }
+
+    return {
+        themeBackground: getThemeBackground(),
+        themeColor: getThemeColor(),
     }
 }

--- a/packages/web3-providers/src/Twitter/index.ts
+++ b/packages/web3-providers/src/Twitter/index.ts
@@ -12,6 +12,7 @@ import {
     getUserNFTAvatar,
     getUserNFTContainer,
     staleUserViaIdentity,
+    getComputedUserSettings,
 } from './apis/index.js'
 import type { TwitterBaseAPI } from '../entry-types.js'
 import { fetchJSON } from '../entry-helpers.js'
@@ -32,14 +33,21 @@ export class TwitterAPI implements TwitterBaseAPI.Provider {
 
     async getUserSettings() {
         const defaults = getDefaultUserSettings()
+        const computed = getComputedUserSettings()
+
         try {
             const userSettings = await timeout(getUserSettings(), 5000)
+
             return {
                 ...defaults,
+                ...computed,
                 ...userSettings,
             }
         } catch {
-            return defaults
+            return {
+                ...defaults,
+                ...computed,
+            }
         }
     }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes [MF-3302](https://mask.atlassian.net/browse/MF-3302)
Closes [MF-3409](https://mask.atlassian.net/browse/MF-3409)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.


[MF-3302]: https://mask.atlassian.net/browse/MF-3302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MF-3409]: https://mask.atlassian.net/browse/MF-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ