### PR TITLE
fix: don't activate on facebook share widget

### DIFF
--- a/packages/mask/content-script/site-adaptors/facebook.com/base.ts
+++ b/packages/mask/content-script/site-adaptors/facebook.com/base.ts
@@ -9,6 +9,7 @@ export const facebookBase: SiteAdaptor.Base = {
     networkIdentifier: EnhanceableSite.Facebook,
     declarativePermissions: { origins },
     shouldActivate(location) {
-        return location.hostname.endsWith('facebook.com')
+        //                                                   facebook share widget
+        return location.hostname.endsWith('facebook.com') && location.pathname !== '/v2.0/plugins/like.php'
     },
 }


### PR DESCRIPTION
MF-0000

<img width="427" alt="image" src="https://github.com/DimensionDev/Maskbook/assets/1141198/c09f66eb-c8b9-4583-9a2f-8b7e27068f62">
