### PR TITLE
fix: parse quoted tweets

### DIFF
--- a/packages/mask/src/site-adaptors/twitter.com/utils/fetch.ts
+++ b/packages/mask/src/site-adaptors/twitter.com/utils/fetch.ts
@@ -124,15 +124,24 @@ export function postContentMessageParser(node: HTMLElement): TypedMessage {
             if (!alt) return makeTypedMessageEmpty()
 
             return makeTypedMessageText(alt)
+        } else if (node instanceof HTMLSpanElement) {
+            return makeTypedMessageText(node.textContent ?? '')
         } else if (node.childNodes.length) {
             const messages = makeTypedMessageTuple(flattenDeep(Array.from(node.childNodes).map(make)))
             return FlattenTypedMessage.NoContext(messages)
         } else return makeTypedMessageEmpty()
     }
     const lang = node.parentElement!.querySelector<HTMLDivElement>('[lang]')
-    return lang
+    const content = lang
         ? FlattenTypedMessage.NoContext(makeTypedMessageTuple(Array.from(lang.childNodes).flatMap(make)))
         : makeTypedMessageEmpty()
+
+    console.log('DEBUG: content')
+    console.log({
+        content,
+    })
+
+    return content
 }
 
 function getElementStyle(element: Element | null): Meta | undefined {

--- a/packages/mask/src/site-adaptors/twitter.com/utils/fetch.ts
+++ b/packages/mask/src/site-adaptors/twitter.com/utils/fetch.ts
@@ -132,11 +132,9 @@ export function postContentMessageParser(node: HTMLElement): TypedMessage {
         } else return makeTypedMessageEmpty()
     }
     const lang = node.parentElement!.querySelector<HTMLDivElement>('[lang]')
-    const content = lang
+    return lang
         ? FlattenTypedMessage.NoContext(makeTypedMessageTuple(Array.from(lang.childNodes).flatMap(make)))
         : makeTypedMessageEmpty()
-
-    return content
 }
 
 function getElementStyle(element: Element | null): Meta | undefined {

--- a/packages/mask/src/site-adaptors/twitter.com/utils/fetch.ts
+++ b/packages/mask/src/site-adaptors/twitter.com/utils/fetch.ts
@@ -136,11 +136,6 @@ export function postContentMessageParser(node: HTMLElement): TypedMessage {
         ? FlattenTypedMessage.NoContext(makeTypedMessageTuple(Array.from(lang.childNodes).flatMap(make)))
         : makeTypedMessageEmpty()
 
-    console.log('DEBUG: content')
-    console.log({
-        content,
-    })
-
     return content
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes [MF-5375](https://mask.atlassian.net/browse/MF-5375)

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.


[MF-5375]: https://mask.atlassian.net/browse/MF-5375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ