### PR TITLE
fix: when collect name is null, nft name is still displayed

### DIFF
--- a/packages/shared/src/UI/components/AssetsManagement/CollectibleItem.tsx
+++ b/packages/shared/src/UI/components/AssetsManagement/CollectibleItem.tsx
@@ -75,9 +75,6 @@ const useStyles = makeStyles<void, 'action' | 'collectibleCard' | 'info'>()((the
         fontWeight: 700,
         color: theme.palette.maskColor.main,
     },
-    hidden: {
-        visibility: 'hidden',
-    },
     action: {
         width: '100%',
         padding: theme.spacing(0, 1),
@@ -163,11 +160,11 @@ export const CollectibleItem = memo(
                         disableNetworkIcon={disableNetworkIcon}
                         onClick={handleClick}
                     />
-                    <div className={cx(classes.info, name ? '' : classes.hidden, classes.ease)}>
+                    <div className={cx(classes.info, classes.ease)}>
                         {disableName ? null : (
                             <div className={classes.nameRow}>
                                 <Typography ref={nameRef} className={classes.name} variant="body2">
-                                    {name}
+                                    {name || <br />}
                                 </Typography>
                                 {verifiedBy?.length ? (
                                     <ShadowRootTooltip title={t.verified_by({ marketplace: verifiedBy.join(', ') })}>

--- a/packages/shared/src/UI/components/AssetsManagement/CollectibleItem.tsx
+++ b/packages/shared/src/UI/components/AssetsManagement/CollectibleItem.tsx
@@ -163,9 +163,13 @@ export const CollectibleItem = memo(
                     <div className={cx(classes.info, classes.ease)}>
                         {disableName ? null : (
                             <div className={classes.nameRow}>
-                                <Typography ref={nameRef} className={classes.name} variant="body2">
-                                    {name || <br />}
-                                </Typography>
+                                {name ? (
+                                    <Typography ref={nameRef} className={classes.name} variant="body2">
+                                        {name}
+                                    </Typography>
+                                ) : (
+                                    <br />
+                                )}
                                 {verifiedBy?.length ? (
                                     <ShadowRootTooltip title={t.verified_by({ marketplace: verifiedBy.join(', ') })}>
                                         <Icons.Verification size={16} />


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes mf-4049
## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
