### PR TITLE
fix: open download link when wallet is not ready

### DIFF
--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/SelectProviderDialog/PluginProviderRender.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/SelectProviderDialog/PluginProviderRender.tsx
@@ -31,6 +31,7 @@ import { useActivatedPluginsDashboard } from '@masknet/plugin-infra/dashboard'
 import { useCallback, useState } from 'react'
 import { DialogDismissIconUI } from '../../../../components/InjectedComponents/DialogDismissIcon.js'
 import { ImageIcon } from '@masknet/shared'
+import { openWindow } from '@masknet/shared-base-ui'
 const descriptors: Record<
     NetworkPluginID,
     Array<NetworkDescriptor<Web3Helper.ChainIdAll, Web3Helper.NetworkTypeAll>>
@@ -175,6 +176,14 @@ export function PluginProviderRender({
             )
             if (!target) return
 
+            const isReady = target.Web3State?.Provider?.isReady(provider.type)
+            const downloadLink = target.Web3State?.Others?.providerResolver.providerDownloadLink(provider.type)
+
+            if (!isReady) {
+                if (downloadLink) openWindow(downloadLink)
+                return
+            }
+
             const connection = target.Web3State?.Connection?.getConnection?.({ providerType: provider.type })
 
             const chainId =
@@ -185,11 +194,10 @@ export function PluginProviderRender({
             const networkDescriptor = descriptors[provider.providerAdaptorPluginID].find((x) => x.chainId === chainId)
 
             if (!chainId || !networkDescriptor) return
-            const isReady = target.Web3State?.Provider?.isReady(provider.type)
-            const downloadLink = target.Web3State?.Others?.providerResolver.providerDownloadLink(provider.type)
+
             onProviderIconClicked(networkDescriptor, provider, isReady, downloadLink)
         },
-        [],
+        [snsPlugins, dashboardPlugins],
     )
 
     const getTips = useCallback((provider: Web3Helper.ProviderTypeAll) => {

--- a/packages/web3-providers/src/Wallet/Solana/Phantom.ts
+++ b/packages/web3-providers/src/Wallet/Solana/Phantom.ts
@@ -20,6 +20,7 @@ export class PhantomProvider
     }
 
     override async setup(): Promise<void> {
+        if (!injectedPhantomProvider.isReady) return
         await injectedPhantomProvider.untilAvailable()
         await injectedPhantomProvider.connect({
             onlyIfTrusted: true,


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-3849

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
