### PR TITLE
fix: person:localhost/$unknown should be a ProfileIdentifier

### DIFF
--- a/packages/mask/background/tasks/Cancellable/CleanProfileAndAvatar.ts
+++ b/packages/mask/background/tasks/Cancellable/CleanProfileAndAvatar.ts
@@ -11,11 +11,9 @@ try {
 async function cleanRelationDB(anotherList: Set<ProfileIdentifier>) {
     await consistentPersonaDBWriteAccess(async (t) => {
         for await (const x of t.objectStore('relations')) {
-            if (!x.value.profile.includes('$unknown')) {
-                const profileIdentifier = ProfileIdentifier.from(x.value.profile).expect(
-                    `${x.value.profile} should be a ProfileIdentifier`,
-                )
-                if (anotherList.has(profileIdentifier)) x.delete()
+            const profileIdentifier = ProfileIdentifier.from(x.value.profile)
+            if (profileIdentifier.some) {
+                if (anotherList.has(profileIdentifier.val)) x.delete()
             }
         }
     })

--- a/packages/mask/background/tasks/Cancellable/CleanProfileAndAvatar.ts
+++ b/packages/mask/background/tasks/Cancellable/CleanProfileAndAvatar.ts
@@ -11,10 +11,12 @@ try {
 async function cleanRelationDB(anotherList: Set<ProfileIdentifier>) {
     await consistentPersonaDBWriteAccess(async (t) => {
         for await (const x of t.objectStore('relations')) {
-            const profileIdentifier = ProfileIdentifier.from(x.value.profile).expect(
-                `${x.value.profile} should be a ProfileIdentifier`,
-            )
-            if (anotherList.has(profileIdentifier)) x.delete()
+            if (!x.value.profile.includes('$unknown')) {
+                const profileIdentifier = ProfileIdentifier.from(x.value.profile).expect(
+                    `${x.value.profile} should be a ProfileIdentifier`,
+                )
+                if (anotherList.has(profileIdentifier)) x.delete()
+            }
         }
     })
 }


### PR DESCRIPTION

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes mf-3852

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
