### PR TITLE
fix(fb): inject web3 tab selector

### DIFF
--- a/packages/mask/src/social-network-adaptor/facebook.com/utils/selector.ts
+++ b/packages/mask/src/social-network-adaptor/facebook.com/utils/selector.ts
@@ -111,7 +111,7 @@ export const toolboxInSidebarSelectorWithNoLeftRailStart: () => LiveSelector<E, 
 
 // for getting normal tab style
 export const profileTabUnselectedSelector: () => LiveSelector<E, true> = () =>
-    querySelector<E>(' [role="tablist"] a[aria-selected="false"]')
+    querySelector<E>('[role="tablist"] a[aria-selected="false"]')
 
 // for getting activated tab style
 export const profileTabSelectedSelector: () => LiveSelector<E, true> = () =>

--- a/packages/mask/src/social-network-adaptor/facebook.com/utils/selector.ts
+++ b/packages/mask/src/social-network-adaptor/facebook.com/utils/selector.ts
@@ -111,19 +111,19 @@ export const toolboxInSidebarSelectorWithNoLeftRailStart: () => LiveSelector<E, 
 
 // for getting normal tab style
 export const profileTabUnselectedSelector: () => LiveSelector<E, true> = () =>
-    querySelector<E>('[data-pagelet="ProfileTabs"] [role="tablist"] a[aria-selected="false"]')
+    querySelector<E>(' [role="tablist"] a[aria-selected="false"]')
 
 // for getting activated tab style
 export const profileTabSelectedSelector: () => LiveSelector<E, true> = () =>
-    querySelector<E>('[data-pagelet="ProfileTabs"] [role="tablist"] a[aria-selected="true"]')
+    querySelector<E>('[role="tablist"] a[aria-selected="true"]')
 
 // for inserting web3 tab
 export const searchProfileTabSelector: () => LiveSelector<E, true> = () =>
-    querySelector<E>('[data-pagelet="ProfileTabs"] [role="tablist"] > div > div > :last-child')
+    querySelector<E>('[role="tablist"] > div > div > :last-child')
 
 // for getting the inserted web3 tab
 export const web3TabSelector: () => LiveSelector<HTMLSpanElement, true> = () =>
-    querySelector<HTMLSpanElement>('[data-pagelet="ProfileTabs"] [role="tablist"] a:nth-child(7)+span')
+    querySelector<HTMLSpanElement>('[role="tablist"] a:nth-child(7)+span')
 
 // for inserting web3 tab content
 export const searchProfileTabPageSelector: () => LiveSelector<E, true> = () =>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes mf-4013

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
