### PR TITLE
fix: get avatar type of current twitter

### DIFF
--- a/packages/mask/src/social-network-adaptor/twitter.com/injection/NFT/index.tsx
+++ b/packages/mask/src/social-network-adaptor/twitter.com/injection/NFT/index.tsx
@@ -4,27 +4,27 @@ import { createReactRootShadowed, startWatch } from '../../../../utils/index.js'
 import {
     searchTwitterAvatarNFTLinkSelector,
     searchTwitterAvatarNFTSelector,
-    searchTwitterAvatarNormalSelector,
     searchTwitterAvatarSelector,
     searchTwitterSquareAvatarSelector,
 } from '../../utils/selector.js'
 import { NFTAvatarClipInTwitter } from './NFTAvatarClip.js'
+import { getAvatarType } from '../../utils/AvatarType.js'
+import { AvatarType } from '@masknet/plugin-avatar'
 
 export function injectNFTAvatarInTwitter(signal: AbortSignal) {
-    const squareWatcher = new MutationObserverWatcher(
-        searchTwitterAvatarNormalSelector().evaluate()
-            ? searchTwitterAvatarNormalSelector().querySelector('div img')
-            : searchTwitterSquareAvatarSelector(),
-    ).useForeach((ele, _, proxy) => {
-        const root = createReactRootShadowed(proxy.afterShadow, { untilVisible: true, signal })
-        if (searchTwitterAvatarNormalSelector().evaluate()) root.render(<NFTAvatarInTwitter />)
-        return () => root.destroy()
-    })
+    const avatarType = getAvatarType()
+    const squareWatcher = new MutationObserverWatcher(searchTwitterSquareAvatarSelector()).useForeach(
+        (ele, _, proxy) => {
+            const root = createReactRootShadowed(proxy.afterShadow, { untilVisible: true, signal })
+            if (avatarType === AvatarType.Square) root.render(<NFTAvatarInTwitter />)
+            return () => root.destroy()
+        },
+    )
     startWatch(squareWatcher, signal)
 
     const defaultWatcher = new MutationObserverWatcher(searchTwitterAvatarSelector()).useForeach((ele, _, proxy) => {
         const root = createReactRootShadowed(proxy.afterShadow, { untilVisible: true, signal })
-        if (searchTwitterAvatarNormalSelector().evaluate()) root.render(<NFTAvatarInTwitter />)
+        if (avatarType === AvatarType.Default) root.render(<NFTAvatarInTwitter />)
         return () => root.destroy()
     })
     startWatch(defaultWatcher, signal)

--- a/packages/mask/src/social-network-adaptor/twitter.com/utils/AvatarType.ts
+++ b/packages/mask/src/social-network-adaptor/twitter.com/utils/AvatarType.ts
@@ -19,7 +19,7 @@ export function getAvatarType(ele?: HTMLElement) {
         ? AvatarType.Square
         : styles.clipPath.includes('#shape-hex')
         ? AvatarType.Clip
-        : AvatarType.Circle
+        : AvatarType.Default
 }
 
 export function getInjectedDom() {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #mf-4046

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
