### PR TITLE
chore: remove hmr from profile

### DIFF
--- a/packages/mask/.webpack/flags.ts
+++ b/packages/mask/.webpack/flags.ts
@@ -54,6 +54,10 @@ export function normalizeBuildFlags(flags: BuildFlags): NormalizedFlags {
     if (!isAbsolute(outputPath)) outputPath = join(__dirname, '../../../', outputPath)
 
     if (mode === 'production') hmr = false
+    if (profiling) {
+        hmr = false
+        devtools = false
+    }
     if (!hmr) reactRefresh = false
 
     return {


### PR DESCRIPTION
mf-0000

This is NOT a performance optimization since it does not affect any production code. This PR makes the profile environment closer to the production environment.

- Modules: 2497 
- First module: 872.3000000715256 
- Total time: 687.1999999284744 
- Largest contentful paint: 1545.9000000953674
