### PR TITLE
fix: fetch headers for twitter api

### DIFF
--- a/packages/web3-providers/src/Twitter/apis/getTokens.ts
+++ b/packages/web3-providers/src/Twitter/apis/getTokens.ts
@@ -82,9 +82,7 @@ export async function getHeaders(overrides?: Record<string, string>) {
     return {
         authorization: `Bearer ${bearerToken}`,
         'x-csrf-token': csrfToken,
-        'content-type': 'application/json',
         'x-twitter-auth-type': 'OAuth2Session',
-        'x-twitter-active-user': 'yes',
         referer: 'https://twitter.com/',
         ...overrides,
     }

--- a/packages/web3-providers/src/Twitter/index.ts
+++ b/packages/web3-providers/src/Twitter/index.ts
@@ -81,9 +81,7 @@ export class TwitterAPI implements TwitterBaseAPI.Provider {
     }
 
     async uploadUserAvatar(screenName: string, image: File | Blob): Promise<TwitterBaseAPI.TwitterResult> {
-        const headers = await getHeaders({
-            referer: `https://twitter.com/${screenName}`,
-        })
+        const headers = await getHeaders()
 
         // INIT
         const initURL = `${UPLOAD_AVATAR_URL}?command=INIT&total_bytes=${image.size}&media_type=${encodeURIComponent(


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes mf-4364

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
