### PR TITLE
fix: add error notification when switch to unsupport network

### DIFF
--- a/packages/plugins/Debugger/src/SNSAdaptor/components/ConsoleContent.tsx
+++ b/packages/plugins/Debugger/src/SNSAdaptor/components/ConsoleContent.tsx
@@ -1,4 +1,4 @@
-import { Button, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import {
     useBalance,
@@ -128,22 +128,6 @@ export function ConsoleContent(props: ConsoleContentProps) {
             content: (
                 <Typography variant="body2" style={{ width: 280, wordBreak: 'break-all' }}>
                     {currentVisitingSocialIdentity?.value?.publicKey}
-                </Typography>
-            ),
-        },
-        {
-            name: 'Follow Lens Dialog',
-            content: (
-                <Typography>
-                    <Button
-                        onClick={() =>
-                            setDialog({
-                                open: true,
-                                handle: 'nicolo.lens',
-                            })
-                        }>
-                        Click
-                    </Button>
                 </Typography>
             ),
         },

--- a/packages/plugins/Debugger/src/SNSAdaptor/components/ConsoleContent.tsx
+++ b/packages/plugins/Debugger/src/SNSAdaptor/components/ConsoleContent.tsx
@@ -1,4 +1,4 @@
-import { Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { Button, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import {
     useBalance,
@@ -128,6 +128,22 @@ export function ConsoleContent(props: ConsoleContentProps) {
             content: (
                 <Typography variant="body2" style={{ width: 280, wordBreak: 'break-all' }}>
                     {currentVisitingSocialIdentity?.value?.publicKey}
+                </Typography>
+            ),
+        },
+        {
+            name: 'Follow Lens Dialog',
+            content: (
+                <Typography>
+                    <Button
+                        onClick={() =>
+                            setDialog({
+                                open: true,
+                                handle: 'nicolo.lens',
+                            })
+                        }>
+                        Click
+                    </Button>
                 </Typography>
             ),
         },

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/hooks/Lens/useFollow.ts
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/hooks/Lens/useFollow.ts
@@ -31,7 +31,7 @@ export function useFollow(
     const t = useI18N()
     const connection = useWeb3Connection()
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
-    const [, handleQueryAuthenticate] = useQueryAuthenticate(account)
+    const handleQueryAuthenticate = useQueryAuthenticate(account)
     const { LENS_HUB_PROXY_CONTRACT_ADDRESS } = useLensConstants(chainId)
     const lensHub = useContract<LensHub>(chainId, LENS_HUB_PROXY_CONTRACT_ADDRESS, LensHubABI as AbiItem[])
     const { fetchJSON } = useSNSAdaptorContext()
@@ -140,7 +140,9 @@ export function useFollow(
             if (
                 error instanceof Error &&
                 !error.message.includes('Transaction was rejected') &&
-                !error.message.includes('Signature canceled')
+                !error.message.includes('Signature canceled') &&
+                !error.message.includes('User rejected the request') &&
+                !error.message.includes('User rejected transaction')
             )
                 showSingletonSnackbar(t.follow_lens_handle(), {
                     processing: false,

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/hooks/Lens/useQueryAuthenticate.ts
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/hooks/Lens/useQueryAuthenticate.ts
@@ -3,14 +3,14 @@ import { Lens } from '@masknet/web3-providers'
 import { ChainId, isValidAddress } from '@masknet/web3-shared-evm'
 import isBefore from 'date-fns/isBefore'
 import add from 'date-fns/add'
-import { useAsyncFn } from 'react-use'
 import { context, lensTokenStorage as storage } from '../../context.js'
+import { useCallback } from 'react'
 
 export function useQueryAuthenticate(address: string) {
     const { chainId } = useChainContext()
     const connection = useWeb3Connection()
 
-    return useAsyncFn(async () => {
+    return useCallback(async () => {
         if (!address || !connection || chainId !== ChainId.Matic || !isValidAddress(address)) return
 
         const accessToken = storage.accessToken?.value?.[address]

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/hooks/Lens/useUnfollow.ts
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/hooks/Lens/useUnfollow.ts
@@ -17,7 +17,7 @@ export function useUnfollow(profileId?: string, onSuccess?: () => void) {
     const t = useI18N()
     const connection = useWeb3Connection()
     const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
-    const [, handleQueryAuthenticate] = useQueryAuthenticate(account)
+    const handleQueryAuthenticate = useQueryAuthenticate(account)
     const web3 = useWeb3(NetworkPluginID.PLUGIN_EVM, { chainId })
     const { fetchJSON } = useSNSAdaptorContext()
 
@@ -82,7 +82,13 @@ export function useUnfollow(profileId?: string, onSuccess?: () => void) {
 
             onSuccess?.()
         } catch (error) {
-            if (error instanceof Error && !error.message.includes('Transaction was rejected'))
+            if (
+                error instanceof Error &&
+                !error.message.includes('Transaction was rejected') &&
+                !error.message.includes('Signature canceled') &&
+                !error.message.includes('User rejected the request') &&
+                !error.message.includes('User rejected transaction')
+            )
                 showSingletonSnackbar(t.unfollow_lens_handle(), {
                     processing: false,
                     variant: 'error',

--- a/packages/shared/src/locales/en-US.json
+++ b/packages/shared/src/locales/en-US.json
@@ -139,6 +139,8 @@
     "plugin_wallet_no_gas_fee": "No Gas Fee",
     "plugin_wallet_invalid_network": "Invalid Network",
     "plugin_wallet_wrong_network": "Wrong Network",
+    "plugin_wallet_unsupported_network": "Unsupported Network",
+    "plugin_wallet_unsupported_chain": "The network is not supported by the current wallet.",
     "plugin_wallet_switch_network": "Switch to {{network}}",
     "plugin_wallet_not_support_network": "This network is not supported yet.",
     "plugin_wallet_switch_network_under_going": "Switching to {{network}}",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-3838

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
