### PR TITLE
fix: mv3 crash

### DIFF
--- a/packages/injected-script/sdk/index.ts
+++ b/packages/injected-script/sdk/index.ts
@@ -34,6 +34,7 @@ export function pasteInstagram(url: string) {
 export function inputText(text: string) {
     sendEvent('input', text)
 }
+
 export function hookInputUploadOnce(
     format: string,
     fileName: string,
@@ -43,50 +44,53 @@ export function hookInputUploadOnce(
     sendEvent('hookInputUploadOnce', format, fileName, Array.from(image), triggerOnActiveElementNow)
 }
 
-if (typeof document !== 'object') {
-    // eslint-disable-next-line no-debugger
-    debugger
-    throw new Error('This script should not be included in the Manifest V3 background')
+if (typeof location === 'object' && location.protocol.includes('extension')) {
+    console.warn(
+        'This package is not expected to be imported in background script or the extension script. Please check your code.',
+    )
 }
-globalThis?.document?.addEventListener?.(CustomEventId, (e) => {
-    const r = decodeEvent((e as CustomEvent).detail)
-    if (r[1].length < 1) return
 
-    switch (r[0]) {
-        case 'resolvePromise':
-            return resolvePromise(...r[1])
-        case 'rejectPromise':
-            return rejectPromise(...r[1])
+export function setup() {
+    document.addEventListener(CustomEventId, (e) => {
+        const r = decodeEvent((e as CustomEvent).detail)
+        if (r[1].length < 1) return
 
-        case 'web3BridgeEmitEvent':
-            const [pathname, eventName, data] = r[1]
-            const provider = [
-                injectedCoin98EVMProvider,
-                injectedCoin98SolanaProvider,
-                injectedPhantomProvider,
-                injectedMetaMaskProvider,
-                injectedMathWalletProvider,
-                injectedWalletLinkProvider,
-                injectedOperaProvider,
-                injectedCloverProvider,
-            ].find((x) => x.pathname === pathname)
+        switch (r[0]) {
+            case 'resolvePromise':
+                return resolvePromise(...r[1])
+            case 'rejectPromise':
+                return rejectPromise(...r[1])
 
-            provider?.emit(eventName, data)
-            return
+            case 'web3BridgeEmitEvent':
+                const [pathname, eventName, data] = r[1]
+                const provider = [
+                    injectedCoin98EVMProvider,
+                    injectedCoin98SolanaProvider,
+                    injectedPhantomProvider,
+                    injectedMetaMaskProvider,
+                    injectedMathWalletProvider,
+                    injectedWalletLinkProvider,
+                    injectedOperaProvider,
+                    injectedCloverProvider,
+                ].find((x) => x.pathname === pathname)
 
-        case 'web3BridgeBindEvent':
-        case 'web3BridgeSendRequest':
-        case 'web3BridgeExecute':
-        case 'web3UntilBridgeOnline':
-        case 'web3BridgePrimitiveAccess':
-        case 'input':
-        case 'paste':
-        case 'pasteImage':
-        case 'instagramUpload':
-        case 'hookInputUploadOnce':
-            break
-        default:
-            const neverEvent: never = r[0]
-            console.log('[@masknet/injected-script]', neverEvent, 'not handled')
-    }
-})
+                provider?.emit(eventName, data)
+                return
+
+            case 'web3BridgeBindEvent':
+            case 'web3BridgeSendRequest':
+            case 'web3BridgeExecute':
+            case 'web3UntilBridgeOnline':
+            case 'web3BridgePrimitiveAccess':
+            case 'input':
+            case 'paste':
+            case 'pasteImage':
+            case 'instagramUpload':
+            case 'hookInputUploadOnce':
+                break
+            default:
+                const neverEvent: never = r[0]
+                console.log('[@masknet/injected-script]', neverEvent, 'not handled')
+        }
+    })
+}

--- a/packages/injected-script/sdk/utils.ts
+++ b/packages/injected-script/sdk/utils.ts
@@ -1,6 +1,10 @@
 import { CustomEventId, type InternalEvents, encodeEvent } from '../shared/index.js'
 
 export function sendEvent<K extends keyof InternalEvents>(name: K, ...params: InternalEvents[K]) {
+    if (typeof location === 'object' && location.protocol.includes('extension')) {
+        console.warn('This code is not expected to be run in the extension pages. Please check your code.')
+        return
+    }
     document.dispatchEvent(
         new CustomEvent(CustomEventId, {
             cancelable: true,

--- a/packages/mask/shared/messages.ts
+++ b/packages/mask/shared/messages.ts
@@ -5,7 +5,3 @@ export const MaskMessages = new WebExtensionMessage<MaskEvents>({ domain: 'mask'
 MaskMessages.serialization = serializer
 
 Object.assign(globalThis, { MaskMessages })
-
-setTimeout(() => {
-    throw new Error('Sentry test')
-})

--- a/packages/mask/src/content-script.ts
+++ b/packages/mask/src/content-script.ts
@@ -4,5 +4,6 @@
 const loaded = Symbol.for('mask_init_content_script')
 if (!Reflect.get(globalThis, loaded)) {
     Reflect.set(globalThis, loaded, true)
+    import(/* webpackMode: 'eager' */ '@masknet/injected-script').then(({ setup }) => setup())
     import(/* webpackMode: 'eager' */ './setup.ui.js')
 }

--- a/packages/shared-base/src/utils/createDeviceFingerprint.ts
+++ b/packages/shared-base/src/utils/createDeviceFingerprint.ts
@@ -3,6 +3,7 @@ import { sha3 } from 'web3-utils'
 
 function createCanvasFingerprint() {
     if (process.env.NODE_ENV === 'test') return ''
+    if (typeof document === 'undefined') return ''
 
     const canvas = document.createElement('canvas')
     const context = canvas.getContext('2d')

--- a/packages/web3-providers/src/Sentry/index.ts
+++ b/packages/web3-providers/src/Sentry/index.ts
@@ -53,6 +53,10 @@ export class SentryAPI implements TelemetryAPI.Provider<Event, Event> {
                     ? `mask-${process.env.VERSION}-reproducible`
                     : `mask-${process.env.COMMIT_HASH}`
                 : undefined
+        if (typeof Sentry === 'undefined') {
+            console.warn('Sentry is not defined')
+            return
+        }
         Sentry.init({
             dsn: process.env.MASK_SENTRY_DSN,
             release,


### PR DESCRIPTION
MF-0000

cc @qqqzhch

@guanbinrui the canvas fingerprint is terrible as I described in https://mask.atlassian.net/jira/software/c/projects/MF/issues/MF-3679, and it also crashes Manifest V3. I disabled it in MV3 temporarily, but we should change it to a more privacy-friendly way to do this.

@guanbinrui now the `injected-scripts` is imported in the background via `packages/web3-providers/src/entry.ts` this is incorrect. `injected-scripts` package should only be used in the content script package. in other places using it is meaningless. I updated the `injected-scripts` package to not crash in MV3 but log warnings on the extension page. Hope we can fix it soon.