### PR TITLE
refactor: disallow use of React.FC and React.ReactElement

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,26 @@ const avoidMistakeRules = {
             types: {
                 // {} is widely used in React.PropsWithChildren<{}>. Unban this until we find better alternatives
                 '{}': false,
+                FC: {
+                    message:
+                        "To declare a component, you don't have to use FC to annotate it. To type something that accepts/is a React Component, use ComponentType<T>.",
+                    fixWith: 'ComponentType',
+                },
+                ReactElement: {
+                    message:
+                        'In most cases, you want ReactNode. Only ignore this rule when you want to use cloneElement.',
+                    fixWith: 'ReactNode',
+                },
+                'React.FC': {
+                    message:
+                        "To declare a component, you don't have to use React.FC to annotate it. To type something that accepts/is a React Component, use React.ComponentType<T>.",
+                    fixWith: 'React.ComponentType',
+                },
+                'React.ReactElement': {
+                    message:
+                        'In most cases, you want React.ReactNode. Only ignore this rule when you want to use cloneElement.',
+                    fixWith: 'React.ReactNode',
+                },
             },
             extendDefaults: true,
         },
@@ -458,6 +478,9 @@ const plugins = {
     'react-hooks': ReactHooksPlugin,
 }
 export default [
+    {
+        settings: { react: { version: '18.3' } },
+    },
     {
         ignores: [
             '**/*.d.ts',

--- a/packages/dashboard/src/components/ConnectActionList/ConnectActionListItem.tsx
+++ b/packages/dashboard/src/components/ConnectActionList/ConnectActionListItem.tsx
@@ -1,9 +1,10 @@
 import { ListItemIcon, ListItemText, styled, ListItemButton } from '@mui/material'
 import { MaskColorVar } from '@masknet/theme'
+import type { ReactNode } from 'react'
 
 export interface ConnectActionListItemProps {
     title: string
-    icon: React.ReactNode
+    icon: ReactNode
     onClick(): void
 }
 

--- a/packages/dashboard/src/components/CreateWalletForm/index.tsx
+++ b/packages/dashboard/src/components/CreateWalletForm/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, type ReactNode } from 'react'
 import {
     FormControl,
     ListItemIcon,
@@ -32,7 +32,7 @@ const useStyles = makeStyles()((theme) => ({
 export interface CreateWalletFormProps {
     options: Array<{
         label: string
-        icon: React.ReactNode
+        icon: ReactNode
         value: number
     }>
 }

--- a/packages/dashboard/src/components/CreateWalletFrame/index.tsx
+++ b/packages/dashboard/src/components/CreateWalletFrame/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, type PropsWithChildren } from 'react'
 import { makeStyles, MaskColorVar } from '@masknet/theme'
 
 const useStyles = makeStyles()({
@@ -20,7 +20,7 @@ const useStyles = makeStyles()({
     },
 })
 
-export interface CreateMaskWalletFrameProps extends React.PropsWithChildren<{}> {}
+export interface CreateMaskWalletFrameProps extends PropsWithChildren<{}> {}
 
 export const CreateMaskWalletFrame = memo<CreateMaskWalletFrameProps>((props) => {
     const { classes } = useStyles()

--- a/packages/dashboard/src/components/DashboardFrame/Navigation.tsx
+++ b/packages/dashboard/src/components/DashboardFrame/Navigation.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, type MouseEvent } from 'react'
 import { useMatch, useNavigate } from 'react-router-dom'
 import {
     List,
@@ -113,7 +113,7 @@ export function Navigation({ onClose }: NavigationProps) {
     const mode = useTheme().palette.mode
     const { pluginID } = useNetworkContext()
 
-    const onExpand = (e: React.MouseEvent<HTMLElement>) => {
+    const onExpand = (e: MouseEvent<HTMLElement>) => {
         e.stopPropagation()
         toggleNavigationExpand()
     }

--- a/packages/dashboard/src/components/DashboardFrame/index.tsx
+++ b/packages/dashboard/src/components/DashboardFrame/index.tsx
@@ -1,7 +1,7 @@
 import { ErrorBoundary } from '@masknet/shared-base-ui'
 import { MaskColorVar } from '@masknet/theme'
 import { Grid, styled, type Theme, useMediaQuery } from '@mui/material'
-import { memo, Suspense, useMemo, useState } from 'react'
+import { memo, Suspense, useMemo, useState, type PropsWithChildren } from 'react'
 import { FollowUs } from '../FollowUs/index.js'
 import { NavigationVersionFooter } from '../NavigationVersionFooter/index.js'
 import { DashboardContext } from './context.js'
@@ -23,7 +23,7 @@ const LeftContainer = styled(Grid)(({ theme }) => ({
     paddingBottom: '22px',
 }))
 
-export interface DashboardFrameProps extends React.PropsWithChildren<{}> {}
+export interface DashboardFrameProps extends PropsWithChildren<{}> {}
 
 export const DashboardFrame = memo((props: DashboardFrameProps) => {
     const isLargeScreen = useMediaQuery<Theme>((theme) => theme.breakpoints.up('lg'))

--- a/packages/dashboard/src/components/FileUpload/index.tsx
+++ b/packages/dashboard/src/components/FileUpload/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from 'react'
+import { type ReactNode, useEffect, useState, type ChangeEvent } from 'react'
 import { MaskColorVar, makeStyles } from '@masknet/theme'
 import { Card, Typography } from '@mui/material'
 import { Icons } from '@masknet/icons'
@@ -43,7 +43,7 @@ export default function FileUpload({ width, height, readAsText, onChange, accept
     const { classes } = useStyles()
     const [file, setFile] = useState<File | null>()
 
-    const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = ({ target }: ChangeEvent<HTMLInputElement>) => {
         if (target.files) {
             setFile(target.files[0])
         }

--- a/packages/dashboard/src/components/FooterLine/About.tsx
+++ b/packages/dashboard/src/components/FooterLine/About.tsx
@@ -11,6 +11,7 @@ import { useDashboardI18N } from '../../locales/index.js'
 import { Version } from './Version.js'
 import links from './links.json'
 import { ABOUT_DIALOG_BACKGROUND } from '../../assets/index.js'
+import type { ReactNode } from 'react'
 
 const useStyles = makeStyles()((theme) => ({
     wrapper: {
@@ -67,7 +68,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-const brands: Record<string, React.ReactNode> = {
+const brands: Record<string, ReactNode> = {
     'https://www.facebook.com/masknetwork': <FacebookIcon />,
     'https://twitter.com/realMaskNetwork': <TwitterIcon />,
     'https://t.me/maskbook_group': <TelegramIcon />,

--- a/packages/dashboard/src/components/FooterLine/index.tsx
+++ b/packages/dashboard/src/components/FooterLine/index.tsx
@@ -64,9 +64,7 @@ function FooterLinkItem(props: FooterLinkAnchorProps) {
     )
 }
 
-interface Props extends HTMLProps<HTMLDivElement> {}
-
-export const FooterLine = memo((props: Props) => {
+export const FooterLine = memo((props: HTMLProps<HTMLDivElement>) => {
     const t = useDashboardI18N()
     const { classes } = useStyles()
     const [isOpen, setOpen] = useState(false)

--- a/packages/dashboard/src/components/HeaderLine/index.tsx
+++ b/packages/dashboard/src/components/HeaderLine/index.tsx
@@ -1,10 +1,8 @@
-import { type FC, type HTMLProps, memo } from 'react'
+import { type HTMLProps, memo } from 'react'
 import { useTheme } from '@mui/material'
 import { Icons } from '@masknet/icons'
 
-interface Props extends HTMLProps<HTMLDivElement> {}
-
-export const HeaderLine: FC<Props> = memo((props) => {
+export const HeaderLine = memo((props: HTMLProps<HTMLElement>) => {
     const mode = useTheme().palette.mode
     const Icon = mode === 'dark' ? Icons.MaskBanner : Icons.Mask
     return (

--- a/packages/dashboard/src/components/Stepper/index.tsx
+++ b/packages/dashboard/src/components/Stepper/index.tsx
@@ -36,7 +36,8 @@ interface StepperProps {
         render: ReactNode
         trigger: boolean
     }
-    // eslint-disable-next-line @typescript-eslint/ban-types In this case we only accept ReactElement because we need to add more props.
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/ban-types
     children: ReactElement[]
 }
 export const Stepper = (props: StepperProps) => {
@@ -45,7 +46,7 @@ export const Stepper = (props: StepperProps) => {
     const [currentStep, setCurrentStep] = useState(defaultStep)
     const [currentTransition, setCurrentTransition] = useState(transition?.render)
 
-    // eslint-disable-next-line @typescript-eslint/ban-types documented above
+    // eslint-disable-next-line @typescript-eslint/ban-types
     const [steps, { set: setSteps }] = useMap<{ [key: string]: ReactElement }>()
     const [stepParams, { set: setParam }] = useMap<{ [key: string]: any }>()
 
@@ -55,7 +56,7 @@ export const Stepper = (props: StepperProps) => {
     }
 
     useEffect(() => {
-        // eslint-disable-next-line @typescript-eslint/ban-types documented above
+        // eslint-disable-next-line @typescript-eslint/ban-types
         Children.forEach(props.children, (child: ReactElement<StepProps>) => {
             if (!isValidElement(child)) return
             const name = child.props.name

--- a/packages/dashboard/src/components/Stepper/index.tsx
+++ b/packages/dashboard/src/components/Stepper/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react'
-import React, { Children, cloneElement, isValidElement, useEffect, useState } from 'react'
+import { Children, cloneElement, isValidElement, useEffect, useState } from 'react'
 import { useMap } from 'react-use'
 import { Box } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
@@ -36,6 +36,7 @@ interface StepperProps {
         render: ReactNode
         trigger: boolean
     }
+    // eslint-disable-next-line @typescript-eslint/ban-types In this case we only accept ReactElement because we need to add more props.
     children: ReactElement[]
 }
 export const Stepper = (props: StepperProps) => {
@@ -44,6 +45,7 @@ export const Stepper = (props: StepperProps) => {
     const [currentStep, setCurrentStep] = useState(defaultStep)
     const [currentTransition, setCurrentTransition] = useState(transition?.render)
 
+    // eslint-disable-next-line @typescript-eslint/ban-types documented above
     const [steps, { set: setSteps }] = useMap<{ [key: string]: ReactElement }>()
     const [stepParams, { set: setParam }] = useMap<{ [key: string]: any }>()
 
@@ -53,6 +55,7 @@ export const Stepper = (props: StepperProps) => {
     }
 
     useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-types documented above
         Children.forEach(props.children, (child: ReactElement<StepProps>) => {
             if (!isValidElement(child)) return
             const name = child.props.name

--- a/packages/dashboard/src/pages/Settings/components/SettingItem.tsx
+++ b/packages/dashboard/src/pages/Settings/components/SettingItem.tsx
@@ -4,7 +4,7 @@ import { MaskColorVar } from '@masknet/theme'
 export interface SettingItemProps extends React.PropsWithChildren<{}> {
     title: React.ReactNode | string
     desc?: React.ReactNode
-    icon?: React.ReactElement
+    icon?: React.ReactNode
     error?: boolean
 }
 

--- a/packages/dashboard/src/pages/TermsGuard.tsx
+++ b/packages/dashboard/src/pages/TermsGuard.tsx
@@ -1,10 +1,10 @@
-import { type FC, type PropsWithChildren, useEffect } from 'react'
+import { type PropsWithChildren, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { DashboardRoutes } from '@masknet/shared-base'
 import urlcat from 'urlcat'
 import { TermsAgreedContext } from '../hooks/useTermsAgreed.js'
 
-const TermsGuardInner: FC<PropsWithChildren<{}>> = ({ children }) => {
+const TermsGuardInner = ({ children }: PropsWithChildren<{}>) => {
     const navigate = useNavigate()
     const [agreed] = TermsAgreedContext.useContainer()
     const { pathname, search } = useLocation()
@@ -24,7 +24,7 @@ const TermsGuardInner: FC<PropsWithChildren<{}>> = ({ children }) => {
     return <>{children}</>
 }
 
-export const TermsGuard: FC<PropsWithChildren<{}>> = ({ children }) => {
+export const TermsGuard = ({ children }: PropsWithChildren<{}>) => {
     return (
         <TermsAgreedContext.Provider>
             <TermsGuardInner>{children}</TermsGuardInner>

--- a/packages/dashboard/src/pages/Wallets/components/WalletStateBar/index.tsx
+++ b/packages/dashboard/src/pages/Wallets/components/WalletStateBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, memo } from 'react'
+import { memo, type PropsWithChildren } from 'react'
 import { Box, Button, Stack, Typography } from '@mui/material'
 import { ProviderType } from '@masknet/web3-shared-evm'
 import { makeStyles, MaskColorVar, LoadingBase } from '@masknet/theme'
@@ -102,7 +102,7 @@ interface WalletStateBarUIProps {
     openMenu: ReturnType<typeof useNetworkSelector>[1]
 }
 
-export const WalletStateBarUI: FC<React.PropsWithChildren<WalletStateBarUIProps>> = ({
+export const WalletStateBarUI = ({
     isPending,
     network,
     provider,
@@ -112,7 +112,7 @@ export const WalletStateBarUI: FC<React.PropsWithChildren<WalletStateBarUIProps>
     openConnectWalletDialog,
     openMenu,
     children,
-}) => {
+}: PropsWithChildren<WalletStateBarUIProps>) => {
     const t = useDashboardI18N()
     const { classes } = useStyles()
 

--- a/packages/dashboard/src/pages/Welcome/Article.tsx
+++ b/packages/dashboard/src/pages/Welcome/Article.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { SOCIAL_MEDIA_ROUND_ICON_MAPPING } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
 import { Typography } from '@mui/material'
-import type { FC, HTMLProps } from 'react'
+import type { HTMLProps } from 'react'
 import { useAsync } from 'react-use'
 import { Services } from '../../API.js'
 
@@ -58,7 +58,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-const Permissions: FC = () => {
+const Permissions = () => {
     const { classes } = useStyles()
     const { value: sites = [] } = useAsync(() => {
         return Services.SiteAdaptor.getSitesWithoutPermission()
@@ -90,13 +90,11 @@ const Permissions: FC = () => {
     )
 }
 
-interface Props extends HTMLProps<HTMLDivElement> {}
-
-export const Article: FC<Props> = ({ className, ...rest }) => {
+export const Article = (props: HTMLProps<HTMLElement>) => {
     const { classes, cx } = useStyles()
 
     return (
-        <article className={cx(classes.article, className)} {...rest}>
+        <article {...props} className={cx(classes.article, props.className)}>
             <Typography variant="h1" className={classes.h1}>
                 Help Us Improve Mask Network
             </Typography>

--- a/packages/mask/src/components/GuideStep/index.tsx
+++ b/packages/mask/src/components/GuideStep/index.tsx
@@ -92,7 +92,8 @@ const NextButton = styled(ActionButton)({
 })
 
 export interface GuideStepProps {
-    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/ban-types
     children: ReactElement
     total: number
     step: number

--- a/packages/mask/src/components/GuideStep/index.tsx
+++ b/packages/mask/src/components/GuideStep/index.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, type ReactElement, useRef, useState, useLayoutEffect } from 'react'
+import { cloneElement, useRef, useState, useLayoutEffect, type ReactElement } from 'react'
 import { useValueRef } from '@masknet/shared-base-ui'
 import { makeStyles, usePortalShadowRoot } from '@masknet/theme'
 import { Box, Modal, styled, Typography } from '@mui/material'
@@ -92,6 +92,7 @@ const NextButton = styled(ActionButton)({
 })
 
 export interface GuideStepProps {
+    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
     children: ReactElement
     total: number
     step: number

--- a/packages/mask/src/components/InjectedComponents/PermissionBoundary.tsx
+++ b/packages/mask/src/components/InjectedComponents/PermissionBoundary.tsx
@@ -6,7 +6,7 @@ import {
     forwardRef,
     memo,
     type PropsWithChildren,
-    type ReactElement,
+    type ReactNode,
     useImperativeHandle,
     useMemo,
     useRef,
@@ -18,8 +18,8 @@ import { PossiblePluginSuggestionUISingle } from './DisabledPluginSuggestion.js'
 interface PermissionBoundaryProps extends PropsWithChildren<{}> {
     permissions: string[]
     fallback?:
-        | ReactElement
-        | ((grantState: AsyncState<boolean>, onGrantPermissions: () => Promise<boolean | undefined>) => ReactElement)
+        | ReactNode
+        | ((grantState: AsyncState<boolean>, onGrantPermissions: () => Promise<boolean | undefined>) => ReactNode)
 }
 
 const PermissionBoundary = memo<PermissionBoundaryProps>(({ permissions, fallback, children }) => {
@@ -28,7 +28,7 @@ const PermissionBoundary = memo<PermissionBoundaryProps>(({ permissions, fallbac
     const [grantState, onGrant] = useGrantPermissions(permissions)
 
     if (!hasPermissions && fallback && permissions.length)
-        return typeof fallback === 'function' ? fallback(grantState, onGrant) : fallback
+        return <>{typeof fallback === 'function' ? fallback(grantState, onGrant) : fallback}</>
 
     return <>{children}</>
 })

--- a/packages/mask/src/components/InjectedComponents/ProfileCard/AvatarDecoration.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileCard/AvatarDecoration.tsx
@@ -1,5 +1,4 @@
 import { Twitter } from '@masknet/web3-providers'
-import type { FC } from 'react'
 import { useAsync } from 'react-use'
 import { RSS3_KEY_SNS, NFTAvatarMiniClip, NFTBadgeTimeline } from '@masknet/plugin-avatar'
 import { MaskMessages } from '../../../utils/messages.js'
@@ -10,7 +9,7 @@ interface Props {
     size: number
     userId?: string
 }
-export const AvatarDecoration: FC<Props> = ({ clipPathId, userId, className, size }) => {
+export const AvatarDecoration = ({ clipPathId, userId, className, size }: Props) => {
     const { value: user } = useAsync(async () => {
         if (!userId) return null
         return Twitter.getUserByScreenName(userId, true)

--- a/packages/mask/src/components/InjectedComponents/ProfileCard/ProfileCardTitle.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileCard/ProfileCardTitle.tsx
@@ -12,7 +12,7 @@ import { makeStyles } from '@masknet/theme'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { NextIDProof } from '@masknet/web3-providers'
 import { useQuery } from '@tanstack/react-query'
-import type { FC, HTMLProps } from 'react'
+import type { HTMLProps } from 'react'
 import { TipButton } from '../../../plugins/Tips/components/index.js'
 import { useLastRecognizedIdentity } from '../../DataSource/useActivatedUI.js'
 import { useCurrentPersona } from '../../DataSource/usePersonaConnectStatus.js'
@@ -98,14 +98,14 @@ export interface ProfileCardTitleProps extends HTMLProps<HTMLDivElement> {
     address?: string
     onAddressChange?(address: string): void
 }
-export const ProfileCardTitle: FC<ProfileCardTitleProps> = ({
+export const ProfileCardTitle = ({
     className,
     socialAccounts,
     address,
     identity,
     onAddressChange,
     ...rest
-}) => {
+}: ProfileCardTitleProps) => {
     const me = useLastRecognizedIdentity()
     const { classes, cx } = useStyles()
 

--- a/packages/mask/src/components/InjectedComponents/ProfileCard/index.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileCard/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo, useState, memo } from 'react'
+import { useEffect, useMemo, useState, memo } from 'react'
 import { Trans } from 'react-i18next'
 import { useUpdateEffect } from 'react-use'
 import { first } from 'lodash-es'
@@ -101,7 +101,7 @@ const useStyles = makeStyles()((theme) => {
     }
 })
 
-export const ProfileCard: FC<Props> = memo(({ identity, currentAddress, ...rest }) => {
+export const ProfileCard = memo(({ identity, currentAddress, ...rest }: Props) => {
     const { classes, cx } = useStyles(undefined, { props: { classes: rest.classes } })
 
     const { t } = useI18N()

--- a/packages/mask/src/components/InjectedComponents/ProfileTab.tsx
+++ b/packages/mask/src/components/InjectedComponents/ProfileTab.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type PropsWithChildren } from 'react'
 import { useMount } from 'react-use'
 import { Typography } from '@mui/material'
 import { MaskMessages, useLocationChange } from '../../utils/index.js'
@@ -7,10 +7,9 @@ import { activatedSocialNetworkUI } from '../../social-network/index.js'
 import { ProfileTabs } from '@masknet/shared-base'
 import { useMatchXS } from '@masknet/shared'
 
-export interface ProfileTabProps extends withClasses<'tab' | 'button' | 'selected'> {
+export interface ProfileTabProps extends withClasses<'tab' | 'button' | 'selected'>, PropsWithChildren<{}> {
     clear(): void
     reset(): void
-    children?: ReactElement
     // Required! This component don't have it own style.
     classes: Record<'root' | 'button' | 'selected', string>
     title: string

--- a/packages/mask/src/components/shared/AvatarBadge/AvatarBadge.tsx
+++ b/packages/mask/src/components/shared/AvatarBadge/AvatarBadge.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { type IconButtonProps, Box } from '@mui/material'
 import { NetworkPluginID, type SocialAccount, type SocialIdentity } from '@masknet/shared-base'
 import { useCollectionByTwitterHandler } from '../../../plugins/Trader/trending/useTrending.js'
@@ -11,7 +10,7 @@ interface Props extends IconButtonProps {
     identity?: SocialIdentity
     socialAccounts?: Array<SocialAccount<Web3Helper.ChainIdAll>>
 }
-export const AvatarBadge: FC<Props> = ({ userId, identity, socialAccounts }) => {
+export const AvatarBadge = ({ userId, identity, socialAccounts }: Props) => {
     const { value: collectionList } = useCollectionByTwitterHandler(userId)
     if (collectionList?.[0]) {
         return (

--- a/packages/mask/src/components/shared/AvatarBadge/CollectionProjectAvatarBadge.tsx
+++ b/packages/mask/src/components/shared/AvatarBadge/CollectionProjectAvatarBadge.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { Icons } from '@masknet/icons'
 import { makeStyles } from '@masknet/theme'
 import type { SocialIdentity } from '@masknet/shared-base'
@@ -18,7 +18,7 @@ interface Props extends IconButtonProps {
     userId: string
     identity?: SocialIdentity
 }
-export const CollectionProjectAvatarBadge: FC<Props> = ({ address, userId, className, identity, ...rest }) => {
+export const CollectionProjectAvatarBadge = ({ address, userId, className, identity, ...rest }: Props) => {
     const buttonRef = useRef<HTMLButtonElement>(null)
     const { classes, cx } = useStyles()
 

--- a/packages/mask/src/components/shared/AvatarBadge/ProfileAvatarBadge.tsx
+++ b/packages/mask/src/components/shared/AvatarBadge/ProfileAvatarBadge.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { CrossIsolationMessages } from '@masknet/shared-base'
 import { makeStyles } from '@masknet/theme'
 import { IconButton, type IconButtonProps } from '@mui/material'
-import { type FC, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 const useStyles = makeStyles()((theme) => ({
     badge: {
@@ -14,7 +14,7 @@ const useStyles = makeStyles()((theme) => ({
 interface Props extends IconButtonProps {
     userId: string
 }
-export const ProfileAvatarBadge: FC<Props> = ({ userId, className, ...rest }) => {
+export const ProfileAvatarBadge = ({ userId, className, ...rest }: Props) => {
     const buttonRef = useRef<HTMLButtonElement>(null)
     const { classes, cx } = useStyles()
 

--- a/packages/mask/src/extension/debug-page/DatabaseOps.tsx
+++ b/packages/mask/src/extension/debug-page/DatabaseOps.tsx
@@ -45,7 +45,7 @@ async function onClear() {
         }),
     )
 }
-export const DatabaseOps: React.FC = () => {
+export const DatabaseOps = () => {
     const { t } = useI18N()
     return (
         <section>

--- a/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectibleItem.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/CollectibleItem.tsx
@@ -129,11 +129,10 @@ export const CollectibleItem = memo(
     }),
 )
 
-interface SkeletonProps extends HTMLProps<HTMLDivElement> {}
-export function CollectibleItemSkeleton({ className, ...rest }: SkeletonProps) {
+export function CollectibleItemSkeleton(props: HTMLProps<HTMLDivElement>) {
     const { classes, cx } = useStyles()
     return (
-        <div className={cx(classes.card, className)} {...rest}>
+        <div {...props} className={cx(classes.card, props.className)}>
             <div className={classes.collectibleCard}>
                 <Skeleton animation="wave" variant="rectangular" height="100%" />
             </div>

--- a/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/LoadingSkeleton.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/CollectibleList/LoadingSkeleton.tsx
@@ -1,10 +1,10 @@
 import { range } from 'lodash-es'
-import type { FC, HTMLProps } from 'react'
+import type { HTMLProps } from 'react'
 import { CollectibleItemSkeleton } from './CollectibleItem.js'
 
-interface Props extends HTMLProps<HTMLDivElement> {}
+interface Props extends Pick<HTMLProps<HTMLDivElement>, 'className'> {}
 
-export const LoadingSkeleton: FC<Props> = ({ className }) => {
+export const LoadingSkeleton = ({ className }: Props) => {
     return (
         <div className={className}>
             {range(3).map((i) => (

--- a/packages/mask/src/extension/options-page/DashboardComponents/InputBox.tsx
+++ b/packages/mask/src/extension/options-page/DashboardComponents/InputBox.tsx
@@ -1,5 +1,6 @@
 import { makeStyles } from '@masknet/theme'
 import { IconButton, InputBase, type InputBaseProps } from '@mui/material'
+import type { PropsWithChildren } from 'react'
 
 const useStyles = makeStyles()((theme) => ({
     input: {
@@ -10,10 +11,9 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export interface InputBoxProps extends withClasses<'root'> {
+export interface InputBoxProps extends withClasses<'root'>, PropsWithChildren<{}> {
     label: string
     onChange?: (keyword: string) => void
-    children?: React.ReactElement
     value?: string
     inputBaseProps?: Partial<InputBaseProps>
 }

--- a/packages/mask/src/extension/options-page/DashboardDialogs/Base.tsx
+++ b/packages/mask/src/extension/options-page/DashboardDialogs/Base.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, useCallback, useReducer } from 'react'
+import { cloneElement, useCallback, useReducer, type ReactElement } from 'react'
 import { cloneDeep, merge } from 'lodash-es'
 import {
     type DialogProps,
@@ -244,7 +244,8 @@ const dialogTheme = extendsTheme((theme) => ({
 }))
 
 interface DashboardDialogWrapperProps extends withClasses<'wrapper'> {
-    icon?: React.ReactElement
+    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used
+    icon?: ReactElement
     iconColor?: string
     primary: string
     secondary?: React.ReactNode

--- a/packages/mask/src/extension/options-page/DashboardDialogs/Base.tsx
+++ b/packages/mask/src/extension/options-page/DashboardDialogs/Base.tsx
@@ -244,7 +244,8 @@ const dialogTheme = extendsTheme((theme) => ({
 }))
 
 interface DashboardDialogWrapperProps extends withClasses<'wrapper'> {
-    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used
+    // cloneElement is used
+    // eslint-disable-next-line @typescript-eslint/ban-types
     icon?: ReactElement
     iconColor?: string
     primary: string

--- a/packages/mask/src/extension/popups/pages/Wallet/Transfer/Prior1559Transfer.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/Transfer/Prior1559Transfer.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, type SyntheticEvent, useCallback, useMemo, useRef, useState } from 'react'
+import { memo, type SyntheticEvent, useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
 import { ChevronDown } from 'react-feather'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useAsync, useAsyncFn, useUpdateEffect } from 'react-use'
@@ -395,7 +395,7 @@ export interface Prior1559TransferUIProps {
     handleConfirm: () => void
     confirmLoading: boolean
     maxAmount: string
-    popoverContent?: ReactElement
+    popoverContent?: ReactNode
     disableConfirm?: boolean
 }
 

--- a/packages/mask/src/extension/popups/pages/Wallet/Transfer/Transfer1559.tsx
+++ b/packages/mask/src/extension/popups/pages/Wallet/Transfer/Transfer1559.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, type SyntheticEvent, useCallback, useMemo, useRef, useState } from 'react'
+import { memo, type SyntheticEvent, useCallback, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useAsync, useAsyncFn, useUpdateEffect } from 'react-use'
 import { Trans } from 'react-i18next'
 import { Controller, FormProvider, useForm, useFormContext } from 'react-hook-form'
@@ -606,7 +606,7 @@ export interface Transfer1559UIProps {
     handleCancel: () => void
     handleConfirm: () => void
     confirmLoading: boolean
-    popoverContent?: ReactElement
+    popoverContent?: ReactNode
     disableConfirm?: boolean
     isAvailableBalance: boolean
 }

--- a/packages/mask/src/plugins/ITO/assets/exchange.tsx
+++ b/packages/mask/src/plugins/ITO/assets/exchange.tsx
@@ -1,6 +1,6 @@
 import { SvgIcon, type SvgIconProps } from '@mui/material'
 
-export const SwapIcon: React.FC = (props: SvgIconProps) => (
+export const SwapIcon = (props: SvgIconProps) => (
     <SvgIcon {...props}>
         <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/Drag.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/Drag.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { PureComponent, type PropsWithChildren, type MouseEvent as ReactMouseEvent } from 'react'
 
 interface StateProps {
     pos: {
@@ -25,7 +25,7 @@ interface DraggableProps {
 // TODO: rewrite to function components
 // TODO: use library like react-dnd instead.
 // eslint-disable-next-line @masknet/jsx-no-class-component
-class Draggable extends React.PureComponent<React.PropsWithChildren<DraggableProps>> {
+class Draggable extends PureComponent<PropsWithChildren<DraggableProps>> {
     ref = React.createRef<HTMLDivElement>()
     mouseMoveFuc = this.onMouseMove.bind(this)
     mouseUpFuc = this.onMouseUp.bind(this)
@@ -43,7 +43,7 @@ class Draggable extends React.PureComponent<React.PropsWithChildren<DraggablePro
         rel: null,
     }
 
-    onMouseDown(e: React.MouseEvent) {
+    onMouseDown(e: MouseEvent | ReactMouseEvent) {
         if (e.button !== 0) return
         if (!this.ref?.current) return
         const divDom = this.ref.current

--- a/packages/mask/src/plugins/Pets/SNSAdaptor/ModelView.tsx
+++ b/packages/mask/src/plugins/Pets/SNSAdaptor/ModelView.tsx
@@ -1,10 +1,10 @@
-import type { FC, HTMLProps } from 'react'
+import type { HTMLProps } from 'react'
 
 interface ModelViewProps extends HTMLProps<HTMLDivElement> {
     source: string
 }
 
-const ModelView: FC<ModelViewProps> = ({ source, ...rest }) => {
+const ModelView = ({ source, ...rest }: ModelViewProps) => {
     if (!source) return null
 
     return (

--- a/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryItem.tsx
+++ b/packages/mask/src/plugins/RedPacket/SNSAdaptor/NftRedPacketHistoryItem.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, type MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, type MouseEventHandler, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIntersectionObserver } from '@react-hookz/web'
 import { fill } from 'lodash-es'
 import { makeStyles, ActionButton } from '@masknet/theme'
@@ -165,8 +165,8 @@ export interface NftRedPacketHistoryItemProps {
     onShowPopover: (anchorEl: HTMLElement, text: string) => void
     onHidePopover: () => void
 }
-export const NftRedPacketHistoryItem: FC<NftRedPacketHistoryItemProps> = memo(
-    ({ history, onSend, onShowPopover, onHidePopover, collections }) => {
+export const NftRedPacketHistoryItem = memo(
+    ({ history, onSend, onShowPopover, onHidePopover, collections }: NftRedPacketHistoryItemProps) => {
         const { account, chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
         const [isViewed, setIsViewed] = useState(false)
         const ref = useRef<HTMLLIElement | null>(null)

--- a/packages/mask/src/plugins/Snapshot/SNSAdaptor/SpaceMenu.tsx
+++ b/packages/mask/src/plugins/Snapshot/SNSAdaptor/SpaceMenu.tsx
@@ -1,4 +1,4 @@
-import type { FC, RefObject } from 'react'
+import type { RefObject } from 'react'
 import { isEqual } from 'lodash-es'
 import { useI18N } from '../../../utils/index.js'
 import { Icons } from '@masknet/icons'
@@ -82,7 +82,7 @@ export interface SpaceMenuProps {
     disableScrollLock?: boolean
 }
 
-export const SpaceMenu: FC<SpaceMenuProps> = ({
+export const SpaceMenu = ({
     options,
     currentOption,
     onSelect,
@@ -91,7 +91,7 @@ export const SpaceMenu: FC<SpaceMenuProps> = ({
     setSpaceMenuOpen,
     disablePortal,
     disableScrollLock,
-}) => {
+}: SpaceMenuProps) => {
     const { classes } = useStyles()
     const { t } = useI18N()
     return (

--- a/packages/mask/src/plugins/Tips/SNSAdaptor/components/TipsRealmContent/index.tsx
+++ b/packages/mask/src/plugins/Tips/SNSAdaptor/components/TipsRealmContent/index.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { Plugin } from '@masknet/plugin-infra'
 import { useLastRecognizedIdentity } from '@masknet/plugin-infra/content-script'
 import { PluginGuide } from '@masknet/shared'
@@ -62,14 +61,14 @@ const useStyles = makeStyles<{ buttonSize: number }, 'postTipsButton'>()((theme,
 }))
 
 const { TipsSlot } = Plugin.SNSAdaptor
-export const TipsRealmContent: FC<Plugin.SNSAdaptor.TipsRealmOptions> = ({
+export const TipsRealmContent = ({
     identity,
     slot,
     accounts,
     iconSize = 24,
     buttonSize = 34,
     onStatusUpdate,
-}) => {
+}: Plugin.SNSAdaptor.TipsRealmOptions) => {
     const t = useI18N()
     const { classes, cx } = useStyles({ buttonSize })
     const userGuide = useTipsUserGuide(activatedSocialNetworkUI.networkIdentifier as EnhanceableSite)

--- a/packages/mask/src/plugins/Tips/components/NFTSection/NFTList.tsx
+++ b/packages/mask/src/plugins/Tips/components/NFTSection/NFTList.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback } from 'react'
+import { useCallback } from 'react'
 import { LoadingBase, makeStyles } from '@masknet/theme'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { ElementAnchor, AssetPreviewer, RetryHint } from '@masknet/shared'
@@ -79,7 +79,7 @@ interface NFTItemProps {
     token: Web3Helper.NonFungibleTokenAll
 }
 
-export const NFTItem: FC<NFTItemProps> = ({ token }) => {
+export const NFTItem = ({ token }: NFTItemProps) => {
     const { classes } = useStyles()
     return (
         <AssetPreviewer
@@ -91,7 +91,7 @@ export const NFTItem: FC<NFTItemProps> = ({ token }) => {
     )
 }
 
-export const NFTList: FC<Props> = ({
+export const NFTList = ({
     selectedPairs,
     tokens,
     onChange,
@@ -100,7 +100,7 @@ export const NFTList: FC<Props> = ({
     nextPage,
     loadFinish,
     loadError,
-}) => {
+}: Props) => {
     const { classes, cx } = useStyles()
     const { pluginID } = useNetworkContext()
 

--- a/packages/mask/src/plugins/Tips/components/NFTSection/index.tsx
+++ b/packages/mask/src/plugins/Tips/components/NFTSection/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, type HTMLProps, useCallback, useMemo } from 'react'
+import { type HTMLProps, useCallback, useMemo } from 'react'
 import { Web3 } from '@masknet/web3-providers'
 import { compact, uniqWith } from 'lodash-es'
 import { Icons } from '@masknet/icons'
@@ -81,7 +81,7 @@ interface Props extends HTMLProps<HTMLDivElement> {
     onEmpty?(empty: boolean): void
 }
 
-export const NFTSection: FC<Props> = ({ className, onEmpty, ...rest }) => {
+export const NFTSection = ({ className, onEmpty, ...rest }: Props) => {
     const {
         nonFungibleTokenAddress: tokenAddress,
         nonFungibleTokenId: tokenId,

--- a/packages/mask/src/plugins/Tips/components/NetworkSection/index.tsx
+++ b/packages/mask/src/plugins/Tips/components/NetworkSection/index.tsx
@@ -1,4 +1,3 @@
-import type { FC, HTMLProps } from 'react'
 import { PluginID, EMPTY_LIST } from '@masknet/shared-base'
 import { useActivatedPlugin } from '@masknet/plugin-infra/dom'
 import { makeStyles } from '@masknet/theme'
@@ -15,9 +14,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-interface Props extends HTMLProps<HTMLDivElement> {}
-
-export const NetworkSection: FC<Props> = () => {
+export const NetworkSection = () => {
     const { classes } = useStyles()
     const { setTargetChainId } = TargetRuntimeContext.useContainer()
 

--- a/packages/mask/src/plugins/Tips/components/RecipientSection/RecipientSelect.tsx
+++ b/packages/mask/src/plugins/Tips/components/RecipientSection/RecipientSelect.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useRef } from 'react'
+import { memo, useRef } from 'react'
 import { Icons } from '@masknet/icons'
 import { makeStyles } from '@masknet/theme'
 import { AccountIcon, ReversedAddress } from '@masknet/shared'
@@ -113,7 +113,7 @@ const PluginIcon = ({ pluginID }: { pluginID: NetworkPluginID }) => {
     return mapping[pluginID]
 }
 
-const ExternalLink: FC<{ account: SocialAccount<Web3Helper.ChainIdAll> }> = ({ account }) => {
+const ExternalLink = ({ account }: { account: SocialAccount<Web3Helper.ChainIdAll> }) => {
     const t = useI18N()
     const { classes, cx } = useStyles()
     const Others = useWeb3Others(account.pluginID)
@@ -135,7 +135,7 @@ const ExternalLink: FC<{ account: SocialAccount<Web3Helper.ChainIdAll> }> = ({ a
 interface Props {
     className?: string
 }
-export const RecipientSelect: FC<Props> = memo(({ className }) => {
+export const RecipientSelect = memo(({ className }: Props) => {
     const { classes, cx } = useStyles()
     const selectRef = useRef(null)
     const { recipient, recipients, setRecipient } = useTip()

--- a/packages/mask/src/plugins/Tips/components/RecipientSection/index.tsx
+++ b/packages/mask/src/plugins/Tips/components/RecipientSection/index.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@masknet/theme'
 import { FormControl, type FormControlProps, Typography } from '@mui/material'
-import type { FC } from 'react'
 import { useTip } from '../../contexts/index.js'
 import { useI18N } from '../../locales/index.js'
 import { RecipientSelect } from './RecipientSelect.js'
@@ -36,7 +35,7 @@ const useStyles = makeStyles()((theme) => {
 
 interface Props extends FormControlProps {}
 
-export const RecipientSection: FC<Props> = ({ className, ...rest }) => {
+export const RecipientSection = ({ className, ...rest }: Props) => {
     const { classes, cx } = useStyles()
     const t = useI18N()
     const {

--- a/packages/mask/src/plugins/Tips/components/TipsButton/index.tsx
+++ b/packages/mask/src/plugins/Tips/components/TipsButton/index.tsx
@@ -9,7 +9,7 @@ import {
 import { makeStyles } from '@masknet/theme'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { useNetworkContext } from '@masknet/web3-hooks-base'
-import { useCallback, useEffect, useMemo, type FC, type HTMLProps, type MouseEventHandler } from 'react'
+import { useCallback, useEffect, useMemo, type HTMLProps, type MouseEventHandler } from 'react'
 import {
     useCurrentVisitingIdentity,
     useSocialIdentityByUserId,
@@ -43,7 +43,7 @@ const useStyles = makeStyles<{ iconSize: number }>()((theme, props) => ({
     },
 }))
 
-export const TipButton: FC<Props> = (props) => {
+export const TipButton = (props: Props) => {
     const {
         className,
         accounts: receivingAccounts = EMPTY_LIST,

--- a/packages/mask/src/plugins/Tips/components/TokenSection/index.tsx
+++ b/packages/mask/src/plugins/Tips/components/TokenSection/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, type HTMLProps, useCallback } from 'react'
+import { type HTMLProps, useCallback } from 'react'
 import { useChainContext, useNetworkContext } from '@masknet/web3-hooks-base'
 import { useSelectFungibleToken, FungibleTokenInput, TokenValue } from '@masknet/shared'
 import { NetworkPluginID } from '@masknet/shared-base'
@@ -16,9 +16,7 @@ const useStyles = makeStyles()({
     },
 })
 
-interface Props extends HTMLProps<HTMLDivElement> {}
-
-export const TokenSection: FC<Props> = ({ className, ...rest }) => {
+export const TokenSection = (props: HTMLProps<HTMLDivElement>) => {
     const { classes, cx } = useStyles()
     const { token, setToken, amount, setAmount, isAvailableBalance, balance } = useTip()
     const { pluginID } = useNetworkContext()
@@ -38,7 +36,7 @@ export const TokenSection: FC<Props> = ({ className, ...rest }) => {
     }, [selectFungibleToken, token?.address, pluginID, chainId])
 
     return (
-        <div className={cx(className, classes.container)} {...rest}>
+        <div {...props} className={cx(props.className, classes.container)}>
             <FungibleTokenInput
                 label=""
                 token={token}

--- a/packages/mask/src/plugins/Tips/contexts/TargetRuntimeContext.tsx
+++ b/packages/mask/src/plugins/Tips/contexts/TargetRuntimeContext.tsx
@@ -6,7 +6,7 @@ import {
     useNetworkContext,
     Web3ContextProvider,
 } from '@masknet/web3-hooks-base'
-import { type FC, type PropsWithChildren, useCallback, useState, useMemo } from 'react'
+import { type PropsWithChildren, useCallback, useState, useMemo } from 'react'
 import { createContainer } from 'unstated-next'
 
 function useTargetRuntime(initPluginID?: NetworkPluginID) {
@@ -39,7 +39,7 @@ export const TargetRuntimeContext = createContainer(useTargetRuntime)
 /**
  * A Tips scoped chain runtime, which controls Web3ContextProvider value
  */
-export const ChainRuntime: FC<PropsWithChildren<{}>> = ({ children }) => {
+export const ChainRuntime = ({ children }: PropsWithChildren<{}>) => {
     const { targetPluginID, targetChainId } = TargetRuntimeContext.useContainer()
     const account = useAccount(targetPluginID)
 

--- a/packages/mask/src/plugins/Tips/contexts/Tip/TipTaskProvider.tsx
+++ b/packages/mask/src/plugins/Tips/contexts/Tip/TipTaskProvider.tsx
@@ -1,6 +1,5 @@
 import {
     type Dispatch,
-    type FC,
     memo,
     type SetStateAction,
     useCallback,
@@ -8,6 +7,7 @@ import {
     useEffect,
     useMemo,
     useState,
+    type PropsWithChildren,
 } from 'react'
 import { useSubscription } from 'use-subscription'
 import { useNonFungibleTokenContract, useChainContext, useNativeToken } from '@masknet/web3-hooks-base'
@@ -26,7 +26,7 @@ import { useRecipientValidate } from './useRecipientValidate.js'
 import { useTipValidate } from './useTipValidate.js'
 import { TargetRuntimeContext } from '../TargetRuntimeContext.js'
 
-interface Props {
+interface Props extends PropsWithChildren<{}> {
     task: TipTask
 }
 
@@ -52,7 +52,7 @@ function useDirtyDetection(deps: any[]): [boolean, Dispatch<SetStateAction<boole
     return [isDirty, setIsDirty]
 }
 
-export const TipTaskProvider: FC<React.PropsWithChildren<Props>> = memo(({ children, task }) => {
+export const TipTaskProvider = memo(({ children, task }: Props) => {
     const { targetPluginID, setTargetPluginID } = TargetRuntimeContext.useContainer()
     const { chainId: targetChainId } = useChainContext()
 

--- a/packages/mask/src/plugins/Tips/contexts/TipTaskManager.tsx
+++ b/packages/mask/src/plugins/Tips/contexts/TipTaskManager.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type PropsWithChildren } from 'react'
 import { isEqual } from 'lodash-es'
 import { EMPTY_LIST } from '@masknet/shared-base'
 import { isSameAddress } from '@masknet/web3-shared-base'
@@ -15,7 +15,7 @@ interface Task extends TipTask {
     id: number
 }
 
-export const TipTaskManager: FC<React.PropsWithChildren<{}>> = ({ children }) => {
+export const TipTaskManager = ({ children }: PropsWithChildren<{}>) => {
     const [tasks, setTasks] = useState<Task[]>(EMPTY_LIST)
 
     const removeTask = useCallback((task: Task) => {

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/FailedTrendingView.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/FailedTrendingView.tsx
@@ -1,5 +1,4 @@
 import { MaskLightTheme, makeStyles } from '@masknet/theme'
-import { type FC } from 'react'
 import { ThemeProvider } from '@mui/material'
 import { TrendingCard, type TrendingCardProps } from './TrendingCard.js'
 import { EmptyStatus } from '@masknet/shared'
@@ -20,7 +19,7 @@ const useStyles = makeStyles()((theme) => ({
 
 interface Props extends TrendingCardProps, TrendingViewDescriptorProps {}
 
-export const FailedTrendingView: FC<Props> = ({ result, resultList, setResult, ...rest }) => {
+export const FailedTrendingView = ({ result, resultList, setResult, ...rest }: Props) => {
     const { t } = useI18N()
     const { classes } = useStyles()
     return (

--- a/packages/mask/src/plugins/Trader/SNSAdaptor/trending/components/CoinIcon.tsx
+++ b/packages/mask/src/plugins/Trader/SNSAdaptor/trending/components/CoinIcon.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { TokenIcon, type TokenIconProps } from '@masknet/shared'
 import type { TokenType } from '@masknet/web3-shared-base'
 import { NetworkPluginID } from '@masknet/shared-base'
@@ -7,6 +6,6 @@ export interface CoinIconProps extends TokenIconProps {
     type: TokenType
 }
 
-export const CoinIcon: FC<CoinIconProps> = ({ type, ...rest }) => {
+export const CoinIcon = ({ type, ...rest }: CoinIconProps) => {
     return <TokenIcon tokenType={type} pluginID={NetworkPluginID.PLUGIN_EVM} {...rest} />
 }

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/GasSetting.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/GasSetting.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type { NetworkPluginID } from '@masknet/shared-base'
 import { chainResolver } from '@masknet/web3-shared-evm'
 import { useChainContext } from '@masknet/web3-hooks-base'
@@ -6,7 +5,7 @@ import { GasSetting1559 } from './GasSetting1559.js'
 import { Prior1559GasSetting } from './Prior1559GasSetting.js'
 import type { GasSettingProps } from './types.js'
 
-export const GasSetting: FC<GasSettingProps> = (props) => {
+export const GasSetting = (props: GasSettingProps) => {
     const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
     const is1559Supported = chainResolver.isSupport(chainId, 'EIP1559')
     return is1559Supported ? <GasSetting1559 {...props} /> : <Prior1559GasSetting {...props} />

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/GasSetting1559.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/GasSetting1559.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useUpdateEffect } from 'react-use'
 import { z as zod } from 'zod'
 import { BigNumber } from 'bignumber.js'
@@ -88,8 +88,8 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export const GasSetting1559: FC<GasSettingProps> = memo(
-    ({ gasLimit, minGasLimit = 0, gasOptionType = GasOptionType.NORMAL, onConfirm = noop }) => {
+export const GasSetting1559 = memo(
+    ({ gasLimit, minGasLimit = 0, gasOptionType = GasOptionType.NORMAL, onConfirm = noop }: GasSettingProps) => {
         const { t } = useI18N()
         const { classes } = useStyles()
         const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
@@ -199,7 +199,7 @@ export const GasSetting1559: FC<GasSettingProps> = memo(
         const handleConfirm = useCallback(
             (data: zod.infer<typeof schema>) => {
                 onConfirm?.({
-                    gasLimit: data.gasLimit,
+                    gasLimit: data.gasLimit as any,
                     maxFee: formatGweiToWei(data.maxFeePerGas).toFixed(0),
                     priorityFee: formatGweiToWei(data.maxPriorityFeePerGas).toFixed(0),
                     gasOption: selectedGasOption,

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/Prior1559GasSetting.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/Prior1559GasSetting.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useUpdateEffect } from 'react-use'
 import { Trans } from 'react-i18next'
 import { Controller, useForm } from 'react-hook-form'
@@ -84,8 +84,8 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export const Prior1559GasSetting: FC<GasSettingProps> = memo(
-    ({ gasLimit, minGasLimit = 0, gasOptionType = GasOptionType.NORMAL, onConfirm = noop }) => {
+export const Prior1559GasSetting = memo(
+    ({ gasLimit, minGasLimit = 0, gasOptionType = GasOptionType.NORMAL, onConfirm = noop }: GasSettingProps) => {
         const { classes } = useStyles()
         const { t } = useI18N()
         const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
@@ -167,7 +167,7 @@ export const Prior1559GasSetting: FC<GasSettingProps> = memo(
         const handleConfirm = useCallback(
             (data: zod.infer<typeof schema>) => {
                 onConfirm({
-                    gasLimit: data.gasLimit,
+                    gasLimit: data.gasLimit as any,
                     gasPrice: toWei(data.gasPrice, 'gwei'),
                     gasOption: selectedGasOption,
                 })

--- a/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/index.tsx
+++ b/packages/mask/src/plugins/Wallet/SNSAdaptor/GasSettingDialog/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react'
+import { useState } from 'react'
 import { DialogContent } from '@mui/material'
 import { WalletMessages } from '@masknet/plugin-wallet'
 import { makeStyles } from '@masknet/theme'
@@ -14,7 +14,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export const GasSettingDialog: FC = () => {
+export const GasSettingDialog = () => {
     const { t } = useI18N()
     const { classes } = useStyles()
     const [gasOptionType, setGasOptionType] = useState<GasOptionType>(GasOptionType.NORMAL)

--- a/packages/plugin-infra/src/sns-adaptor/Widget.ts
+++ b/packages/plugin-infra/src/sns-adaptor/Widget.ts
@@ -7,7 +7,7 @@ import type { Plugin } from '../types.js'
 export interface WidgetProps<Name extends keyof Plugin.SNSAdaptor.WidgetRegistry> {
     name: Name
     pluginID?: PluginID
-    fallback?: React.ReactElement | null
+    fallback?: React.ReactNode | null
 }
 
 export function Widget<Name extends keyof Plugin.SNSAdaptor.WidgetRegistry>(
@@ -20,6 +20,6 @@ export function Widget<Name extends keyof Plugin.SNSAdaptor.WidgetRegistry>(
         return null
     }, [plugins])
 
-    if (!WidgetComponent) return fallback || createElement(Fragment, {})
+    if (!WidgetComponent) return createElement(Fragment, { children: fallback })
     return createElement(WidgetComponent, rest)
 }

--- a/packages/plugins/Avatar/src/Application/NFTAvatarDialog.tsx
+++ b/packages/plugins/Avatar/src/Application/NFTAvatarDialog.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Box, DialogContent } from '@mui/material'
 import { LoadingBase, makeStyles } from '@masknet/theme'
 import { MemoryRouter } from 'react-router-dom'
@@ -29,7 +29,7 @@ interface NFTAvatarDialogProps extends InjectedDialogProps {
     startPicking?: boolean
 }
 
-export const NFTAvatarDialog: FC<NFTAvatarDialogProps> = ({ startPicking, ...rest }) => {
+export const NFTAvatarDialog = ({ startPicking, ...rest }: NFTAvatarDialogProps) => {
     const { classes } = useStyles()
 
     const initialEntries = useMemo(() => {

--- a/packages/plugins/Avatar/src/Application/NFTListDialog.tsx
+++ b/packages/plugins/Avatar/src/Application/NFTListDialog.tsx
@@ -16,7 +16,7 @@ import { isGreaterThan, isSameAddress } from '@masknet/web3-shared-base'
 import { ChainId } from '@masknet/web3-shared-evm'
 import { Box, Button, DialogActions, DialogContent, Stack, Typography } from '@mui/material'
 import { compact, uniqBy } from 'lodash-es'
-import { type FC, useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useUpdateEffect } from 'react-use'
 import { supportPluginIds } from '../constants.js'
@@ -69,7 +69,7 @@ const useStyles = makeStyles()((theme) => ({
 const gridProps = {
     columns: 'repeat(auto-fill, minmax(20%, 1fr))',
 }
-export const NFTListDialog: FC = () => {
+export const NFTListDialog = () => {
     const t = useI18N()
     const sharedI18N = useSharedI18N()
     const { classes } = useStyles()

--- a/packages/plugins/Avatar/src/Application/RouterDialog.tsx
+++ b/packages/plugins/Avatar/src/Application/RouterDialog.tsx
@@ -1,10 +1,10 @@
 import { InjectedDialog, type InjectedDialogProps } from '@masknet/shared'
-import { type FC, useLayoutEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import { matchPath, useLocation, useNavigate } from 'react-router-dom'
 import { useI18N } from '../locales/index.js'
 import { RoutePaths } from './Routes.js'
 
-export const RouterDialog: FC<InjectedDialogProps> = (props: InjectedDialogProps) => {
+export const RouterDialog = (props: InjectedDialogProps) => {
     const t = useI18N()
     const { pathname } = useLocation()
     const navigate = useNavigate()

--- a/packages/plugins/Avatar/src/Application/Routes.tsx
+++ b/packages/plugins/Avatar/src/Application/Routes.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { NFTListDialog } from './NFTListDialog.js'
 import { PersonaPage } from './PersonaPage.js'
@@ -11,7 +10,7 @@ export enum RoutePaths {
     Exit = '/exit',
 }
 
-export const AvatarRoutes: FC = () => (
+export const AvatarRoutes = () => (
     <Routes>
         <Route path={RoutePaths.Personas} element={<PersonaPage />} />
         <Route path={RoutePaths.NFTPicker} element={<NFTListDialog />} />

--- a/packages/plugins/Avatar/src/Application/UploadAvatarDialog.tsx
+++ b/packages/plugins/Avatar/src/Application/UploadAvatarDialog.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
 import AvatarEditor from 'react-avatar-editor'
 import { useSubscription } from 'use-subscription'
 import { Button, DialogActions, DialogContent, Slider } from '@mui/material'
@@ -56,7 +56,7 @@ async function uploadAvatar(blob: Blob, userId: string): Promise<AvatarInfo | un
     }
 }
 
-export const UploadAvatarDialog: FC = () => {
+export const UploadAvatarDialog = () => {
     const t = useI18N()
     const { classes } = useStyles()
     const { proof, proofs, selectedTokenInfo } = useAvatarManagement()

--- a/packages/plugins/Avatar/src/contexts/AvatarManagement/index.tsx
+++ b/packages/plugins/Avatar/src/contexts/AvatarManagement/index.tsx
@@ -2,7 +2,6 @@ import { first, noop } from 'lodash-es'
 import {
     createContext,
     type Dispatch,
-    type FC,
     memo,
     type PropsWithChildren,
     type SetStateAction,
@@ -47,7 +46,7 @@ export const AvatarManagementContext = createContext<AvatarManagementContextOpti
 
 interface Props extends PropsWithChildren<{ socialIdentity?: SocialIdentity }> {}
 
-export const AvatarManagementProvider: FC<Props> = memo(({ children, socialIdentity }) => {
+export const AvatarManagementProvider = memo(({ children, socialIdentity }: Props) => {
     const nextIDWallets = useMemo(
         () =>
             socialIdentity?.binding?.proofs.filter(

--- a/packages/plugins/FileService/src/SNSAdaptor/MainDialog.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/MainDialog.tsx
@@ -39,12 +39,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-const FileServiceDialog: React.FC<FileServiceDialogProps> = ({
-    onClose,
-    selectMode,
-    selectedFileIds,
-    compositionType,
-}) => {
+const FileServiceDialog = ({ onClose, selectMode, selectedFileIds, compositionType }: FileServiceDialogProps) => {
     const { classes } = useStyles()
     const [confirmed] = useTermsConfirmed()
 

--- a/packages/plugins/FileService/src/SNSAdaptor/Routes.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/Routes.tsx
@@ -1,9 +1,8 @@
-import type { FC } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { RoutePaths } from '../constants.js'
 import { Terms, FileBrowser, FilePicker, UploadFile } from './components/index.js'
 
-export const FileRoutes: FC = () => (
+export const FileRoutes = () => (
     <Routes>
         <Route path={RoutePaths.Browser} element={<FileBrowser />} />
         <Route path={RoutePaths.FileSelector} element={<FilePicker />} />

--- a/packages/plugins/FileService/src/SNSAdaptor/components/FileChip.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/FileChip.tsx
@@ -1,4 +1,4 @@
-import type { FC, HTMLProps } from 'react'
+import type { HTMLProps } from 'react'
 import { Typography } from '@mui/material'
 import { Icons } from '@masknet/icons'
 import { makeStyles } from '@masknet/theme'
@@ -19,7 +19,7 @@ interface SingleFileChipProps extends Omit<HTMLProps<HTMLDivElement>, 'ref' | 's
     onClick(options: { compositionType: CompositionType }): void
 }
 
-export const SingleFileChip: FC<SingleFileChipProps> = ({ name, size, onClick, ...rest }) => {
+export const SingleFileChip = ({ name, size, onClick, ...rest }: SingleFileChipProps) => {
     const { classes } = useStyles()
     const t = useI18N()
     const { type } = useCompositionContext()
@@ -41,7 +41,7 @@ interface MultipleFileChipProps
         Pick<SingleFileChipProps, 'onClick'> {
     count: number
 }
-export const MultipleFileChip: FC<MultipleFileChipProps> = ({ count, onClick, ...rest }) => {
+export const MultipleFileChip = ({ count, onClick, ...rest }: MultipleFileChipProps) => {
     const { classes, cx } = useStyles()
     const t = useI18N()
     const { type } = useCompositionContext()

--- a/packages/plugins/FileService/src/SNSAdaptor/components/FileList.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/FileList.tsx
@@ -1,7 +1,7 @@
 import { List, ListItem, Typography } from '@mui/material'
 import { makeStyles, Boundary, useCustomSnackbar } from '@masknet/theme'
 import type { FileInfo } from '../../types.js'
-import { type FC, type HTMLProps, useCallback, useRef } from 'react'
+import { type HTMLProps, useCallback, useRef } from 'react'
 import {
     DisplayingFile,
     type DisplayingFileProps,
@@ -45,7 +45,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-interface FileListBaseProps extends HTMLProps<HTMLDivElement> {
+interface FileListBaseProps extends HTMLProps<HTMLElement> {
     files: FileInfo[]
     onLoadMore?(): void
 }
@@ -53,7 +53,7 @@ interface FileListProps extends FileListBaseProps, Pick<ManageableFileProps, 'on
     onLoadMore?(): void
 }
 
-export const FileList: FC<FileListProps> = ({ files, onLoadMore, className, onDownload, onSend, ...rest }) => {
+export const FileList = ({ files, onLoadMore, className, onDownload, onSend, ...rest }: FileListProps) => {
     const t = useI18N()
     const { classes, cx } = useStyles()
     const { uploadStateMap, refetchFiles } = useFileManagement()
@@ -152,13 +152,13 @@ interface SelectableFileListProps extends Omit<FileListBaseProps, 'onChange' | '
 }
 
 const FILE_LIMIT = 2
-export const SelectableFileList: FC<SelectableFileListProps> = ({
+export const SelectableFileList = ({
     files,
     className,
     selectedIds = EMPTY_LIST,
     onChange,
     ...rest
-}) => {
+}: SelectableFileListProps) => {
     const { classes, cx } = useStyles()
 
     const selectedIdsRef = useRef(selectedIds)
@@ -205,13 +205,7 @@ interface DisplayingFileFileListProps extends FileListBaseProps, Pick<Displaying
 /**
  * Render in decrypted post
  */
-export const DisplayingFileList: FC<DisplayingFileFileListProps> = ({
-    files,
-    className,
-    onSave,
-    onDownload,
-    ...rest
-}) => {
+export const DisplayingFileList = ({ files, className, onSave, onDownload, ...rest }: DisplayingFileFileListProps) => {
     const { classes, cx } = useStyles()
 
     return (

--- a/packages/plugins/FileService/src/SNSAdaptor/components/Files/DisplayingFile.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/Files/DisplayingFile.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { formatFileSize } from '@masknet/kit'
 import { makeStyles } from '@masknet/theme'
 import { Button, Typography } from '@mui/material'
-import { type FC, memo } from 'react'
+import { memo } from 'react'
 import { Translate } from '../../../locales/index.js'
 import type { FileInfo } from '../../../types.js'
 import { type FileBaseProps, FileFrame } from './FileFrame.js'
@@ -36,7 +36,7 @@ export interface DisplayingFileProps extends FileBaseProps {
     onDownload?(file: FileInfo): void
 }
 
-export const DisplayingFile: FC<DisplayingFileProps> = memo(({ file, onSave, onDownload, ...rest }) => {
+export const DisplayingFile = memo(({ file, onSave, onDownload, ...rest }: DisplayingFileProps) => {
     const { classes } = useStyles()
 
     return (

--- a/packages/plugins/FileService/src/SNSAdaptor/components/Files/FileFrame.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/Files/FileFrame.tsx
@@ -1,13 +1,4 @@
-import {
-    type FC,
-    type HTMLProps,
-    memo,
-    type PropsWithChildren,
-    type ReactNode,
-    useEffect,
-    useRef,
-    useState,
-} from 'react'
+import { type HTMLProps, memo, type ReactNode, useEffect, useRef, useState } from 'react'
 import { Icons } from '@masknet/icons'
 import { Typography } from '@mui/material'
 import { makeStyles, ShadowRootTooltip, useBoundedPopperProps } from '@masknet/theme'
@@ -50,13 +41,7 @@ interface FileFrameProps extends FileBaseProps {
     operations?: ReactNode
 }
 
-export const FileFrame: FC<PropsWithChildren<FileFrameProps>> = memo(function FileFrame({
-    className,
-    children,
-    file,
-    operations,
-    ...rest
-}) {
+export const FileFrame = memo(function FileFrame({ className, children, file, operations, ...rest }: FileFrameProps) {
     const { classes, cx } = useStyles()
 
     const rootRef = useRef<HTMLDivElement>(null)

--- a/packages/plugins/FileService/src/SNSAdaptor/components/Files/ManageableFile.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/Files/ManageableFile.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { formatFileSize } from '@masknet/kit'
 import { makeStyles, ShadowRootMenu } from '@masknet/theme'
 import { MenuItem, Typography } from '@mui/material'
-import { type FC, memo, useRef, useState } from 'react'
+import { memo, useRef, useState } from 'react'
 import { Translate, useI18N } from '../../../locales/index.js'
 import type { FileInfo } from '../../../types.js'
 import { type FileBaseProps, FileFrame } from './FileFrame.js'
@@ -48,89 +48,83 @@ export interface ManageableFileProps extends FileBaseProps {
     onSend?(file: FileInfo): void
 }
 
-export const ManageableFile: FC<ManageableFileProps> = memo(
-    ({ file, onDownload, onRename, onDelete, onSend, ...rest }) => {
-        const { classes, cx } = useStyles()
-        const menuRef = useRef<HTMLDivElement>(null)
-        const [menuOpen, setMenuOpen] = useState(false)
-        const t = useI18N()
+export const ManageableFile = memo(({ file, onDownload, onRename, onDelete, onSend, ...rest }: ManageableFileProps) => {
+    const { classes, cx } = useStyles()
+    const menuRef = useRef<HTMLDivElement>(null)
+    const [menuOpen, setMenuOpen] = useState(false)
+    const t = useI18N()
 
-        return (
-            <FileFrame
-                file={file}
-                {...rest}
-                operations={
-                    <div className={classes.operations}>
-                        <Icons.Send
-                            className={classes.operationButton}
+    return (
+        <FileFrame
+            file={file}
+            {...rest}
+            operations={
+                <div className={classes.operations}>
+                    <Icons.Send
+                        className={classes.operationButton}
+                        onClick={() => {
+                            onSend?.(file)
+                        }}
+                        size={20}
+                    />
+                    <Icons.More
+                        ref={menuRef}
+                        className={cx(classes.operationButton, classes.menuButton)}
+                        onClick={() => setMenuOpen(true)}
+                        size={20}
+                    />
+                    <ShadowRootMenu
+                        classes={{ paper: classes.menu }}
+                        anchorEl={menuRef.current}
+                        anchorOrigin={{
+                            horizontal: 'right',
+                            vertical: 'bottom',
+                        }}
+                        transformOrigin={{
+                            horizontal: 'right',
+                            vertical: 'top',
+                        }}
+                        disableScrollLock
+                        open={menuOpen}
+                        disablePortal
+                        onClose={() => setMenuOpen(false)}>
+                        <MenuItem
                             onClick={() => {
-                                onSend?.(file)
-                            }}
-                            size={20}
-                        />
-                        <Icons.More
-                            ref={menuRef}
-                            className={cx(classes.operationButton, classes.menuButton)}
-                            onClick={() => setMenuOpen(true)}
-                            size={20}
-                        />
-                        <ShadowRootMenu
-                            classes={{ paper: classes.menu }}
-                            anchorEl={menuRef.current}
-                            anchorOrigin={{
-                                horizontal: 'right',
-                                vertical: 'bottom',
-                            }}
-                            transformOrigin={{
-                                horizontal: 'right',
-                                vertical: 'top',
-                            }}
-                            disableScrollLock
-                            open={menuOpen}
-                            disablePortal
-                            onClose={() => setMenuOpen(false)}>
-                            <MenuItem
-                                onClick={() => {
-                                    onDownload?.(file)
-                                    setMenuOpen(false)
-                                }}>
-                                <Typography className={classes.menuLabel}>{t.download()}</Typography>
-                            </MenuItem>
-                            <MenuItem
-                                onClick={() => {
-                                    onRename?.(file)
-                                    setMenuOpen(false)
-                                }}>
-                                <Typography className={classes.menuLabel}>{t.rename()}</Typography>
-                            </MenuItem>
-                            <MenuItem
-                                onClick={() => {
-                                    onDelete?.(file)
-                                    setMenuOpen(false)
-                                }}>
-                                <Typography
-                                    className={classes.menuLabel}
-                                    color={(theme) => theme.palette.maskColor.danger}>
-                                    {t.delete()}
-                                </Typography>
-                            </MenuItem>
-                        </ShadowRootMenu>
-                    </div>
-                }>
-                <Typography className={classes.desc}>{formatFileSize(file.size, true)}</Typography>
-                {file.key ? (
-                    <Typography className={classes.meta}>
-                        <Translate.file_key
-                            components={{
-                                key: <Typography className={classes.metaValue} component="span" />,
-                            }}
-                            values={{ key: file.key }}
-                        />
-                    </Typography>
-                ) : null}
-            </FileFrame>
-        )
-    },
-)
-
-ManageableFile.displayName = 'ManageableFile'
+                                onDownload?.(file)
+                                setMenuOpen(false)
+                            }}>
+                            <Typography className={classes.menuLabel}>{t.download()}</Typography>
+                        </MenuItem>
+                        <MenuItem
+                            onClick={() => {
+                                onRename?.(file)
+                                setMenuOpen(false)
+                            }}>
+                            <Typography className={classes.menuLabel}>{t.rename()}</Typography>
+                        </MenuItem>
+                        <MenuItem
+                            onClick={() => {
+                                onDelete?.(file)
+                                setMenuOpen(false)
+                            }}>
+                            <Typography className={classes.menuLabel} color={(theme) => theme.palette.maskColor.danger}>
+                                {t.delete()}
+                            </Typography>
+                        </MenuItem>
+                    </ShadowRootMenu>
+                </div>
+            }>
+            <Typography className={classes.desc}>{formatFileSize(file.size, true)}</Typography>
+            {file.key ? (
+                <Typography className={classes.meta}>
+                    <Translate.file_key
+                        components={{
+                            key: <Typography className={classes.metaValue} component="span" />,
+                        }}
+                        values={{ key: file.key }}
+                    />
+                </Typography>
+            ) : null}
+        </FileFrame>
+    )
+})

--- a/packages/plugins/FileService/src/SNSAdaptor/components/Files/SelectableFile.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/Files/SelectableFile.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { formatFileSize } from '@masknet/kit'
 import { makeStyles } from '@masknet/theme'
 import { Checkbox, Typography } from '@mui/material'
-import { type FC, memo } from 'react'
+import { memo } from 'react'
 import { Translate } from '../../../locales/index.js'
 import { type FileBaseProps, FileFrame } from './FileFrame.js'
 
@@ -28,7 +28,7 @@ interface SelectableFileProps extends Omit<FileBaseProps, 'onChange'> {
     onChange?(/** file id */ value: string, checked: boolean): void
 }
 
-export const SelectableFile: FC<SelectableFileProps> = memo(({ file, selected, onChange, disabled, ...rest }) => {
+export const SelectableFile = memo(({ file, selected, onChange, disabled, ...rest }: SelectableFileProps) => {
     const { classes, theme } = useStyles()
 
     return (

--- a/packages/plugins/FileService/src/SNSAdaptor/components/Files/UploadingFile.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/Files/UploadingFile.tsx
@@ -1,7 +1,7 @@
 import { formatFileSize } from '@masknet/kit'
 import { makeStyles } from '@masknet/theme'
 import { LinearProgress, linearProgressClasses, Typography } from '@mui/material'
-import { type FC, memo } from 'react'
+import { memo } from 'react'
 import { type FileBaseProps, FileFrame } from './FileFrame.js'
 
 const useStyles = makeStyles()((theme) => ({
@@ -29,7 +29,7 @@ export interface UploadingFileProps extends FileBaseProps {
     progress?: number
 }
 
-export const UploadingFile: FC<UploadingFileProps> = memo(({ file, progress, ...rest }) => {
+export const UploadingFile = memo(({ file, progress, ...rest }: UploadingFileProps) => {
     const { classes } = useStyles()
 
     return (

--- a/packages/plugins/FileService/src/SNSAdaptor/components/UploadDropArea.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/UploadDropArea.tsx
@@ -63,7 +63,7 @@ interface Props extends HTMLProps<HTMLDivElement> {
     onSelectFile(file: File): void
 }
 
-export const UploadDropArea: React.FC<Props> = memo(({ maxFileSize, onSelectFile, className, ...rest }) => {
+export const UploadDropArea = memo(({ maxFileSize, onSelectFile, className, ...rest }: Props) => {
     const t = useI18N()
     const { classes, cx } = useStyles()
     const { showSnackbar } = useCustomSnackbar()

--- a/packages/plugins/FileService/src/SNSAdaptor/components/UploadFile.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/components/UploadFile.tsx
@@ -70,7 +70,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export const UploadFile: React.FC = () => {
+export const UploadFile = () => {
     const t = useI18N()
     const { classes, theme } = useStyles()
     const [encrypted, setEncrypted] = useState(true)

--- a/packages/plugins/FileService/src/SNSAdaptor/contexts/Confirm/ConfirmDialog.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/contexts/Confirm/ConfirmDialog.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { InjectedDialog, type InjectedDialogProps } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
 import { Button, DialogContent, Typography } from '@mui/material'
-import { type FC, memo, type ReactNode } from 'react'
+import { memo, type ReactNode } from 'react'
 
 const useStyles = makeStyles()((theme) => ({
     paper: {
@@ -60,8 +60,8 @@ export interface ConfirmDialogProps extends Omit<InjectedDialogProps, 'title' | 
 }
 
 // Yet, another Confirm Dialog
-export const ConfirmDialog: FC<ConfirmDialogProps> = memo(
-    ({ title, message, description, confirmLabel = 'Confirm', onSubmit, onClose, ...rest }) => {
+export const ConfirmDialog = memo(
+    ({ title, message, description, confirmLabel = 'Confirm', onSubmit, onClose, ...rest }: ConfirmDialogProps) => {
         const { classes } = useStyles()
 
         return (

--- a/packages/plugins/FileService/src/SNSAdaptor/contexts/FileManagement/index.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/contexts/FileManagement/index.tsx
@@ -6,7 +6,6 @@ import { noop, omit } from 'lodash-es'
 import {
     createContext,
     type Dispatch,
-    type FC,
     memo,
     type PropsWithChildren,
     type SetStateAction,
@@ -67,7 +66,7 @@ interface Props extends PropsWithChildren<{}> {
     compositionType: CompositionType
 }
 
-export const FileManagementProvider: FC<Props> = memo(({ children, compositionType }) => {
+export const FileManagementProvider = memo(({ children, compositionType }: Props) => {
     const { value: files = EMPTY_LIST, retry: refetchFiles } = useAsyncRetry(
         () => PluginFileServiceRPC.getAllFiles(),
         [],

--- a/packages/plugins/FileService/src/SNSAdaptor/contexts/RenameDialog/RenameDialog.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/contexts/RenameDialog/RenameDialog.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { InjectedDialog, type InjectedDialogProps } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
 import { Button, DialogContent, InputBase, Typography } from '@mui/material'
-import { type FC, memo, type ReactNode, useState } from 'react'
+import { memo, type ReactNode, useState } from 'react'
 import { useI18N } from '../../../locales/i18n_generated.js'
 
 const useStyles = makeStyles()((theme) => ({
@@ -66,8 +66,8 @@ export interface RenameDialogProps extends Omit<InjectedDialogProps, 'title' | '
     onSubmit?(result: string | null): void
 }
 
-export const RenameDialog: FC<RenameDialogProps> = memo(
-    ({ title, message, description, currentName, onSubmit, onClose, ...rest }) => {
+export const RenameDialog = memo(
+    ({ title, message, description, currentName, onSubmit, onClose, ...rest }: RenameDialogProps) => {
         const { classes } = useStyles()
         const t = useI18N()
         const [name, setName] = useState(currentName)

--- a/packages/plugins/FileService/src/SNSAdaptor/contexts/index.tsx
+++ b/packages/plugins/FileService/src/SNSAdaptor/contexts/index.tsx
@@ -1,4 +1,4 @@
-import type { FC, PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 import { ConfirmProvider } from './Confirm/index.js'
 import { RenameProvider } from './RenameDialog/index.js'
 
@@ -6,7 +6,7 @@ export * from './Confirm/index.js'
 export * from './RenameDialog/index.js'
 export * from './FileManagement/index.js'
 
-export const UIProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
+export const UIProvider = ({ children }: PropsWithChildren<{}>) => {
     return (
         <ConfirmProvider>
             <RenameProvider>{children}</RenameProvider>

--- a/packages/plugins/Gitcoin/src/SNSAdaptor/contexts/Donate/DonateDialog.tsx
+++ b/packages/plugins/Gitcoin/src/SNSAdaptor/contexts/Donate/DonateDialog.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from 'bignumber.js'
-import { type FC, memo, useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { useAsync } from 'react-use'
 import { Icons } from '@masknet/icons'
 import { useSNSAdaptorContext } from '@masknet/plugin-infra/content-script'
@@ -74,7 +74,7 @@ export interface DonateDialogProps extends InjectedDialogProps {
     grant: GitcoinGrant
 }
 
-export const DonateDialog: FC<DonateDialogProps> = memo(({ onSubmit, grant, ...rest }) => {
+export const DonateDialog = memo(({ onSubmit, grant, ...rest }: DonateDialogProps) => {
     const t = useI18N()
     const { classes, theme } = useStyles()
     const { title, admin_address: address, tenants } = grant

--- a/packages/plugins/Gitcoin/src/SNSAdaptor/contexts/Donate/GiveBackSelect.tsx
+++ b/packages/plugins/Gitcoin/src/SNSAdaptor/contexts/Donate/GiveBackSelect.tsx
@@ -1,10 +1,10 @@
-import { type FC, memo } from 'react'
+import { memo } from 'react'
 import { MenuItem, Select, type SelectProps } from '@mui/material'
 
 interface Props extends SelectProps<number> {}
 
 const OPTIONS = [0, 0.05, 0.1, 0.15]
-export const GiveBackSelect: FC<Props> = memo((props) => {
+export const GiveBackSelect = memo((props: Props) => {
     return (
         <Select
             {...props}

--- a/packages/plugins/Gitcoin/src/SNSAdaptor/contexts/ResultModal/Modal.tsx
+++ b/packages/plugins/Gitcoin/src/SNSAdaptor/contexts/ResultModal/Modal.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@masknet/theme'
 import type { FungibleToken } from '@masknet/web3-shared-base'
 import type { ChainId, SchemaType } from '@masknet/web3-shared-evm'
 import { Button, DialogActions, DialogContent, Typography } from '@mui/material'
-import type { FC, PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 import { useI18N } from '../../../locales/index.js'
 
 const useStyles = makeStyles()((theme) => ({
@@ -47,7 +47,7 @@ export interface ResultModalProps extends PropsWithChildren<InjectedDialogProps>
     onShare?(): void
 }
 
-export const ResultModal: FC<ResultModalProps> = ({
+export const ResultModal = ({
     className,
     confirmLabel,
     children,
@@ -56,7 +56,7 @@ export const ResultModal: FC<ResultModalProps> = ({
     onSubmit,
     onShare,
     ...rest
-}) => {
+}: ResultModalProps) => {
     const { classes } = useStyles()
     const t = useI18N()
     return (

--- a/packages/plugins/GoPlusSecurity/src/SNSAdaptor/components/TokenPanel.tsx
+++ b/packages/plugins/GoPlusSecurity/src/SNSAdaptor/components/TokenPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { forwardRef } from 'react'
 import { Link, Stack, Typography } from '@mui/material'
 import { useTheme } from '@mui/system'
 import { makeStyles } from '@masknet/theme'
@@ -36,7 +36,7 @@ interface TokenPanelProps {
     tokenMarketCap?: number
 }
 
-export const TokenPanel = React.forwardRef(({ tokenSecurity, tokenMarketCap }: TokenPanelProps, ref) => {
+export const TokenPanel = forwardRef(({ tokenSecurity, tokenMarketCap }: TokenPanelProps, ref) => {
     const t = useI18N()
     const { classes } = useStyles()
     const theme = useTheme()

--- a/packages/plugins/MaskBox/src/SNSAdaptor/components/CountdownText/index.tsx
+++ b/packages/plugins/MaskBox/src/SNSAdaptor/components/CountdownText/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react'
+import { memo } from 'react'
 import { useCountdown } from './useCountdown.js'
 
 interface Props {
@@ -15,7 +15,7 @@ function formatCountdown(options: Record<string, number>) {
     return paris.filter(Boolean).join(' ')
 }
 
-export const CountdownText: FC<Props> = memo(({ finishTime }) => {
+export const CountdownText = memo(({ finishTime }: Props) => {
     const { days, hours, minutes, seconds } = useCountdown(finishTime ?? 0)
     const buttonLabel = `Start Sale in ${formatCountdown({
         day: days,

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CollectibleApprovalCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CollectibleApprovalCard.tsx
@@ -2,7 +2,6 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { formatEthereumAddress } from '@masknet/web3-shared-evm'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useFeedOwner } from '../../contexts/index.js'
 import { useAddressLabel } from '../../hooks/index.js'
@@ -48,7 +47,7 @@ interface CollectibleApprovalFeedCardProps extends Omit<FeedCardProps, 'feed'> {
  *
  * - CollectibleApproval
  */
-export const CollectibleApprovalCard: FC<CollectibleApprovalFeedCardProps> = ({ feed, ...rest }) => {
+export const CollectibleApprovalCard = ({ feed, ...rest }: CollectibleApprovalFeedCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
 

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CollectibleCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CollectibleCard.tsx
@@ -4,7 +4,7 @@ import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { isSameAddress } from '@masknet/web3-shared-base'
 import { formatEthereumAddress } from '@masknet/web3-shared-evm'
 import { Typography } from '@mui/material'
-import { type FC, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -127,7 +127,7 @@ interface CollectibleCardProps extends Omit<FeedCardProps, 'feed'> {
  * - CollectibleMint
  * - CollectibleOut
  */
-export const CollectibleCard: FC<CollectibleCardProps> = ({ feed, ...rest }) => {
+export const CollectibleCard = ({ feed, ...rest }: CollectibleCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
 

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CommentCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/CommentCard.tsx
@@ -4,7 +4,6 @@ import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { resolveResourceURL } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
 import Linkify from 'linkify-react'
-import type { FC } from 'react'
 import { Translate, useI18N } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -87,7 +86,7 @@ interface CommentCardProps extends Omit<FeedCardProps, 'feed'> {
  *
  * - NoteLink
  */
-export const CommentCard: FC<CommentCardProps> = ({ feed, ...rest }) => {
+export const CommentCard = ({ feed, ...rest }: CommentCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
     const { classes: mdClasses } = useMarkdownStyles()

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/DonationCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/DonationCard.tsx
@@ -2,7 +2,7 @@ import { Image, Markdown } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { Typography } from '@mui/material'
-import { type FC, type HTMLProps, memo, useState } from 'react'
+import { type HTMLProps, memo, useState } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardType } from '../share.js'
@@ -98,7 +98,7 @@ interface DonationCardProps extends Omit<FeedCardProps, 'feed'> {
 interface CardBodyProps extends HTMLProps<HTMLDivElement> {
     metadata: RSS3BaseAPI.DonateMetadata
 }
-const CardBody: FC<CardBodyProps> = memo(({ metadata, className, ...rest }) => {
+const CardBody = memo(({ metadata, className, ...rest }: CardBodyProps) => {
     const { classes, cx } = useStyles()
     return (
         <div className={cx(classes.body, className)} {...rest}>
@@ -117,7 +117,7 @@ const CardBody: FC<CardBodyProps> = memo(({ metadata, className, ...rest }) => {
  *
  * - DonationDonate
  */
-export const DonationCard: FC<DonationCardProps> = ({ feed, actionIndex, className, ...rest }) => {
+export const DonationCard = ({ feed, actionIndex, className, ...rest }: DonationCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
     const { classes: mdClasses } = useMarkdownStyles()

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/LiquidityCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/LiquidityCard.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { resolveResourceURL } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useI18N } from '../../../locales/index.js'
 import { useFeedOwner } from '../../contexts/index.js'
@@ -77,7 +76,7 @@ interface TokenFeedCardProps extends Omit<FeedCardProps, 'feed'> {
  * - TokenOut
  * - UnknownBurn
  */
-export const LiquidityCard: FC<TokenFeedCardProps> = ({ feed, className, ...rest }) => {
+export const LiquidityCard = ({ feed, className, ...rest }: TokenFeedCardProps) => {
     const { verbose } = rest
     const t = useI18N()
     const { classes, cx } = useStyles()

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/NoteCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/NoteCard.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { resolveIPFS_URL, resolveResourceURL } from '@masknet/web3-shared-base'
 import { Link, Typography } from '@mui/material'
-import { type FC, useCallback } from 'react'
+import { useCallback } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -133,7 +133,7 @@ const cardTypeMap = {
  * - NoteEdit
  * - NoteLink
  */
-export const NoteCard: FC<NoteCardProps> = ({ feed, className, ...rest }) => {
+export const NoteCard = ({ feed, className, ...rest }: NoteCardProps) => {
     const { classes, cx } = useStyles()
     const { classes: mdClasses } = useMarkdownStyles()
 

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProfileCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProfileCard.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { resolveResourceURL } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -80,7 +79,7 @@ interface ProfileCardProps extends Omit<FeedCardProps, 'feed'> {
  *
  * - ProfileCreate
  */
-export const ProfileCard: FC<ProfileCardProps> = ({ feed, ...rest }) => {
+export const ProfileCard = ({ feed, ...rest }: ProfileCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
 

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProfileLinkCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProfileLinkCard.tsx
@@ -4,7 +4,6 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { formatDomainName } from '@masknet/web3-shared-evm'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -83,7 +82,7 @@ const resolveHandle = (metadata: RSS3BaseAPI.FollowMetadata) => {
  *
  * - ProfileLink, aka Follow, Unfollow
  */
-export const ProfileLinkCard: FC<ProfileLinkCardProps> = ({ feed, className, ...rest }) => {
+export const ProfileLinkCard = ({ feed, className, ...rest }: ProfileLinkCardProps) => {
     const { classes, cx } = useStyles()
 
     const action = feed.actions[0]

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProfileProxy.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProfileProxy.tsx
@@ -3,7 +3,6 @@ import { Image } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -65,7 +64,7 @@ interface ProfileProxyCardProps extends Omit<FeedCardProps, 'feed'> {
  *
  * - ProfileProxy
  */
-export const ProfileProxyCard: FC<ProfileProxyCardProps> = ({ feed, className, ...rest }) => {
+export const ProfileProxyCard = ({ feed, className, ...rest }: ProfileProxyCardProps) => {
     const { classes, cx } = useStyles()
 
     const action = feed.actions[0]

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProposeCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/ProposeCard.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardType } from '../share.js'
@@ -46,7 +45,7 @@ interface ProposeCardProps extends Omit<FeedCardProps, 'feed'> {
  * - NoteCreate
  * - NoteEdit
  */
-export const ProposeCard: FC<ProposeCardProps> = ({ feed, ...rest }) => {
+export const ProposeCard = ({ feed, ...rest }: ProposeCardProps) => {
     const { classes } = useStyles()
 
     const action = feed.actions[0]

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/StakingCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/StakingCard.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { resolveResourceURL } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useI18N } from '../../../locales/index.js'
 import { useFeedOwner } from '../../contexts/index.js'
@@ -58,7 +57,7 @@ interface StakingFeedCardProps extends Omit<FeedCardProps, 'feed'> {
  * - TokenStake
  * - TokenUnstake
  */
-export const StakingCard: FC<StakingFeedCardProps> = ({ feed, ...rest }) => {
+export const StakingCard = ({ feed, ...rest }: StakingFeedCardProps) => {
     const { verbose } = rest
     const t = useI18N()
     const { classes, cx } = useStyles()

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenApprovalCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenApprovalCard.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { isGreaterThan } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useFeedOwner } from '../../contexts/index.js'
 import { useAddressLabel } from '../../hooks/index.js'
@@ -57,7 +56,7 @@ interface TokenApprovalFeedCardProps extends Omit<FeedCardProps, 'feed'> {
  *
  * - TokenApproval
  */
-export const TokenApprovalCard: FC<TokenApprovalFeedCardProps> = ({ feed, ...rest }) => {
+export const TokenApprovalCard = ({ feed, ...rest }: TokenApprovalFeedCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
 

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenBridgeCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenBridgeCard.tsx
@@ -4,7 +4,6 @@ import { NetworkPluginID } from '@masknet/shared-base'
 import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { Translate } from '../../../locales/index.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -62,7 +61,7 @@ interface TokenBridgeCardProps extends Omit<FeedCardProps, 'feed'> {
  *
  * - TokenBridge
  */
-export const TokenBridgeCard: FC<TokenBridgeCardProps> = ({ feed, ...rest }) => {
+export const TokenBridgeCard = ({ feed, ...rest }: TokenBridgeCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
 

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenOperationCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenOperationCard.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { isSameAddress } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { useI18N } from '../../../locales/index.js'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useFeedOwner } from '../../contexts/index.js'
@@ -81,7 +80,7 @@ const contextMap: Partial<
  * - TokenOut
  * - TokenBurn
  */
-export const TokenOperationCard: FC<TokenFeedCardProps> = ({ feed, ...rest }) => {
+export const TokenOperationCard = ({ feed, ...rest }: TokenFeedCardProps) => {
     const { verbose } = rest
     const t = useI18N()
     const { classes, cx } = useStyles()

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenSwapCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/TokenSwapCard.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { Image } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
@@ -61,7 +60,7 @@ interface TokenSwapCardProps extends Omit<FeedCardProps, 'feed'> {
  *
  * - TokenSwap
  */
-export const TokenSwapCard: FC<TokenSwapCardProps> = ({ feed, ...rest }) => {
+export const TokenSwapCard = ({ feed, ...rest }: TokenSwapCardProps) => {
     const { verbose } = rest
     const t = useI18N()
     const { classes, cx } = useStyles()

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/UnknownCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/UnknownCard.tsx
@@ -2,7 +2,6 @@ import { makeStyles } from '@masknet/theme'
 import { type RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { isSameAddress } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import type { FC } from 'react'
 import { useFeedOwner } from '../../contexts/index.js'
 import { CardType } from '../share.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -20,7 +19,7 @@ interface TokenFeedCardProps extends Omit<FeedCardProps, 'feed'> {
     feed: RSS3BaseAPI.Web3Feed
 }
 
-export const UnknownCard: FC<TokenFeedCardProps> = ({ feed, ...rest }) => {
+export const UnknownCard = ({ feed, ...rest }: TokenFeedCardProps) => {
     const { classes, theme } = useStyles()
 
     const action = feed.actions[0]

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/VoteCard.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/VoteCard.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@masknet/theme'
 import { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { Typography } from '@mui/material'
 import Linkify from 'linkify-react'
-import { useMemo, type FC } from 'react'
+import { useMemo } from 'react'
 import { Translate } from '../../../locales/i18n_generated.js'
 import { useAddressLabel } from '../../hooks/index.js'
 import { CardFrame, type FeedCardProps } from '../base.js'
@@ -62,7 +62,7 @@ interface VoteCardProps extends Omit<FeedCardProps, 'feed'> {
  * - NoteCreate
  * - NoteEdit
  */
-export const VoteCard: FC<VoteCardProps> = ({ feed, className, ...rest }) => {
+export const VoteCard = ({ feed, className, ...rest }: VoteCardProps) => {
     const { verbose } = rest
     const { classes, cx } = useStyles()
     const { classes: mdClasses } = useMarkdownStyles()

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/common.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/FeedCard/common.tsx
@@ -2,7 +2,7 @@ import { type ReverseAddressProps, ReversedAddress } from '@masknet/shared'
 import { makeStyles } from '@masknet/theme'
 import { formatBalance } from '@masknet/web3-shared-base'
 import { Link, Typography } from '@mui/material'
-import type { ComponentProps, FC } from 'react'
+import type { ComponentProps } from 'react'
 import { type IntermediateRepresentation, type Opts } from 'linkifyjs'
 
 const useStyles = makeStyles()((theme) => ({
@@ -30,7 +30,7 @@ interface LabelProps extends ComponentProps<typeof Typography> {
     title?: string
 }
 
-export const Label: FC<LabelProps> = ({ className, ...rest }) => {
+export const Label = ({ className, ...rest }: LabelProps) => {
     const { classes, cx } = useStyles()
     return <Typography className={cx(classes.label, className)} component="span" {...rest} />
 }
@@ -38,7 +38,7 @@ export const Label: FC<LabelProps> = ({ className, ...rest }) => {
 interface AddressLabelProps extends Omit<ReverseAddressProps, 'address'> {
     address?: ReverseAddressProps['address']
 }
-export const AddressLabel: FC<AddressLabelProps> = ({ address, pluginID, size, className, ...rest }) => {
+export const AddressLabel = ({ address, pluginID, size, className, ...rest }: AddressLabelProps) => {
     const { classes, cx } = useStyles()
     return address ? (
         <ReversedAddress

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/Slider.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/Slider.tsx
@@ -1,16 +1,7 @@
 import { Icons } from '@masknet/icons'
 import { makeStyles } from '@masknet/theme'
 import { range } from 'lodash-es'
-import {
-    type FC,
-    Children,
-    useState,
-    useRef,
-    type CSSProperties,
-    type HTMLProps,
-    useEffect,
-    useLayoutEffect,
-} from 'react'
+import { Children, useState, useRef, type CSSProperties, type HTMLProps, useEffect, useLayoutEffect } from 'react'
 
 const useStyles = makeStyles<void, 'active'>()((theme, _, refs) => ({
     container: {},
@@ -49,7 +40,7 @@ interface Props extends HTMLProps<HTMLDivElement> {
     onUpdate?(index: number): void
 }
 
-export const Slider: FC<Props> = ({ children, className, onUpdate, ...rest }) => {
+export const Slider = ({ children, className, onUpdate, ...rest }: Props) => {
     const containerRef = useRef<HTMLDivElement>(null)
     const { classes, cx } = useStyles()
     const [index, setIndex] = useState(0)

--- a/packages/plugins/RSS3/src/SNSAdaptor/components/base.tsx
+++ b/packages/plugins/RSS3/src/SNSAdaptor/components/base.tsx
@@ -3,7 +3,7 @@ import { makeStyles, ShadowRootTooltip } from '@masknet/theme'
 import type { RSS3BaseAPI } from '@masknet/web3-providers/types'
 import { Typography } from '@mui/material'
 import { BigNumber } from 'bignumber.js'
-import type { FC, HTMLProps, ReactNode } from 'react'
+import type { HTMLProps, ReactNode } from 'react'
 import formatDateTime from 'date-fns/format'
 import { useViewFeedDetails } from '../contexts/index.js'
 import { type CardType, cardTypeIconMap, formatTimestamp, getPlatformIcon } from './share.js'
@@ -67,7 +67,7 @@ export interface CardFrameProps extends Omit<HTMLProps<HTMLDivElement>, 'type' |
     badge?: ReactNode
 }
 
-export const CardFrame: FC<CardFrameProps> = ({
+export const CardFrame = ({
     type,
     feed,
     actionIndex,
@@ -77,7 +77,7 @@ export const CardFrame: FC<CardFrameProps> = ({
     verbose,
     badge,
     ...rest
-}) => {
+}: CardFrameProps) => {
     const { classes, cx } = useStyles()
     const CardIcon = cardTypeIconMap[type]
     const PrimaryPlatformIcon = getPlatformIcon(feed.network)

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/LensBadge.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/LensBadge.tsx
@@ -1,4 +1,4 @@
-import { memo, type FC, useRef, useEffect } from 'react'
+import { memo, useRef, useEffect } from 'react'
 import { IconButton } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import { Icons } from '@masknet/icons'
@@ -24,7 +24,7 @@ interface Props {
     userId: string
 }
 
-export const LensBadge: FC<Props> = memo(({ slot, accounts, userId }) => {
+export const LensBadge = memo(({ slot, accounts, userId }: Props) => {
     const buttonRef = useRef<HTMLButtonElement>(null)
     const { classes } = useStyles()
 

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/LensList.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/LensList.tsx
@@ -4,7 +4,7 @@ import { CrossIsolationMessages } from '@masknet/shared-base'
 import { ActionButton, makeStyles } from '@masknet/theme'
 import type { FireflyBaseAPI } from '@masknet/web3-providers/types'
 import { List, ListItem, Typography, type ListProps } from '@mui/material'
-import { memo, type FC } from 'react'
+import { memo } from 'react'
 import { useI18N } from '../../locales/i18n_generated.js'
 import { useAsync } from 'react-use'
 import { useChainContext } from '@masknet/web3-hooks-base'
@@ -76,7 +76,7 @@ interface Props extends ListProps {
     accounts: FireflyBaseAPI.LensAccount[]
 }
 
-export const LensList: FC<Props> = memo(({ className, accounts, ...rest }) => {
+export const LensList = memo(({ className, accounts, ...rest }: Props) => {
     const { classes, cx } = useStyles()
     const t = useI18N()
     return (

--- a/packages/plugins/Web3Profile/src/SNSAdaptor/components/ProfileCard.tsx
+++ b/packages/plugins/Web3Profile/src/SNSAdaptor/components/ProfileCard.tsx
@@ -16,7 +16,7 @@ import {
     alpha,
 } from '@mui/material'
 import { useQuery } from '@tanstack/react-query'
-import { memo, type FC, useState, useCallback, useMemo, useRef } from 'react'
+import { memo, useState, useCallback, useMemo, useRef } from 'react'
 import { resolveNextIDPlatformWalletName } from '@masknet/web3-shared-base'
 
 const useStyles = makeStyles()((theme) => ({
@@ -107,7 +107,7 @@ interface Props extends CardProps {
     onAddWallet?(): void
 }
 
-export const ProfileCard: FC<Props> = memo(function ProfileCard({
+export const ProfileCard = memo(function ProfileCard({
     profile,
     avatar,
     walletProofs = EMPTY_LIST,
@@ -119,7 +119,7 @@ export const ProfileCard: FC<Props> = memo(function ProfileCard({
     onToggle,
     onAddWallet,
     ...rest
-}) {
+}: Props) {
     const { classes, cx } = useStyles()
     const t = useI18N()
     const [expanded, setExpanded] = useState(initialExpanded)

--- a/packages/shared/src/UI/components/Alert/index.tsx
+++ b/packages/shared/src/UI/components/Alert/index.tsx
@@ -2,7 +2,7 @@ import { Icons } from '@masknet/icons'
 import { makeStyles } from '@masknet/theme'
 import { Box, Typography } from '@mui/material'
 import type { BoxProps } from '@mui/system'
-import { type FC, memo } from 'react'
+import { memo } from 'react'
 
 const useStyles = makeStyles()((theme) => ({
     alert: {
@@ -22,7 +22,7 @@ interface Props extends BoxProps {
     onClose?: () => void
 }
 
-export const Alert: FC<Props> = memo(function Alert({ className, children, open, onClose, ...rest }) {
+export const Alert = memo(function Alert({ className, children, open, onClose, ...rest }: Props) {
     const { classes, cx } = useStyles()
 
     if (!open) return null

--- a/packages/shared/src/UI/components/ApplicationEntry/index.tsx
+++ b/packages/shared/src/UI/components/ApplicationEntry/index.tsx
@@ -92,7 +92,7 @@ interface ApplicationEntryProps {
     disabled?: boolean
     recommendFeature?: Plugin.SNSAdaptor.ApplicationEntry['recommendFeature']
     iconFilterColor?: string
-    tooltipHint?: string | React.ReactElement
+    tooltipHint?: React.ReactNode
     onClick: () => void
 }
 

--- a/packages/shared/src/UI/components/AssetsManagement/CollectibleCard.tsx
+++ b/packages/shared/src/UI/components/AssetsManagement/CollectibleCard.tsx
@@ -1,4 +1,4 @@
-import { memo, type HTMLProps, type FC } from 'react'
+import { memo, type HTMLProps } from 'react'
 import { Card } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import type { Web3Helper } from '@masknet/web3-helpers'
@@ -64,8 +64,17 @@ export interface CollectibleCardProps extends HTMLProps<HTMLDivElement> {
     isSelected?: boolean
 }
 
-export const CollectibleCard: FC<CollectibleCardProps> = memo(
-    ({ className, pluginID, asset, disableNetworkIcon, disableInspect, indicatorIcon, isSelected, ...rest }) => {
+export const CollectibleCard = memo(
+    ({
+        className,
+        pluginID,
+        asset,
+        disableNetworkIcon,
+        disableInspect,
+        indicatorIcon,
+        isSelected,
+        ...rest
+    }: CollectibleCardProps) => {
         const { classes, cx } = useStyles()
 
         const icon =

--- a/packages/shared/src/UI/components/AssetsManagement/Collection.tsx
+++ b/packages/shared/src/UI/components/AssetsManagement/Collection.tsx
@@ -4,7 +4,7 @@ import { ShadowRootTooltip, makeStyles, useDetectOverflow } from '@masknet/theme
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { Skeleton, Typography } from '@mui/material'
 import { range } from 'lodash-es'
-import { memo, useEffect, useLayoutEffect, useRef, useState, type FC, type HTMLProps } from 'react'
+import { memo, useEffect, useLayoutEffect, useRef, useState, type HTMLProps } from 'react'
 import { useSharedI18N } from '../../../index.js'
 import { CollectibleCard } from './CollectibleCard.js'
 import { CollectibleItem, CollectibleItemSkeleton, type CollectibleItemProps } from './CollectibleItem.js'
@@ -90,7 +90,7 @@ export interface CollectionProps
 /**
  * Props inherited from div on take effect when rendering as a folder
  */
-export const Collection: FC<CollectionProps> = memo(
+export const Collection = memo(
     ({
         className,
         collection,
@@ -106,7 +106,7 @@ export const Collection: FC<CollectionProps> = memo(
         onItemClick,
         selectedAsset,
         ...rest
-    }) => {
+    }: CollectionProps) => {
         const t = useSharedI18N()
         const { compact, containerRef } = useCompactDetection()
         const { classes, cx } = useStyles({ compact })
@@ -204,7 +204,7 @@ export interface CollectionSkeletonProps extends HTMLProps<HTMLDivElement> {
     count: number
     expanded?: boolean
 }
-export const CollectionSkeleton: FC<CollectionSkeletonProps> = ({ className, count, id, expanded, ...rest }) => {
+export const CollectionSkeleton = ({ className, count, id, expanded, ...rest }: CollectionSkeletonProps) => {
     const { compact, containerRef } = useCompactDetection()
     const { classes, cx } = useStyles({ compact })
 
@@ -233,7 +233,7 @@ export const CollectionSkeleton: FC<CollectionSkeletonProps> = ({ className, cou
     return <>{skeletons}</>
 }
 
-export const LazyCollection: FC<CollectionProps> = memo((props) => {
+export const LazyCollection = memo((props: CollectionProps) => {
     const { className, collection } = props
     const placeholderRef = useRef<HTMLDivElement>(null)
     const [seen, setSeen] = useState(false)
@@ -256,7 +256,7 @@ export const LazyCollection: FC<CollectionProps> = memo((props) => {
     }, [placeholderRef.current, seen])
 
     if (seen) {
-        return <Collection {...props} />
+        return <Collection {...props} ref={undefined} />
     }
     return (
         <div className={className} ref={placeholderRef}>

--- a/packages/shared/src/UI/components/AssetsManagement/CollectionList.tsx
+++ b/packages/shared/src/UI/components/AssetsManagement/CollectionList.tsx
@@ -10,7 +10,7 @@ import { ChainId as SolanaChainId } from '@masknet/web3-shared-solana'
 import { Box, Button, Typography, styled } from '@mui/material'
 import type { BoxProps } from '@mui/system'
 import { range, sortBy } from 'lodash-es'
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSharedI18N } from '../../../locales/i18n_generated.js'
 import { CollectibleItem, CollectibleItemSkeleton } from './CollectibleItem.js'
 import { Collection, LazyCollection, type CollectionProps, CollectionSkeleton } from './Collection.js'
@@ -391,7 +391,7 @@ interface ExpandedCollectionProps extends CollectionProps {
 }
 
 /** An ExpandedCollection tiles collectable cards */
-const ExpandedCollection: FC<ExpandedCollectionProps> = memo(({ gridProps = EMPTY_OBJECT, ...collectionProps }) => {
+const ExpandedCollection = memo(({ gridProps = EMPTY_OBJECT, ...collectionProps }: ExpandedCollectionProps) => {
     const { loadAssets, getAssets } = useUserAssets()
     const { classes, theme } = useStyles(gridProps)
     const { collection, assets } = collectionProps
@@ -400,7 +400,7 @@ const ExpandedCollection: FC<ExpandedCollectionProps> = memo(({ gridProps = EMPT
         <>
             <Box width="100%">
                 <Box className={classes.grid}>
-                    <Collection {...collectionProps} />
+                    <Collection {...collectionProps} ref={undefined} />
                     {loading ? range(20).map((i) => <CollectibleItemSkeleton omitName key={i} />) : null}
                 </Box>
             </Box>

--- a/packages/shared/src/UI/components/AssetsManagement/LoadingSkeleton.tsx
+++ b/packages/shared/src/UI/components/AssetsManagement/LoadingSkeleton.tsx
@@ -1,11 +1,11 @@
-import type { FC, HTMLProps } from 'react'
+import type { HTMLProps } from 'react'
 import { range } from 'lodash-es'
 import { CollectibleItemSkeleton } from './CollectibleItem.js'
 import { CollectionSkeleton } from './Collection.js'
 
-export interface LoadingSkeletonProps extends HTMLProps<HTMLDivElement> {}
+export interface LoadingSkeletonProps extends Pick<HTMLProps<HTMLDivElement>, 'className'> {}
 
-export const LoadingSkeleton: FC<LoadingSkeletonProps> = ({ className }) => {
+export const LoadingSkeleton = ({ className }: LoadingSkeletonProps) => {
     return (
         <div className={className}>
             {range(4).map((i) => (

--- a/packages/shared/src/UI/components/AssetsManagement/UserAssetsContext.tsx
+++ b/packages/shared/src/UI/components/AssetsManagement/UserAssetsContext.tsx
@@ -8,7 +8,6 @@ import {
     useMemo,
     useReducer,
     useRef,
-    type FC,
     type PropsWithChildren,
     type MutableRefObject,
 } from 'react'
@@ -40,7 +39,7 @@ export const AssetsContext = createContext<AssetsContextOptions>({
     loadVerifiedBy: () => Promise.resolve(),
 })
 
-interface Props {
+interface Props extends PropsWithChildren<{}> {
     pluginID: NetworkPluginID
     address: string
 }
@@ -48,7 +47,7 @@ interface Props {
 /** Min merged collection chunk size */
 const CHUNK_SIZE = 8
 
-export const UserAssetsProvider: FC<PropsWithChildren<Props>> = memo(({ pluginID, address, children }) => {
+export const UserAssetsProvider = memo(({ pluginID, address, children }: Props) => {
     const [{ assetsMap, verifiedMap }, dispatch] = useReducer(assetsReducer, initialAssetsState)
     const indicatorMapRef = useRef<Map<string, PageIndicator | undefined>>(new Map())
     const assetsMapRef = useRef<AssetsReducerState['assetsMap']>({})

--- a/packages/shared/src/UI/components/NFTList/index.tsx
+++ b/packages/shared/src/UI/components/NFTList/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback } from 'react'
+import { useCallback } from 'react'
 import { noop } from 'lodash-es'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { ElementAnchor, AssetPreviewer, RetryHint } from '@masknet/shared'
@@ -116,7 +116,7 @@ const useStyles = makeStyles<{ columns?: number; gap?: number }>()((theme, { col
     }
 })
 
-export const NFTItem: FC<NFTItemProps> = ({ token, pluginID }) => {
+export const NFTItem = ({ token, pluginID }: NFTItemProps) => {
     const { classes } = useStyles({})
     const Others = useWeb3Others(pluginID)
     const caption = isLens(token.metadata?.name) ? token.metadata?.name : Others.formatTokenId(token.tokenId, 4)
@@ -160,7 +160,7 @@ export const NFTItem: FC<NFTItemProps> = ({ token, pluginID }) => {
     )
 }
 
-export const NFTList: FC<Props> = ({
+export const NFTList = ({
     selectable,
     selectedPairs,
     tokens,
@@ -173,7 +173,7 @@ export const NFTList: FC<Props> = ({
     finished,
     pluginID,
     hasError,
-}) => {
+}: Props) => {
     const { classes, cx } = useStyles({ columns, gap })
 
     const isRadio = limit === 1

--- a/packages/shared/src/UI/components/PluginGuide/index.tsx
+++ b/packages/shared/src/UI/components/PluginGuide/index.tsx
@@ -4,12 +4,12 @@ import { Box, Button, Portal, Typography } from '@mui/material'
 import React, {
     cloneElement,
     createContext,
-    type ReactElement,
     useEffect,
     useLayoutEffect,
     useRef,
     useState,
     useMemo,
+    type ReactElement,
 } from 'react'
 import { usePluginGuideRecord } from './usePluginGuideRecord.js'
 
@@ -78,7 +78,8 @@ const useStyles = makeStyles()((theme) => ({
 }))
 
 export interface GuideStepProps {
-    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/ban-types
     children: ReactElement
     step: number
     totalStep: number

--- a/packages/shared/src/UI/components/PluginGuide/index.tsx
+++ b/packages/shared/src/UI/components/PluginGuide/index.tsx
@@ -4,7 +4,6 @@ import { Box, Button, Portal, Typography } from '@mui/material'
 import React, {
     cloneElement,
     createContext,
-    type PropsWithChildren,
     type ReactElement,
     useEffect,
     useLayoutEffect,
@@ -78,7 +77,9 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export interface GuideStepProps extends PropsWithChildren<{}> {
+export interface GuideStepProps {
+    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
+    children: ReactElement
     step: number
     totalStep: number
     arrow?: boolean
@@ -142,7 +143,7 @@ export function PluginGuide({
 
     return (
         <>
-            {cloneElement(children as ReactElement, { ref: childrenRef })}
+            {cloneElement(children, { ref: childrenRef })}
             {usePortalShadowRoot((container) => {
                 if (!stepVisible) return null
                 return (

--- a/packages/shared/src/UI/components/SocialAccountList/SocialTooltip.tsx
+++ b/packages/shared/src/UI/components/SocialAccountList/SocialTooltip.tsx
@@ -3,7 +3,8 @@ import { type NextIDPlatform } from '@masknet/shared-base'
 import { makeStyles, ShadowRootTooltip } from '@masknet/theme'
 import { resolveNextIDPlatformName } from '@masknet/web3-shared-base'
 import { Typography } from '@mui/material'
-import { useRef, type ReactElement, cloneElement, useEffect, useState } from 'react'
+import { useRef, cloneElement, useEffect, useState } from 'react'
+import type { ReactElement } from 'react-markdown/lib/react-markdown.js'
 
 const useStyles = makeStyles()({
     title: {
@@ -13,7 +14,8 @@ const useStyles = makeStyles()({
 
 interface SocialTooltipProps {
     platform?: NextIDPlatform
-    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/ban-types
     children: ReactElement
 }
 export function SocialTooltip({ children, platform }: SocialTooltipProps) {

--- a/packages/shared/src/UI/components/SocialAccountList/SocialTooltip.tsx
+++ b/packages/shared/src/UI/components/SocialAccountList/SocialTooltip.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles()({
 
 interface SocialTooltipProps {
     platform?: NextIDPlatform
+    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
     children: ReactElement
 }
 export function SocialTooltip({ children, platform }: SocialTooltipProps) {

--- a/packages/shared/src/UI/components/SocialAccountList/SocialTooltip.tsx
+++ b/packages/shared/src/UI/components/SocialAccountList/SocialTooltip.tsx
@@ -55,7 +55,7 @@ export function SocialTooltip({ children, platform }: SocialTooltipProps) {
             arrow
             placement="top"
             title={title}>
-            {cloneElement(children, { ...children.props, ref })}
+            {cloneElement(children, { ...children.props, ref } as any)}
         </ShadowRootTooltip>
     )
 }

--- a/packages/shared/src/UI/components/SocialIcon/index.tsx
+++ b/packages/shared/src/UI/components/SocialIcon/index.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, FC, HTMLProps } from 'react'
+import type { ComponentType, HTMLProps } from 'react'
 import { type GeneratedIconProps, Icons } from '@masknet/icons'
 
 const socialIconMap = {
@@ -11,7 +11,7 @@ interface Props extends HTMLProps<HTMLDivElement> {
     /** Social url */
     url?: string
 }
-export const SocialIcon: FC<Props> = ({ url, ...rest }) => {
+export const SocialIcon = ({ url, ...rest }: Props) => {
     if (!url) return null
 
     const host = new URL(url).host as keyof typeof socialIconMap

--- a/packages/shared/src/UI/components/TokenMenuList/index.tsx
+++ b/packages/shared/src/UI/components/TokenMenuList/index.tsx
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import { isEqual } from 'lodash-es'
 import { Icons } from '@masknet/icons'
 import type { Web3Helper } from '@masknet/web3-helpers'
@@ -54,7 +53,7 @@ export interface TokenMenuListProps {
     fromSocialCard?: boolean
 }
 
-export const TokenMenuList: FC<TokenMenuListProps> = ({ options, currentOption, onSelect, fromSocialCard = false }) => {
+export const TokenMenuList = ({ options, currentOption, onSelect, fromSocialCard = false }: TokenMenuListProps) => {
     const { classes } = useStyles()
     const theme = useTheme()
     return (

--- a/packages/shared/src/UI/components/TokenPrice/index.tsx
+++ b/packages/shared/src/UI/components/TokenPrice/index.tsx
@@ -1,4 +1,4 @@
-import type { FC, HTMLProps } from 'react'
+import type { HTMLProps } from 'react'
 import type { BigNumber } from 'bignumber.js'
 import { type ChainId, isZeroAddress } from '@masknet/web3-shared-evm'
 import { CurrencyType, multipliedBy } from '@masknet/web3-shared-base'
@@ -12,13 +12,13 @@ interface TokenPriceProps extends Omit<HTMLProps<HTMLSpanElement>, 'children'> {
     currencyType?: CurrencyType
 }
 
-export const TokenPrice: FC<TokenPriceProps> = ({
+export const TokenPrice = ({
     chainId,
     contractAddress,
     amount,
     currencyType = CurrencyType.USD,
     ...rest
-}) => {
+}: TokenPriceProps) => {
     const { value: tokenPrice = 0 } = useFungibleTokenPrice(
         NetworkPluginID.PLUGIN_EVM,
         contractAddress?.toLowerCase(),

--- a/packages/shared/src/UI/components/TokenTransactionConfirmModal/index.tsx
+++ b/packages/shared/src/UI/components/TokenTransactionConfirmModal/index.tsx
@@ -5,7 +5,7 @@ import type { Web3Helper } from '@masknet/web3-helpers'
 import { useNonFungibleAsset } from '@masknet/web3-hooks-base'
 import { TokenType } from '@masknet/web3-shared-base'
 import { Box, Button, DialogActions, DialogContent, Typography } from '@mui/material'
-import type { FC, PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 import { useSharedI18N } from '../../../locales/index.js'
 
 const useStyles = makeStyles()((theme) => ({
@@ -81,7 +81,7 @@ export interface TokenTransactionConfirmModalProps extends PropsWithChildren<Inj
     onConfirm?(): void
 }
 
-export const TokenTransactionConfirmModal: FC<TokenTransactionConfirmModalProps> = ({
+export const TokenTransactionConfirmModal = ({
     className,
     confirmText,
     onConfirm,
@@ -95,7 +95,7 @@ export const TokenTransactionConfirmModal: FC<TokenTransactionConfirmModalProps>
     nonFungibleTokenId,
     onClose,
     ...rest
-}) => {
+}: TokenTransactionConfirmModalProps) => {
     const { classes } = useStyles()
     const t = useSharedI18N()
     confirmText = confirmText || 'Confirm'

--- a/packages/shared/src/UI/components/TokenValue/index.tsx
+++ b/packages/shared/src/UI/components/TokenValue/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, type HTMLProps, useMemo } from 'react'
+import { type HTMLProps, useMemo } from 'react'
 import { BigNumber } from 'bignumber.js'
 import { useChainContext, useFungibleTokenPrice, useNetworkContext } from '@masknet/web3-hooks-base'
 import { TokenIcon } from '@masknet/shared'
@@ -43,7 +43,7 @@ interface Props extends HTMLProps<HTMLDivElement> {
     token?: Web3Helper.FungibleTokenAll | null
 }
 
-export const TokenValue: FC<Props> = ({ className, token, amount, ...rest }) => {
+export const TokenValue = ({ className, token, amount, ...rest }: Props) => {
     const { classes, cx } = useStyles()
     const { pluginID } = useNetworkContext()
     const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()

--- a/packages/shared/src/UI/components/TokenWithSocialGroupMenu/index.tsx
+++ b/packages/shared/src/UI/components/TokenWithSocialGroupMenu/index.tsx
@@ -1,4 +1,4 @@
-import { type FC, type PropsWithChildren, useCallback, memo } from 'react'
+import { type PropsWithChildren, useCallback, memo } from 'react'
 import { groupBy, toPairs } from 'lodash-es'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { Icons } from '@masknet/icons'
@@ -67,7 +67,7 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-export interface TokenWithSocialGroupProps extends MenuProps {
+export interface TokenWithSocialGroupProps extends PropsWithChildren<MenuProps> {
     collectionList: Web3Helper.TokenResultAll[]
     currentCollection?: Web3Helper.TokenResultAll
     socialAccounts?: Array<SocialAccount<Web3Helper.ChainIdAll>>
@@ -84,96 +84,92 @@ const menuGroupNameMap: Record<'FungibleToken' | 'NonFungibleToken' | 'NonFungib
     NonFungibleCollection: 'NFT',
 }
 
-export const TokenWithSocialGroupMenu: FC<PropsWithChildren<TokenWithSocialGroupProps>> = memo(
-    function TokenWithSocialGroupMenu({
-        currentCollection,
-        collectionList: collectionList_,
-        disablePortal = true,
-        disableScrollLock = true,
-        socialAccounts,
-        currentAddress,
-        onAddressChange,
-        fromSocialCard,
-        onTokenChange,
-        onClose,
-        ...rest
-    }) {
-        const { classes } = useStyles()
-        const t = useSharedI18N()
+export const TokenWithSocialGroupMenu = memo(function TokenWithSocialGroupMenu({
+    currentCollection,
+    collectionList: collectionList_,
+    disablePortal = true,
+    disableScrollLock = true,
+    socialAccounts,
+    currentAddress,
+    onAddressChange,
+    fromSocialCard,
+    onTokenChange,
+    onClose,
+    ...rest
+}: TokenWithSocialGroupProps) {
+    const { classes } = useStyles()
+    const t = useSharedI18N()
 
-        const onSelect = useCallback(
-            (value: Web3Helper.TokenResultAll, index: number) => {
-                onTokenChange?.(value, index)
-                onClose?.()
-            },
-            [onTokenChange, onClose],
-        )
+    const onSelect = useCallback(
+        (value: Web3Helper.TokenResultAll, index: number) => {
+            onTokenChange?.(value, index)
+            onClose?.()
+        },
+        [onTokenChange, onClose],
+    )
 
-        const collectionList = useTokenMenuCollectionList(collectionList_, currentCollection)
+    const collectionList = useTokenMenuCollectionList(collectionList_, currentCollection)
 
-        const groups: Array<
-            [
-                type: SearchResultType.FungibleToken | SearchResultType.NonFungibleToken,
-                collectionList: Web3Helper.TokenResultAll[],
-            ]
-        > = toPairs(groupBy(collectionList, (x) => x.type)).map(([type, collectionList]) => [
-            type as SearchResultType.FungibleToken | SearchResultType.NonFungibleToken,
-            collectionList,
-        ])
+    const groups: Array<
+        [
+            type: SearchResultType.FungibleToken | SearchResultType.NonFungibleToken,
+            collectionList: Web3Helper.TokenResultAll[],
+        ]
+    > = toPairs(groupBy(collectionList, (x) => x.type)).map(([type, collectionList]) => [
+        type as SearchResultType.FungibleToken | SearchResultType.NonFungibleToken,
+        collectionList,
+    ])
 
-        return (
-            <Menu
-                disablePortal={disablePortal}
-                disableScrollLock={disableScrollLock}
-                PaperProps={{
-                    className: classes.addressMenu,
-                }}
-                onClose={onClose}
-                {...rest}>
-                {groups.map(([type, groupOptions]) => (
-                    <div key={type} className={classes.group}>
-                        <Typography className={classes.groupName}>{menuGroupNameMap[type]}</Typography>
-                        <Divider className={classes.divider} />
-                        <TokenMenuList
-                            options={groupOptions}
-                            currentOption={currentCollection}
-                            onSelect={onSelect}
-                            fromSocialCard={fromSocialCard}
-                        />
-                    </div>
-                ))}
-
-                <div key="rss3" className={classes.group}>
-                    {collectionList?.length > 0 && socialAccounts?.length ? (
-                        <>
-                            <Typography className={classes.groupName}>
-                                {t.address_viewer_address_name_address()}
-                            </Typography>
-                            <Divider className={classes.divider} />
-                        </>
-                    ) : null}
-                    {socialAccounts?.map((x) => {
-                        return (
-                            <MenuItem
-                                className={classes.menuItem}
-                                key={x.address}
-                                value={x.address}
-                                onClick={() => {
-                                    onAddressChange?.(x.address)
-                                    onClose?.()
-                                }}>
-                                <div className={classes.addressItem}>
-                                    <AddressItem socialAccount={x} linkIconClassName={classes.secondLinkIcon} />
-                                    <AccountIcon socialAccount={x} />
-                                </div>
-                                {isSameAddress(currentAddress, x.address) && (
-                                    <Icons.CheckCircle size={20} className={classes.selectedIcon} />
-                                )}
-                            </MenuItem>
-                        )
-                    })}
+    return (
+        <Menu
+            disablePortal={disablePortal}
+            disableScrollLock={disableScrollLock}
+            PaperProps={{
+                className: classes.addressMenu,
+            }}
+            onClose={onClose}
+            {...rest}>
+            {groups.map(([type, groupOptions]) => (
+                <div key={type} className={classes.group}>
+                    <Typography className={classes.groupName}>{menuGroupNameMap[type]}</Typography>
+                    <Divider className={classes.divider} />
+                    <TokenMenuList
+                        options={groupOptions}
+                        currentOption={currentCollection}
+                        onSelect={onSelect}
+                        fromSocialCard={fromSocialCard}
+                    />
                 </div>
-            </Menu>
-        )
-    },
-)
+            ))}
+
+            <div key="rss3" className={classes.group}>
+                {collectionList?.length > 0 && socialAccounts?.length ? (
+                    <>
+                        <Typography className={classes.groupName}>{t.address_viewer_address_name_address()}</Typography>
+                        <Divider className={classes.divider} />
+                    </>
+                ) : null}
+                {socialAccounts?.map((x) => {
+                    return (
+                        <MenuItem
+                            className={classes.menuItem}
+                            key={x.address}
+                            value={x.address}
+                            onClick={() => {
+                                onAddressChange?.(x.address)
+                                onClose?.()
+                            }}>
+                            <div className={classes.addressItem}>
+                                <AddressItem socialAccount={x} linkIconClassName={classes.secondLinkIcon} />
+                                <AccountIcon socialAccount={x} />
+                            </div>
+                            {isSameAddress(currentAddress, x.address) && (
+                                <Icons.CheckCircle size={20} className={classes.selectedIcon} />
+                            )}
+                        </MenuItem>
+                    )
+                })}
+            </div>
+        </Menu>
+    )
+})

--- a/packages/shared/src/UI/components/WalletStatusBox/TransactionList.tsx
+++ b/packages/shared/src/UI/components/WalletStatusBox/TransactionList.tsx
@@ -1,4 +1,4 @@
-import { type FC, forwardRef, useCallback, useMemo, useState, useEffect } from 'react'
+import { forwardRef, useCallback, useMemo, useState, useEffect } from 'react'
 import { useAsync } from 'react-use'
 import { noop } from 'lodash-es'
 import format from 'date-fns/format'
@@ -81,7 +81,7 @@ interface TransactionProps extends GridProps {
     transaction: RecentTransactionComputed<Web3Helper.ChainIdAll, Web3Helper.TransactionAll>
     onClear?(tx: RecentTransactionComputed<Web3Helper.ChainIdAll, Web3Helper.TransactionAll>): void
 }
-const Transaction: FC<TransactionProps> = ({ chainId, transaction: tx, onClear = noop, ...rest }) => {
+const Transaction = ({ chainId, transaction: tx, onClear = noop, ...rest }: TransactionProps) => {
     const t = useSharedI18N()
     const { classes, theme } = useStyles()
 
@@ -170,17 +170,24 @@ interface Props extends ListProps {
     onClear?(tx: RecentTransactionComputed<Web3Helper.ChainIdAll, Web3Helper.TransactionAll>): void
 }
 
-export const TransactionList: FC<Props> = forwardRef(({ className, transactions, onClear = noop, ...rest }, ref) => {
-    const { classes, cx } = useStyles()
-    const { chainId } = useChainContext()
-    if (!transactions.length) return null
-    return (
-        <List className={cx(classes.list, className)} {...rest} ref={ref}>
-            {transactions.map((tx) => (
-                <ListItem key={tx.id} className={classes.listItem}>
-                    <Transaction className={classes.transaction} transaction={tx} chainId={chainId} onClear={onClear} />
-                </ListItem>
-            ))}
-        </List>
-    )
-})
+export const TransactionList = forwardRef<HTMLUListElement, Props>(
+    ({ className, transactions, onClear = noop, ...rest }, ref) => {
+        const { classes, cx } = useStyles()
+        const { chainId } = useChainContext()
+        if (!transactions.length) return null
+        return (
+            <List className={cx(classes.list, className)} {...rest} ref={ref}>
+                {transactions.map((tx) => (
+                    <ListItem key={tx.id} className={classes.listItem}>
+                        <Transaction
+                            className={classes.transaction}
+                            transaction={tx}
+                            chainId={chainId}
+                            onClear={onClear}
+                        />
+                    </ListItem>
+                ))}
+            </List>
+        )
+    },
+)

--- a/packages/shared/src/contexts/common/Confirm/Dialog.tsx
+++ b/packages/shared/src/contexts/common/Confirm/Dialog.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { makeStyles } from '@masknet/theme'
 import { Button, DialogActions, DialogContent, dialogClasses } from '@mui/material'
 import { useSharedI18N } from '../../../locales/index.js'
@@ -32,14 +32,14 @@ export interface ConfirmDialogProps extends Omit<InjectedDialogProps, 'title' | 
     maxWidthOfContent?: number
 }
 
-export const ConfirmDialog: FC<ConfirmDialogProps> = ({
+export const ConfirmDialog = ({
     title,
     confirmLabel,
     content,
     onSubmit,
     maxWidthOfContent,
     ...rest
-}) => {
+}: ConfirmDialogProps) => {
     const t = useSharedI18N()
     const { classes } = useStyles(maxWidthOfContent)
 

--- a/packages/shared/src/contexts/components/AddCollectiblesDialog.tsx
+++ b/packages/shared/src/contexts/components/AddCollectiblesDialog.tsx
@@ -12,7 +12,7 @@ import { Button, DialogContent, Stack, Typography } from '@mui/material'
 import { Box } from '@mui/system'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { compact, isNaN, uniq } from 'lodash-es'
-import { memo, useCallback, useMemo, useState, type FC, type FormEvent } from 'react'
+import { memo, useCallback, useMemo, useState, type FormEvent } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { CollectibleItem, CollectibleItemSkeleton } from '../../UI/components/AssetsManagement/CollectibleItem.js'
@@ -120,14 +120,14 @@ export interface AddCollectiblesDialogProps<T extends NetworkPluginID = NetworkP
     ): void
 }
 
-export const AddCollectiblesDialog: FC<AddCollectiblesDialogProps> = memo(function AddCollectiblesDialog({
+export const AddCollectiblesDialog = memo(function AddCollectiblesDialog({
     open,
     pluginID,
     chainId,
     account: defaultAccount,
     onClose,
     onSubmit,
-}) {
+}: AddCollectiblesDialogProps) {
     const t = useSharedI18N()
     const walletAccount = useAccount()
     const account = defaultAccount || walletAccount

--- a/packages/shared/src/contexts/components/SelectFungibleTokenDialog.tsx
+++ b/packages/shared/src/contexts/components/SelectFungibleTokenDialog.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import {
     useNetworkContext,
     useNativeTokenAddress,
@@ -63,7 +63,7 @@ export interface SelectFungibleTokenDialogProps<T extends NetworkPluginID = Netw
     onClose?(): void
 }
 
-export const SelectFungibleTokenDialog: FC<SelectFungibleTokenDialogProps> = ({
+export const SelectFungibleTokenDialog = ({
     open,
     pluginID,
     chainId,
@@ -77,7 +77,7 @@ export const SelectFungibleTokenDialog: FC<SelectFungibleTokenDialogProps> = ({
     onClose,
     title,
     enableManage = true,
-}) => {
+}: SelectFungibleTokenDialogProps) => {
     const t = useSharedI18N()
     const { networkIdentifier } = useBaseUIRuntime()
     const compact = networkIdentifier === EnhanceableSite.Minds

--- a/packages/shared/src/contexts/components/SelectGasSettingsDialog.tsx
+++ b/packages/shared/src/contexts/components/SelectGasSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useChainContext, useNetworkContext } from '@masknet/web3-hooks-base'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { useSharedI18N } from '@masknet/shared'
@@ -43,7 +43,7 @@ export interface SelectGasSettingsDialogProps<T extends NetworkPluginID = Networ
     onClose?(): void
 }
 
-export const SelectGasSettingsDialog: FC<SelectGasSettingsDialogProps> = ({
+export const SelectGasSettingsDialog = ({
     open,
     pluginID,
     chainId,
@@ -55,7 +55,7 @@ export const SelectGasSettingsDialog: FC<SelectGasSettingsDialogProps> = ({
     onSubmit,
     onClose,
     title,
-}) => {
+}: SelectGasSettingsDialogProps) => {
     const t = useSharedI18N()
     const { classes } = useStyles({ compact: disableSlippageTolerance ?? true })
     const { pluginID: pluginID_ } = useNetworkContext(pluginID)

--- a/packages/shared/src/contexts/components/SelectNonFungibleContractDialog/index.tsx
+++ b/packages/shared/src/contexts/components/SelectNonFungibleContractDialog/index.tsx
@@ -10,7 +10,7 @@ import { SchemaType, isLensCollect, isLensFollower, isLensProfileAddress } from 
 import { DialogContent, List, Stack, Typography } from '@mui/material'
 import { Box } from '@mui/system'
 import { compact } from 'lodash-es'
-import { memo, useCallback, useMemo, useState, type FC } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { useSubscription } from 'use-subscription'
 import { InjectedDialog } from '../InjectedDialog.js'
 import { ContractItem } from './ContractItem.js'
@@ -67,8 +67,8 @@ export interface SelectNonFungibleContractDialogProps<T extends NetworkPluginID 
     ): void
 }
 
-export const SelectNonFungibleContractDialog: FC<SelectNonFungibleContractDialogProps> = memo(
-    ({ open, pluginID, chainId, onClose, onSubmit }) => {
+export const SelectNonFungibleContractDialog = memo(
+    ({ open, pluginID, chainId, onClose, onSubmit }: SelectNonFungibleContractDialogProps) => {
         const t = useSharedI18N()
         const { classes } = useStyles()
         const [keyword, setKeyword] = useState('')

--- a/packages/shared/src/hooks/useMenu.tsx
+++ b/packages/shared/src/hooks/useMenu.tsx
@@ -41,7 +41,7 @@ export function useMenuConfig(
     config: MenuConfigOptions,
     ref?: MutableRefObject<HTMLDivElement | null>,
 ): [
-    menu: React.ReactElement,
+    menu: React.ReactNode,
     openDialog: (anchorElOrEvent: HTMLElement | SyntheticEvent<HTMLElement>) => void,
     closeDialog: () => void,
 ] {

--- a/packages/shared/src/hooks/useOpenShareTxDialog.tsx
+++ b/packages/shared/src/hooks/useOpenShareTxDialog.tsx
@@ -4,7 +4,7 @@ import type { NetworkPluginID } from '@masknet/shared-base'
 import { explorerResolver } from '@masknet/web3-shared-evm'
 import { Done as DoneIcon } from '@mui/icons-material'
 import { Link, Typography } from '@mui/material'
-import { type FC, memo, useCallback } from 'react'
+import { memo, useCallback } from 'react'
 import { useShowConfirm } from '../contexts/common/index.js'
 import { useSharedI18N } from '../locales/index.js'
 
@@ -43,7 +43,7 @@ interface ShareTransactionOptions {
 
 type ShareTransactionProps = Omit<ShareTransactionOptions, 'title' | 'onShare'>
 
-const ShareTransaction: FC<ShareTransactionProps> = memo(({ message, content, hash }) => {
+const ShareTransaction = memo(({ message, content, hash }: ShareTransactionProps) => {
     const { classes } = useStyles()
     const t = useSharedI18N()
     const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()

--- a/packages/shared/src/modals/WalletConnectQRCodeDialog/QRCodeDialog.tsx
+++ b/packages/shared/src/modals/WalletConnectQRCodeDialog/QRCodeDialog.tsx
@@ -17,7 +17,7 @@ interface QRCodeDialogProps {
     onClose(): void
 }
 
-export const QRCodeDialog: React.FC<QRCodeDialogProps> = ({ uri, open, onClose }) => {
+export const QRCodeDialog = ({ uri, open, onClose }: QRCodeDialogProps) => {
     const t = useSharedI18N()
     const { classes } = useStyles()
     return (

--- a/packages/shared/src/modals/WalletConnectQRCodeDialog/QRCodeModal.tsx
+++ b/packages/shared/src/modals/WalletConnectQRCodeDialog/QRCodeModal.tsx
@@ -14,9 +14,11 @@ const useStyles = makeStyles()((theme) => ({
     tip: { fontSize: 12, marginTop: '10px' },
 }))
 
-export const QRCodeModal: React.FC<{
+interface QRCodeModalProps {
     uri: string
-}> = ({ uri }) => {
+}
+
+export const QRCodeModal = ({ uri }: QRCodeModalProps) => {
     const t = useSharedI18N()
     const { classes } = useStyles()
 

--- a/packages/shared/src/wallet/FormattedAddress.tsx
+++ b/packages/shared/src/wallet/FormattedAddress.tsx
@@ -1,4 +1,4 @@
-import { type FC, Fragment } from 'react'
+import { Fragment } from 'react'
 import { identity } from 'lodash-es'
 
 export interface FormattedAddressProps {
@@ -7,7 +7,7 @@ export interface FormattedAddressProps {
     formatter?: (address: string, size?: number) => string
 }
 
-export const FormattedAddress: FC<FormattedAddressProps> = ({ address, size, formatter = identity }) => {
+export const FormattedAddress = ({ address, size, formatter = identity }: FormattedAddressProps) => {
     if (!address) return null
     return <Fragment>{formatter(address, size)}</Fragment>
 }

--- a/packages/shared/src/wallet/FormattedBalance.tsx
+++ b/packages/shared/src/wallet/FormattedBalance.tsx
@@ -24,7 +24,7 @@ export const FormattedBalance = (props: FormattedBalanceProps) => {
     let formatted = formatter(valueInt, decimals, significant)
     if (minimumBalance && !isZero(formatted) && isLessThan(valueInt, minimumBalance)) {
         // it's a BigNumber so it's ok
-
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         formatted = '<' + formatter(minimumBalance, decimals, significant).toString()
     }
     const { classes } = useStyles(undefined, { props })

--- a/packages/shared/src/wallet/FormattedBalance.tsx
+++ b/packages/shared/src/wallet/FormattedBalance.tsx
@@ -1,4 +1,4 @@
-import { type FC, Fragment } from 'react'
+import { Fragment } from 'react'
 import { BigNumber } from 'bignumber.js'
 import { isZero, isLessThan } from '@masknet/web3-shared-base'
 import { makeStyles } from '@masknet/theme'
@@ -18,13 +18,13 @@ export interface FormattedBalanceProps extends withClasses<'balance' | 'symbol'>
     formatter?: (value: BigNumber.Value, decimals?: number, significant?: number) => string
 }
 
-export const FormattedBalance: FC<FormattedBalanceProps> = (props) => {
+export const FormattedBalance = (props: FormattedBalanceProps) => {
     const { value, decimals, significant, symbol, minimumBalance, formatter = (value) => value } = props
     const valueInt = new BigNumber(value ?? '0').toFixed(0)
     let formatted = formatter(valueInt, decimals, significant)
     if (minimumBalance && !isZero(formatted) && isLessThan(valueInt, minimumBalance)) {
         // it's a BigNumber so it's ok
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+
         formatted = '<' + formatter(minimumBalance, decimals, significant).toString()
     }
     const { classes } = useStyles(undefined, { props })

--- a/packages/shared/src/wallet/FormattedCurrency.tsx
+++ b/packages/shared/src/wallet/FormattedCurrency.tsx
@@ -1,4 +1,4 @@
-import { type FC, Fragment } from 'react'
+import { Fragment } from 'react'
 import type { BigNumber } from 'bignumber.js'
 
 export interface FormattedCurrencyProps {
@@ -7,12 +7,12 @@ export interface FormattedCurrencyProps {
     formatter?: (value: BigNumber.Value, sign?: string) => string
 }
 
-export const FormattedCurrency: FC<FormattedCurrencyProps> = ({
+export const FormattedCurrency = ({
     value,
     sign,
     // it's a BigNumber so it's ok
     // eslint-disable-next-line @typescript-eslint/no-base-to-string
     formatter = (value, sign) => `${sign} ${value}`.trim(),
-}) => {
+}: FormattedCurrencyProps) => {
     return <Fragment>{formatter(value, sign)}</Fragment>
 }

--- a/packages/theme/src/Components/Boundary/index.tsx
+++ b/packages/theme/src/Components/Boundary/index.tsx
@@ -1,13 +1,12 @@
 import {
     cloneElement,
     createContext,
-    type FC,
     memo,
-    type ReactElement,
     type RefObject,
     useContext,
     useMemo,
     useRef,
+    type ReactElement,
 } from 'react'
 
 interface Options {
@@ -19,10 +18,11 @@ const BoundaryContext = createContext<Options>({
 })
 
 interface BoundaryProps {
+    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
     children: ReactElement
 }
 
-export const Boundary: FC<BoundaryProps> = memo(({ children }) => {
+export const Boundary = memo(({ children }: BoundaryProps) => {
     const boundaryRef = useRef<HTMLElement>(null)
     const contextValue = useMemo(() => ({ boundaryRef }), [boundaryRef.current])
     return (

--- a/packages/theme/src/Components/Boundary/index.tsx
+++ b/packages/theme/src/Components/Boundary/index.tsx
@@ -18,7 +18,8 @@ const BoundaryContext = createContext<Options>({
 })
 
 interface BoundaryProps {
-    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/ban-types
     children: ReactElement
 }
 

--- a/packages/theme/src/Components/FolderTabs/index.tsx
+++ b/packages/theme/src/Components/FolderTabs/index.tsx
@@ -1,4 +1,4 @@
-import { Children, type FC, useState, type HTMLProps, type ReactElement } from 'react'
+import { Children, useState, type HTMLProps, type ReactElement, type ComponentType } from 'react'
 import { makeStyles } from '../../UIHelper/makeStyles.js'
 import { MaskColorVar } from '../../CSSVariables/index.js'
 
@@ -61,16 +61,17 @@ interface TabPanelProps extends HTMLProps<HTMLDivElement> {
     value?: number | string
 }
 
-export const FolderTabPanel: FC<TabPanelProps> = ({ className, ...rest }) => {
+export const FolderTabPanel = ({ className, ...rest }: TabPanelProps) => {
     const { classes, cx } = useStyles()
     return <div className={cx(classes.tabPanel, className)} role="tabpanel" {...rest} />
 }
 
-type TabPanelReactElement = ReactElement<TabPanelProps, FC<TabPanelProps>>
+// eslint-disable-next-line @typescript-eslint/ban-types this is a subtype of ReactElement
+type TabPanelReactElement = ReactElement<TabPanelProps, ComponentType<TabPanelProps>>
 
-interface FolderTabsProps extends HTMLProps<HTMLDivElement> {}
+interface FolderTabsProps extends Pick<HTMLProps<HTMLDivElement>, 'defaultValue' | 'children'> {}
 
-export const FolderTabs: FC<FolderTabsProps> = ({ children: childNodes, defaultValue = 0, ...rest }) => {
+export const FolderTabs = ({ children: childNodes, defaultValue = 0 }: FolderTabsProps) => {
     const { classes, cx } = useStyles()
     const [value, setValue] = useState(defaultValue)
     const tabs = Children.map(childNodes as TabPanelReactElement[], (child, index) => {

--- a/packages/theme/src/Components/FolderTabs/index.tsx
+++ b/packages/theme/src/Components/FolderTabs/index.tsx
@@ -1,4 +1,4 @@
-import { Children, useState, type HTMLProps, type ReactElement, type ComponentType } from 'react'
+import { Children, useState, type HTMLProps, type ComponentType, type ReactElement } from 'react'
 import { makeStyles } from '../../UIHelper/makeStyles.js'
 import { MaskColorVar } from '../../CSSVariables/index.js'
 
@@ -66,7 +66,8 @@ export const FolderTabPanel = ({ className, ...rest }: TabPanelProps) => {
     return <div className={cx(classes.tabPanel, className)} role="tabpanel" {...rest} />
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types this is a subtype of ReactElement
+// this is a subtype of ReactElement
+// eslint-disable-next-line @typescript-eslint/ban-types
 type TabPanelReactElement = ReactElement<TabPanelProps, ComponentType<TabPanelProps>>
 
 interface FolderTabsProps extends Pick<HTMLProps<HTMLDivElement>, 'defaultValue' | 'children'> {}

--- a/packages/theme/src/Components/SearchableList/MaskSearchableItemInList.tsx
+++ b/packages/theme/src/Components/SearchableList/MaskSearchableItemInList.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import type { PropsWithChildren } from 'react'
 
-interface FixSizeListItemProps<T> extends React.PropsWithChildren<{}> {
+interface FixSizeListItemProps<T> extends PropsWithChildren<{}> {
     data: {
         dataSet: T[]
         onSelect: any
@@ -9,7 +9,7 @@ interface FixSizeListItemProps<T> extends React.PropsWithChildren<{}> {
     style: any
 }
 
-export interface MaskSearchableListItemProps<T> extends React.PropsWithChildren<{}> {
+export interface MaskSearchableListItemProps<T> extends PropsWithChildren<{}> {
     data: T
     index: number
     onSelect(item: T): void

--- a/packages/theme/src/Components/TextOverflowTooltip/index.tsx
+++ b/packages/theme/src/Components/TextOverflowTooltip/index.tsx
@@ -1,14 +1,15 @@
 import { Tooltip as MuiTooltip, type TooltipProps } from '@mui/material'
-import { cloneElement, memo, type FC, type ReactElement } from 'react'
+import { cloneElement, memo, type ReactElement, type ReactNode } from 'react'
 import type { ShadowRootTooltip } from '../../entry.js'
 import { useDetectOverflow } from '../../hooks/index.js'
 
 interface TextOverflowTooltipProps extends TooltipProps {
     as?: typeof MuiTooltip | typeof ShadowRootTooltip
+    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
     children: ReactElement
 }
 
-export const TextOverflowTooltip: FC<TextOverflowTooltipProps> = memo(({ children, as, ...rest }) => {
+export const TextOverflowTooltip = memo(({ children, as, ...rest }: TextOverflowTooltipProps) => {
     const [overflow, ref] = useDetectOverflow()
 
     const Tooltip = as ?? MuiTooltip

--- a/packages/theme/src/Components/TextOverflowTooltip/index.tsx
+++ b/packages/theme/src/Components/TextOverflowTooltip/index.tsx
@@ -1,11 +1,12 @@
 import { Tooltip as MuiTooltip, type TooltipProps } from '@mui/material'
-import { cloneElement, memo, type ReactElement, type ReactNode } from 'react'
+import { cloneElement, memo, type ReactElement } from 'react'
 import type { ShadowRootTooltip } from '../../entry.js'
 import { useDetectOverflow } from '../../hooks/index.js'
 
 interface TextOverflowTooltipProps extends TooltipProps {
     as?: typeof MuiTooltip | typeof ShadowRootTooltip
-    // eslint-disable-next-line @typescript-eslint/ban-types cloneElement is used.
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/ban-types
     children: ReactElement
 }
 

--- a/packages/typed-message/react/src/Metadata/index.ts
+++ b/packages/typed-message/react/src/Metadata/index.ts
@@ -1,6 +1,6 @@
 import type { TypedMessage } from '@masknet/typed-message'
 import { type Result, Ok, Err, Some, type Option, None } from 'ts-results-es'
-import type { ReactElement, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import z_schema from 'z-schema'
 import { produce, enableMapSet, type Draft } from 'immer'
 
@@ -72,7 +72,7 @@ export function isDataMatchJSONSchema(data: any, jsonSchema: object) {
  * @param metadataReader A metadata reader (can be return value of createTypedMessageMetadataReader)
  */
 export function createRenderWithMetadata<T>(metadataReader: (meta: TypedMessage['meta']) => Result<T, void>) {
-    return (metadata: TypedMessage['meta'], render: (data: T) => ReactElement | null): ReactElement | null => {
+    return (metadata: TypedMessage['meta'], render: (data: T) => ReactNode | null): ReactNode | null => {
         const message = metadataReader(metadata)
         if (message.ok) return render(message.val)
         return null

--- a/packages/web3-hooks/base/src/Telemetry/index.tsx
+++ b/packages/web3-hooks/base/src/Telemetry/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useMemo, type ProviderProps } from 'react'
 import type { CommonOptions } from '@masknet/web3-telemetry/types'
 import { useChainContext, useNetworkContext } from '../useContext.js'
 import { useNetworkType } from '../useNetworkType.js'
@@ -7,7 +7,7 @@ import { useProviderType } from '../useProviderType.js'
 const Telemetry = createContext<CommonOptions>(null!)
 Telemetry.displayName = 'TelemetryContext'
 
-export function TelemetryProvider({ value, children }: Partial<React.ProviderProps<CommonOptions>>) {
+export function TelemetryProvider({ value, children }: Partial<ProviderProps<CommonOptions>>) {
     const { pluginID } = useNetworkContext()
     const { account, chainId } = useChainContext()
 

--- a/packages/web3-hooks/base/src/useContext.tsx
+++ b/packages/web3-hooks/base/src/useContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, type ReactNode, useContext, useState, useMemo } from 'react'
+import React, { createContext, type ReactNode, useContext, useState, useMemo, type ProviderProps } from 'react'
 import { isUndefined, omitBy } from 'lodash-es'
 import type { WebExtensionMessage } from '@dimensiondev/holoflows-kit'
 import { compose, type MaskEvents, type NetworkPluginID } from '@masknet/shared-base'
@@ -42,11 +42,11 @@ NetworkContext.displayName = 'NetworkContext'
 const ChainContext = createContext<ChainContextGetter & ChainContextSetter>(null!)
 ChainContext.displayName = 'ChainContext'
 
-export function EnvironmentContextProvider({ value, children }: React.ProviderProps<EnvironmentContext>) {
+export function EnvironmentContextProvider({ value, children }: ProviderProps<EnvironmentContext>) {
     return <EnvironmentContext.Provider value={value}>{children}</EnvironmentContext.Provider>
 }
 
-export function NetworkContextProvider({ value, children }: React.ProviderProps<NetworkPluginID>) {
+export function NetworkContextProvider({ value, children }: ProviderProps<NetworkPluginID>) {
     const [pluginID = value, setPluginID] = useState<NetworkPluginID>()
     const context = useMemo(
         () => ({
@@ -58,7 +58,7 @@ export function NetworkContextProvider({ value, children }: React.ProviderProps<
     return <NetworkContext.Provider value={context}>{children}</NetworkContext.Provider>
 }
 
-export function ChainContextProvider({ value, children }: React.ProviderProps<ChainContextGetter>) {
+export function ChainContextProvider({ value, children }: ProviderProps<ChainContextGetter>) {
     const { pluginID } = useNetworkContext()
     const { controlled } = value
 
@@ -95,7 +95,7 @@ export function ChainContextProvider({ value, children }: React.ProviderProps<Ch
 export function Web3ContextProvider({
     value,
     children,
-}: React.ProviderProps<
+}: ProviderProps<
     {
         pluginID: NetworkPluginID
         messages?: WebExtensionMessage<MaskEvents>

--- a/packages/web3-providers/src/GoPlusLabs/types.ts
+++ b/packages/web3-providers/src/GoPlusLabs/types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { SecurityAPI } from '../entry-types.js'
 
 export interface GoPlusSpender {
@@ -47,7 +48,7 @@ export interface NFTSpenderInfo {
     address: string
     amount: string
     name: string
-    logo: React.ReactNode | undefined
+    logo: ReactNode | undefined
     contract: {
         address: string
         name: string

--- a/packages/web3-providers/src/Rabby/types.ts
+++ b/packages/web3-providers/src/Rabby/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 export interface RawTokenSpender {
     id: string
     address: string
@@ -33,7 +35,7 @@ export type TokenInfo = Omit<RawTokenInfo, 'spenders'>
 export type TokenSpender = Omit<RawTokenSpender, 'protocol'> & {
     tokenInfo: TokenInfo
     name: string | undefined
-    logo: React.ReactNode | undefined
+    logo: ReactNode | undefined
     isMaskDapp: boolean
 }
 

--- a/packages/web3-shared/base/src/specs/index.ts
+++ b/packages/web3-shared/base/src/specs/index.ts
@@ -13,6 +13,7 @@ import type {
     SocialIdentity,
     SocialAccount,
 } from '@masknet/shared-base'
+import type { ComponentType, ReactNode } from 'react'
 
 export enum CurrencyType {
     NATIVE = 'native',
@@ -548,7 +549,7 @@ export interface FungibleTokenSpender<ChainId, SchemaType> {
     /** spender name */
     name: string | undefined
     /** spender logo */
-    logo: React.ReactNode | undefined
+    logo: ReactNode | undefined
     /** allowance token amount of this spender */
     amount?: number
     /** allowance token amount(not formatted by token decimals) of this spender */
@@ -563,7 +564,7 @@ export interface NonFungibleContractSpender<ChainId, SchemaType> {
     contract: Pick<NonFungibleTokenContract<ChainId, SchemaType>, 'name' | 'address'>
     address: string
     name: string | undefined
-    logo: React.ReactNode | undefined
+    logo: ReactNode | undefined
 }
 
 /**
@@ -1077,7 +1078,7 @@ export interface Web3State<ChainId, SchemaType, ProviderType, NetworkType, Trans
 export interface NetworkIconClickBaitProps<ChainId, ProviderType, NetworkType> {
     network: NetworkDescriptor<ChainId, NetworkType>
     provider?: ProviderDescriptor<ChainId, ProviderType>
-    children?: React.ReactNode
+    children?: ReactNode
     onClick?: (
         network: NetworkDescriptor<ChainId, NetworkType>,
         provider?: ProviderDescriptor<ChainId, ProviderType>,
@@ -1086,7 +1087,7 @@ export interface NetworkIconClickBaitProps<ChainId, ProviderType, NetworkType> {
 
 export interface ProviderIconClickBaitProps<ChainId, ProviderType, NetworkType> {
     provider: ProviderDescriptor<ChainId, ProviderType>
-    children?: React.ReactNode
+    children?: ReactNode
     onClick?: (
         network: NetworkDescriptor<ChainId, NetworkType>,
         provider: ProviderDescriptor<ChainId, ProviderType>,
@@ -1101,12 +1102,12 @@ export interface AddressFormatterProps {
 export interface Web3UI<ChainId, ProviderType, NetworkType> {
     SelectNetworkMenu?: {
         /** This UI will receive network icon as children component, and the plugin may hook click handle on it. */
-        NetworkIconClickBait?: React.ComponentType<NetworkIconClickBaitProps<ChainId, ProviderType, NetworkType>>
+        NetworkIconClickBait?: ComponentType<NetworkIconClickBaitProps<ChainId, ProviderType, NetworkType>>
     }
     SelectProviderDialog?: {
         /** This UI will receive network icon as children component, and the plugin may hook click handle on it. */
-        NetworkIconClickBait?: React.ComponentType<NetworkIconClickBaitProps<ChainId, ProviderType, NetworkType>>
+        NetworkIconClickBait?: ComponentType<NetworkIconClickBaitProps<ChainId, ProviderType, NetworkType>>
         /** This UI will receive provider icon as children component, and the plugin may hook click handle on it. */
-        ProviderIconClickBait?: React.ComponentType<ProviderIconClickBaitProps<ChainId, ProviderType, NetworkType>>
+        ProviderIconClickBait?: ComponentType<ProviderIconClickBaitProps<ChainId, ProviderType, NetworkType>>
     }
 }


### PR DESCRIPTION
mf-0000

React.FC makes it impossible to declare a component with generics. To make our code consistent in style, we should only use the function declaration instead of React.FC.

React.ReactElement is usually wrong. You'd always want to use React.ReactNode. This should only be allowed when cloneElement is used.