### PR TITLE
chore: infer class names from useStyles() when override classes is not provided

### DIFF
--- a/packages/mask/src/components/InjectedComponents/SearchResultInspector.tsx
+++ b/packages/mask/src/components/InjectedComponents/SearchResultInspector.tsx
@@ -90,12 +90,12 @@ export function SearchResultInspector(props: SearchResultInspectorProps) {
     if (!contentComponent) return null
 
     return (
-        <div className={classes.root}>
+        <div>
             <ScopedDomainsContainer.Provider>
                 <div className={classes.contentWrapper}>
-                    <div className={classes.content}>{contentComponent}</div>
+                    <div>{contentComponent}</div>
                     {tabs.length ? (
-                        <div className={classes.tabs}>
+                        <div>
                             <TabContext value={currentTab}>
                                 <MaskTabList variant="base" onChange={onChange} aria-label="Web3Tabs">
                                     {tabs.map((tab) => (

--- a/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectibleCard.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectibleCard.tsx
@@ -97,7 +97,6 @@ export const CollectibleCard = memo(function CollectibleCard({
                         url={asset.metadata?.mediaURL || asset.metadata?.imageURL}
                         classes={{
                             fallbackImage: classes.fallbackImage,
-                            root: classes.wrapper,
                         }}
                     />
                     {networkIcon ? (

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/NonFungibleTickersTable.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/NonFungibleTickersTable.tsx
@@ -211,11 +211,7 @@ export function NonFungibleTickersTable({
                     {cell}
                 </TableCell>
             ))
-            return (
-                <TableRow key={index} className={classes.tableContent}>
-                    {cells}
-                </TableRow>
-            )
+            return <TableRow key={index}>{cells}</TableRow>
         }) ?? []
 
     const headCells = Object.values(headCellMap)

--- a/packages/plugins/FileService/src/SNSAdaptor/components/FileList.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/FileList.tsx
@@ -115,7 +115,7 @@ export const FileList: FC<FileListProps> = ({ files, onLoadMore, className, onDo
             <Boundary>
                 <List className={classes.list} classes={{ root: classes.listRoot }}>
                     {files.map((file) => (
-                        <ListItem key={file.id} className={classes.listItem} classes={{ root: classes.itemRoot }}>
+                        <ListItem key={file.id} className={classes.listItem}>
                             {uploadStateMap[file.id] ? (
                                 <UploadingFile
                                     className={classes.file}
@@ -178,8 +178,7 @@ export const SelectableFileList: FC<SelectableFileListProps> = ({
                         return (
                             <ListItem
                                 key={file.id}
-                                className={cx(classes.listItem, disabled ? classes.disabled : null)}
-                                classes={{ root: classes.itemRoot }}>
+                                className={cx(classes.listItem, disabled ? classes.disabled : null)}>
                                 <SelectableFile
                                     disabled={disabled}
                                     className={classes.file}
@@ -213,7 +212,7 @@ export const DisplayingFileList: FC<DisplayingFileFileListProps> = ({
         <section className={cx(classes.container, className)} {...rest}>
             <List className={classes.list} classes={{ root: classes.listRoot }}>
                 {files.map((file) => (
-                    <ListItem key={file.id} className={classes.listItem} classes={{ root: classes.itemRoot }}>
+                    <ListItem key={file.id} className={classes.listItem}>
                         <DisplayingFile className={classes.file} file={file} onSave={onSave} onDownload={onDownload} />
                     </ListItem>
                 ))}

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CommentCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CommentCard.tsx
@@ -125,7 +125,7 @@ export const CommentCard: FC<CommentCardProps> = ({ feed, ...rest }) => {
                         width={imageSize}
                     />
                 ) : null}
-                <div className={classes.article}>
+                <div>
                     {commentTarget?.title ? (
                         <Typography variant="h1" className={classes.title}>
                             {commentTarget?.title}

--- a/packages/theme/src/UIHelper/makeStyles.ts
+++ b/packages/theme/src/UIHelper/makeStyles.ts
@@ -22,7 +22,7 @@ export const { makeStyles } = createMakeStyles({ useTheme }) as any as {
         },
     ) => {
         classes: StyleOverrides extends { classes?: { [key in infer ExtraKeys]?: string | undefined } }
-            ? Record<ExtraKeys | RuleName, string>
+            ? Record<string extends ExtraKeys ? RuleName : ExtraKeys | RuleName, string>
             : Record<RuleName, string>
         theme: Theme
         css: Css


### PR DESCRIPTION
close MF-0000

## Before

<img width="750" alt="image" src="https://user-images.githubusercontent.com/1141198/221333501-2e0c6e19-f242-43d1-ab2d-5dc0e1f1f28d.png">

## After

<img width="977" alt="image" src="https://user-images.githubusercontent.com/1141198/221333504-8d2bfc28-6979-4f4f-b2c2-d13da8cdf44d.png">
