### PR TITLE
refactor: improve useValueRef

### DIFF
--- a/packages/shared-base-ui/src/hooks/useValueRef.ts
+++ b/packages/shared-base-ui/src/hooks/useValueRef.ts
@@ -1,4 +1,4 @@
-import { useDebugValue, useEffect, useSyncExternalStore } from 'react'
+import { use, useDebugValue, useEffect, useSyncExternalStore } from 'react'
 import type { ValueRef, ValueRefJSON, ValueRefWithReady } from '@masknet/shared-base'
 import { useQuery } from '@tanstack/react-query'
 
@@ -6,13 +6,16 @@ function getServerSnapshot(): never {
     throw new Error('getServerSnapshot is not supported')
 }
 export function useValueRef<T>(ref: ValueRef<T>): T {
+    if ('readyPromise' in ref) {
+        const ref2 = ref as ValueRefWithReady<T>
+        if (!ref2.nowReady) use(ref2.readyPromise)
+    }
     return useSyncExternalStore(
         (f) => ref.addListener(f),
         () => ref.value,
         getServerSnapshot,
     )
 }
-
 export function useValueRefReactQuery<T>(key: `@@${string}`, ref: ValueRefWithReady<T>) {
     const { data, refetch } = useQuery({
         queryKey: [key],


### PR DESCRIPTION
mf-0000

now useValueRef will use Suspense to wait data load. This change is because I observed that `<GuideStep>` might accidentally render for already-setup users if useValueRef is not ready yet and returns a fallback value.