### PR TITLE
fix: default image of ens and lens

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -140,6 +140,7 @@
         "languagedetector",
         "leaderboard",
         "lendingpool",
+        "lensprotocol",
         "lenster",
         "linkify",
         "linkifyjs",

--- a/packages/web3-shared/evm/src/helpers/resolver.ts
+++ b/packages/web3-shared/evm/src/helpers/resolver.ts
@@ -26,9 +26,8 @@ export function resolveNonFungibleTokenIdFromEnsDomain(domain: string): string {
 }
 
 export function resolveImageURL(image?: string, name?: string, address?: string) {
-    if (!image) {
-        if (name?.includes('.lens')) return new URL('./lens.svg', import.meta.url).toString()
-        if (isENSContractAddress(address || '')) return new URL('./ens.svg', import.meta.url).toString()
-    }
+    if (name?.includes('.lens') || name?.includes('lensprotocol'))
+        return new URL('./lens.svg', import.meta.url).toString()
+    if (isENSContractAddress(address || '')) return new URL('./ens.svg', import.meta.url).toString()
     return image
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes mf-3914

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
