### PR TITLE
chore: let shadowRootInit be open when there is no browser API

### DIFF
--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -112,7 +112,6 @@ function Configuration(env, argv) {
                 'process.nextTick': require.resolve('next-tick'),
             }),
             new webpack.DefinePlugin({
-                'process.env.MASK_APP': 'true',
                 'process.env.WEB3_CONSTANTS_RPC': process.env.WEB3_CONSTANTS_RPC ?? '{}',
                 'process.env.MASK_SENTRY_DSN': process.env.MASK_SENTRY_DSN ?? '{}',
                 'process.env.NODE_DEBUG': 'undefined',

--- a/packages/flags/package.json
+++ b/packages/flags/package.json
@@ -16,7 +16,8 @@
       }
     },
     "types": "./dist/index.d.ts",
-    "devDependencies": {
-      "urlcat": "^3.1.0"
+    "dependencies": {
+      "urlcat": "^3.1.0",
+      "@dimensiondev/holoflows-kit": "0.9.0-20230307045856-46252fb"
     }
   }

--- a/packages/flags/src/flags/index.ts
+++ b/packages/flags/src/flags/index.ts
@@ -1,17 +1,24 @@
 import { env } from './buildInfo.js'
+import { Environment, isEnvironment } from '@dimensiondev/holoflows-kit'
 
-const testOnly = process.env.NODE_ENV === 'test'
-const devOnly = process.env.NODE_ENV === 'development'
-const prodOnly = process.env.NODE_ENV === 'production'
-const insiderOnly = env.channel === 'insider' || devOnly
-const betaOrInsiderOnly = insiderOnly || env.channel === 'beta'
+const isTest = process.env.NODE_ENV === 'test'
+const isDev = process.env.NODE_ENV === 'development'
+const isProd = process.env.NODE_ENV === 'production'
+const isInsider = env.channel === 'insider' || isDev
+const isBeta = isInsider || env.channel === 'beta'
 
 export const flags = {
-    mask_SDK_ready: betaOrInsiderOnly,
-    support_testnet_switch: betaOrInsiderOnly,
+    mask_SDK_ready: isBeta,
+    support_testnet_switch: isBeta,
 
     shadowRootInit: {
-        mode: '__REACT_DEVTOOLS_GLOBAL_HOOK__' in globalThis || betaOrInsiderOnly || testOnly ? 'open' : 'closed',
+        mode:
+            '__REACT_DEVTOOLS_GLOBAL_HOOK__' in globalThis ||
+            isBeta ||
+            isTest ||
+            !isEnvironment(Environment.HasBrowserAPI)
+                ? 'open'
+                : 'closed',
         delegatesFocus: true,
     } as const satisfies ShadowRootInit,
 
@@ -20,32 +27,32 @@ export const flags = {
     sandboxedPluginRuntime: false,
 
     // sentry
-    sentry_earliest_version: env.VERSION || env.VERSION,
+    sentry_earliest_version: env.VERSION,
     sentry_sample_rate: 0.05,
-    sentry_enabled: prodOnly,
-    sentry_event_enabled: prodOnly,
-    sentry_exception_enabled: prodOnly,
-    sentry_fetch_transaction_enabled: prodOnly,
-    sentry_async_transaction_enabled: devOnly,
+    sentry_enabled: isProd,
+    sentry_event_enabled: isProd,
+    sentry_exception_enabled: isProd,
+    sentry_fetch_transaction_enabled: isProd,
+    sentry_async_transaction_enabled: isDev,
 
     // mixpanel
-    mixpanel_earliest_version: env.VERSION || env.VERSION,
+    mixpanel_earliest_version: env.VERSION,
     mixpanel_sample_rate: 1,
-    mixpanel_enabled: prodOnly,
-    mixpanel_event_enabled: prodOnly,
-    mixpanel_exception_enabled: prodOnly,
+    mixpanel_enabled: isProd,
+    mixpanel_event_enabled: isProd,
+    mixpanel_exception_enabled: isProd,
     mixpanel_project_token: 'b815b822fd131650e92ff8539eb5e793',
 
     // wallet connect
     wc_v1_bridge_url: 'https://bridge.walletconnect.org',
     wc_v2_relay_url: 'wss://relay.walletconnect.com',
     wc_v2_project_id: '8f1769933420afe8873860925fcca14f',
-    wc_v2_mode: process.env.NODE_ENV === 'production' ? 'error' : 'debug',
+    wc_v2_mode: isProd ? 'error' : 'debug',
     wc_v1_enabled: true,
     wc_v2_enabled: false,
 } as const
 
 Object.freeze(flags.shadowRootInit)
 if (process.env.NODE_ENV === 'development') {
-    console.log('Mask Network starts with flags:', flags)
+    console.log('[mask] flags:', flags)
 }

--- a/packages/polyfills/types/env.d.ts
+++ b/packages/polyfills/types/env.d.ts
@@ -2,7 +2,6 @@
 declare module NodeJS {
     interface ProcessEnv {
         readonly NODE_ENV: 'development' | 'production' | 'test'
-        readonly MASK_APP: boolean
         readonly MASK_SENTRY_DSN: string
         /**
          * Run skip tests like

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -112,7 +112,7 @@ importers:
     dependencies:
       '@dimensiondev/holoflows-kit':
         specifier: 0.9.0-20230307045856-46252fb
-        version: 0.9.0-20230307045856-46252fb
+        version: 0.9.0-20230307045856-46252fb(@types/webextension-polyfill@0.10.1)
       '@emotion/cache':
         specifier: 11.10.3
         version: 11.10.3(patch_hash=anquw7u43yedhv6g6kmhzkdhze)
@@ -275,7 +275,7 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@4.9.5)
+        version: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@5.2.0-dev.20230630)
       typescript:
         specifier: 5.2.0-dev.20230630
         version: 5.2.0-dev.20230630
@@ -841,7 +841,10 @@ importers:
         version: 0.17.4
 
   packages/flags:
-    devDependencies:
+    dependencies:
+      '@dimensiondev/holoflows-kit':
+        specifier: 0.9.0-20230307045856-46252fb
+        version: 0.9.0-20230307045856-46252fb(@types/webextension-polyfill@0.10.1)
       urlcat:
         specifier: ^3.1.0
         version: 3.1.0(patch_hash=5r5xyq4zgcnqugwsrx4lxq2i4e)
@@ -7854,7 +7857,7 @@ packages:
       '@msgpack/msgpack': 1.12.2
     dev: false
 
-  /@dimensiondev/holoflows-kit@0.9.0-20230307045856-46252fb:
+  /@dimensiondev/holoflows-kit@0.9.0-20230307045856-46252fb(@types/webextension-polyfill@0.10.1):
     resolution: {integrity: sha512-SprqopLhwmps3Zjrr/fsl+kPmYv6hEc9gZvF3EDtr4v2D2zj1PUkUwktku7fBgzvidivOxyarsLGgGorzhsK6Q==, tarball: https://npm.pkg.github.com/download/@DimensionDev/holoflows-kit/0.9.0-20230307045856-46252fb/70734fddff9acedef83c8f3925fd0ae615c00be7}
     peerDependencies:
       '@types/webextension-polyfill': ^0.10.0
@@ -7863,6 +7866,7 @@ packages:
         optional: true
     dependencies:
       '@servie/events': 3.0.0
+      '@types/webextension-polyfill': 0.10.1
       event-iterator: 2.0.0
       lodash-es: 4.17.21
       tslib: 2.6.0
@@ -10772,6 +10776,45 @@ packages:
     engines: {node: '>=14'}
     optional: true
 
+  /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.11.0)(webpack@5.88.0):
+    resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      '@types/webpack': 4.x || 5.x
+      react-refresh: '>=0.10.0 <1.0.0'
+      sockjs-client: ^1.4.0
+      type-fest: '>=0.17.0 <4.0.0'
+      webpack: '>=4.43.0 <6.0.0'
+      webpack-dev-server: 3.x || 4.x
+      webpack-hot-middleware: 2.x
+      webpack-plugin-serve: 0.x || 1.x
+    peerDependenciesMeta:
+      '@types/webpack':
+        optional: true
+      sockjs-client:
+        optional: true
+      type-fest:
+        optional: true
+      webpack-dev-server:
+        optional: true
+      webpack-hot-middleware:
+        optional: true
+      webpack-plugin-serve:
+        optional: true
+    dependencies:
+      ansi-html-community: 0.0.8
+      common-path-prefix: 3.0.0
+      core-js-pure: 3.26.1
+      error-stack-parser: 2.1.4
+      find-up: 5.0.0
+      html-entities: 2.3.3
+      loader-utils: 2.0.4
+      react-refresh: 0.11.0
+      schema-utils: 3.2.0
+      source-map: 0.7.4
+      webpack: 5.88.0(@swc/core@1.3.70)
+    dev: true
+
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0)(webpack-dev-server@4.15.1)(webpack@5.88.0):
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
@@ -12714,7 +12757,7 @@ packages:
       '@babel/core': 7.22.9
       '@babel/preset-flow': 7.18.6(@babel/core@7.22.9)
       '@babel/preset-react': 7.18.6(@babel/core@7.22.9)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.14.0)(webpack-dev-server@4.15.1)(webpack@5.88.0)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.11.0)(webpack@5.88.0)
       '@storybook/addons': 6.5.13(react-dom@0.0.0-experimental-0a360642d-20230711)(react@0.0.0-experimental-0a360642d-20230711)
       '@storybook/builder-webpack5': 6.5.13(@swc/core@1.3.70)(eslint@8.45.0)(react-dom@0.0.0-experimental-0a360642d-20230711)(react@0.0.0-experimental-0a360642d-20230711)(typescript@5.2.0-dev.20230630)
       '@storybook/client-logger': 6.5.13
@@ -21992,7 +22035,7 @@ packages:
       solc: 0.7.3(debug@4.3.4)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@5.2.0-dev.20230630)
       tsort: 0.0.1
       typescript: 5.2.0-dev.20230630
       undici: 5.20.0
@@ -23899,7 +23942,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@5.2.0-dev.20230630)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -27829,7 +27872,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.26
-      ts-node: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@5.2.0-dev.20230630)
       yaml: 2.1.3
     dev: false
 
@@ -32056,6 +32099,7 @@ packages:
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
 
   /ts-node@10.9.1(@swc/core@1.3.70)(@types/node@20.4.2)(typescript@5.2.0-dev.20230630):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
@@ -32353,6 +32397,7 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /typescript@5.2.0-dev.20230630:
     resolution: {integrity: sha512-PpI4tXtyv86eAhapMWrJF5roAxswu022vmSjDRU7NzPqT5+DlBktIlDePOrBo7OUBWNVEiUfsWuoDNbq5Sjj6Q==}
@@ -32806,6 +32851,7 @@ packages:
     resolution: {integrity: sha512-qY6b94/aGMIHh70EEQ/4hfR2LUGZ+fPQNp64cf7yRX9kAp4XG2tx7LgYUU1Qkh17bFylME0u4n3lOezonougPw==}
     dependencies:
       qs: 6.11.0
+    dev: false
     patched: true
 
   /use-subscription@1.6.0(react@0.0.0-experimental-0a360642d-20230711):


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes # (NO_ISSUE)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
