### PR TITLE
chore: set getTelemetryID timeout longer

### DIFF
--- a/packages/mask/src/initialization/telemetry.ts
+++ b/packages/mask/src/initialization/telemetry.ts
@@ -2,7 +2,7 @@ import { TelemetryID } from '../../../shared-base/src/Telemetry/index.js'
 import Services from '../extension/service.js'
 import { timeout } from '@masknet/kit'
 
-await timeout(
-    Services.Helper.getTelemetryID().then((id) => (TelemetryID.value = id)),
-    100,
-).catch(console.error)
+const task = Services.Helper.getTelemetryID().then((id) => {
+    TelemetryID.value = id
+})
+await timeout(task, 1000, 'Services.Helper.getTelemetryID timed out').catch(console.error)

--- a/packages/mask/src/initialization/telemetry.ts
+++ b/packages/mask/src/initialization/telemetry.ts
@@ -1,8 +1,14 @@
 import { TelemetryID } from '../../../shared-base/src/Telemetry/index.js'
 import Services from '../extension/service.js'
-import { timeout } from '@masknet/kit'
+import { delay } from '@masknet/kit'
 
+const timeStart = Date.now()
 const task = Services.Helper.getTelemetryID().then((id) => {
     TelemetryID.value = id
+    const timeEnd = Date.now()
+    if (timeEnd - timeStart > 500) {
+        console.warn(`Services.Helper.getTelemetryID took ${timeEnd - timeStart}ms.`)
+    }
 })
-await timeout(task, 1000, 'Services.Helper.getTelemetryID timed out').catch(console.error)
+
+await Promise.race([delay(500), task])


### PR DESCRIPTION
mf-0000

the original limit seems too short (100ms). I don't know why the startup is so slow, maybe related to the heavy initialization cost.