### PR TITLE
add IDE-extension to improve DX(i18n) in code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,8 @@
         "dbaeumer.vscode-eslint",
         "aaron-bond.better-comments",
         "davidanson.vscode-markdownlint",
-        "christian-kohler.path-intellisense"
+        "christian-kohler.path-intellisense",
+        "inlang.vs-code-extension"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -7,7 +7,7 @@ export async function defineConfig(env) {
 	)
 
 	return {
-		referenceLanguage: "en",
+		referenceLanguage: "en-US",
 		plugins: [
 			i18nextPlugin({
 				pathPattern: "./packages/shared/src/locales/{language}.json",

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -11,6 +11,7 @@ export async function defineConfig(env) {
 		plugins: [
 			i18nextPlugin({
 				pathPattern: "./packages/shared/src/locales/{language}.json",
+                ignore: ["qya-AA.json"]
 			}),
             standardLintRules(),
 		],

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,18 @@
+export async function defineConfig(env) {
+	const { default: i18nextPlugin } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@2/dist/index.js",
+	)
+  const { default: standardLintRules } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-standard-lint-rules@3/dist/index.js",
+	)
+
+	return {
+		referenceLanguage: "en",
+		plugins: [
+			i18nextPlugin({
+				pathPattern: "./packages/shared/src/locales/{language}.json",
+			}),
+            standardLintRules(),
+		],
+	}
+}

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -10,7 +10,7 @@ export async function defineConfig(env) {
 		referenceLanguage: "en-US",
 		plugins: [
 			i18nextPlugin({
-				pathPattern: "./packages/shared/src/locales/{language}.json",
+				pathPattern: "./packages/mask/shared-ui/locales/{language}.json",
                 ignore: ["qya-AA.json"]
 			}),
             standardLintRules(),


### PR DESCRIPTION
## Description

In order to use the i18n [IDE-extension](https://inlang.com/documentation/apps/ide-extension) of `inlang` a changed to following files:
- Added inlang.config.js 
- Added extensions to recommendations

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Previews

Extract the message to add it to the .json translation files.
![image](https://github.com/DimensionDev/Maskbook/assets/58360188/c0d872d2-1463-4d6e-a12a-99f00f057ecf)

Inline Annotations to see the language string of the default language:
![image](https://github.com/DimensionDev/Maskbook/assets/58360188/05d8b656-d514-471b-a6a4-e5694ea2209e)

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
