### PR TITLE
chore: aurora use ethereum as native token

### DIFF
--- a/packages/web3-constants/evm/coingecko.json
+++ b/packages/web3-constants/evm/coingecko.json
@@ -44,7 +44,7 @@
         "Avalanche_Fuji": "",
         "Celo": "celo",
         "Fantom": "fantom",
-        "Aurora": "aurora-near",
+        "Aurora": "ethereum",
         "Aurora_Testnet": "",
         "Conflux": "conflux-token",
         "Astar": "astar"


### PR DESCRIPTION
MF-0000