### PR TITLE
fix: dashboard bootstraping

### DIFF
--- a/packages/dashboard/src/pages/Personas/index.tsx
+++ b/packages/dashboard/src/pages/Personas/index.tsx
@@ -1,9 +1,9 @@
-import { Paper, Stack, Tab, Tabs } from '@mui/material'
-import { makeStyles, MaskColorVar, useCustomSnackbar } from '@masknet/theme'
-import { PageFrame } from '../../components/PageFrame/index.js'
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { capitalize } from 'lodash-es'
 import { TabContext, TabPanel } from '@mui/lab'
+import { Paper, Stack, Tab, Tabs } from '@mui/material'
+import { makeStyles, MaskColorVar, useCustomSnackbar } from '@masknet/theme'
 import { PersonaSetup } from './components/PersonaSetup/index.js'
 import { PersonaDrawer } from './components/PersonaDrawer/index.js'
 import { PersonaContext } from './hooks/usePersonaContext.js'
@@ -14,7 +14,7 @@ import { PersonaContent } from './components/PersonaContent/index.js'
 import { PersonaRowCard } from './components/PersonaCard/Row.js'
 import { PersonaStateBar } from './components/PersonaStateBar/index.js'
 import { UserProvider } from '../Settings/hooks/UserContext.js'
-import { useNavigate } from 'react-router-dom'
+import { PageFrame } from '../../components/PageFrame/index.js'
 
 const useStyles = makeStyles()((theme) => ({
     tab: {

--- a/packages/dashboard/src/pages/Personas/index.tsx
+++ b/packages/dashboard/src/pages/Personas/index.tsx
@@ -47,7 +47,7 @@ function Personas() {
     useEffect(() => {
         if (personas?.length !== 0) return
         showSnackbar(t.personas_setup_tip(), { variant: 'warning' })
-        navigate(DashboardRoutes.Setup)
+        // navigate(DashboardRoutes.Setup)
     }, [personas])
 
     const [activeTab, setActiveTab] = useState(

--- a/packages/dashboard/src/pages/Personas/index.tsx
+++ b/packages/dashboard/src/pages/Personas/index.tsx
@@ -47,7 +47,7 @@ function Personas() {
     useEffect(() => {
         if (personas?.length !== 0) return
         showSnackbar(t.personas_setup_tip(), { variant: 'warning' })
-        // navigate(DashboardRoutes.Setup)
+        navigate(DashboardRoutes.Setup)
     }, [personas])
 
     const [activeTab, setActiveTab] = useState(
@@ -57,6 +57,8 @@ function Personas() {
     useEffect(() => {
         setActiveTab(firstProfileNetwork(currentPersona) ?? definedSocialNetworks[0].networkIdentifier)
     }, [currentPersona, definedSocialNetworks])
+
+    if (!personas.length) return null
 
     return (
         <UserProvider>


### PR DESCRIPTION
## Description

If no persona exists then render nothing.

Closes [MF-4317](https://mask.atlassian.net/browse/MF-4317)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

<img width="1323" alt="image" src="https://github.com/DimensionDev/Maskbook/assets/52657989/7496850b-18f3-4f38-ab65-ed3812ab9684">

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.


[MF-4317]: https://mask.atlassian.net/browse/MF-4317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ