### PR TITLE
fix: default image for lens and ens

### DIFF
--- a/packages/shared/src/UI/components/AssetPreviewer/index.tsx
+++ b/packages/shared/src/UI/components/AssetPreviewer/index.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles()((theme) => ({
 
 export interface AssetPreviewerProps extends withClasses<'root' | 'fallbackImage' | 'container'> {
     url?: string
-    fallbackImage?: URL | JSX.Element
+    fallbackImage?: URL | JSX.Element | string
     icon?: React.ReactNode
 }
 

--- a/packages/shared/src/UI/components/NFTList/index.tsx
+++ b/packages/shared/src/UI/components/NFTList/index.tsx
@@ -7,7 +7,7 @@ import { CrossIsolationMessages, NetworkPluginID } from '@masknet/shared-base'
 import { isSameAddress } from '@masknet/web3-shared-base'
 import { useWeb3State } from '@masknet/web3-hooks-base'
 import { Checkbox, List, ListItem, Radio, Stack, Typography } from '@mui/material'
-import { isLens } from '@masknet/web3-shared-evm'
+import { isLens, resolveImageURL } from '@masknet/web3-shared-evm'
 
 interface NFTItemProps {
     token: Web3Helper.NonFungibleTokenAll
@@ -137,6 +137,12 @@ export const NFTItem: FC<NFTItemProps> = ({ token, pluginID }) => {
                     container: classes.image,
                     root: classes.root,
                 }}
+                fallbackImage={resolveImageURL(
+                    undefined,
+                    token.metadata?.name,
+                    token.collection?.name,
+                    token.contract?.address,
+                )}
             />
             <TextOverflowTooltip as={ShadowRootTooltip} title={caption} disableInteractive arrow placement="bottom">
                 <Typography className={classes.caption}>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # mf-4139

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
