### PR TITLE
fix: bugfix for mnemonic print in dark mode

### DIFF
--- a/packages/dashboard/src/components/SetupFrame/index.tsx
+++ b/packages/dashboard/src/components/SetupFrame/index.tsx
@@ -32,7 +32,7 @@ export const SetupFrame = memo<SetupFrameProps>(({ children, hiddenSpline }) => 
                                 fontSize={36}
                                 fontWeight={700}
                                 lineHeight={1.2}
-                                color={theme.palette.maskColor.main}
+                                color={theme.palette.maskColor.publicMain}
                                 display="flex"
                                 width="70%"
                                 justifyContent="center">

--- a/packages/dashboard/src/pages/SetupPersona/Mnemonic/ComponentToPrint.tsx
+++ b/packages/dashboard/src/pages/SetupPersona/Mnemonic/ComponentToPrint.tsx
@@ -63,6 +63,17 @@ const useStyles = makeStyles()((theme) => ({
         alignItems: 'center',
         columnGap: 12,
     },
+    wordCard: {
+        backgroundColor: theme.palette.maskColor.publicBg,
+        color: theme.palette.maskColor.publicThird,
+        '&::marker': {
+            backgroundColor: theme.palette.maskColor.publicBg,
+            color: theme.palette.maskColor.publicThird,
+        },
+    },
+    text: {
+        color: theme.palette.maskColor.publicMain,
+    },
 }))
 
 export const ComponentToPrint = forwardRef((props: ComponentToPrintProps, ref: ForwardedRef<any>) => {
@@ -92,7 +103,7 @@ export const ComponentToPrint = forwardRef((props: ComponentToPrintProps, ref: F
                 <QRCode value={qrValue} ecLevel="L" size={136} quietZone={6} />
             </Box>
             <Typography className={classes.title}>{t.create_account_identity_id()}</Typography>
-            <Words words={words} />
+            <Words words={words} classes={{ text: classes.text, wordCard: classes.wordCard }} />
             <Typography className={classes.tips}>
                 <Icons.Info color="light" size={20} />
                 {t.print_tips()}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-0000

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
