### PR TITLE
fix: init plugin hub in popup

### DIFF
--- a/packages/mask/popups/components/NetworkSelector/index.tsx
+++ b/packages/mask/popups/components/NetworkSelector/index.tsx
@@ -3,12 +3,11 @@ import { Box, MenuItem, Typography } from '@mui/material'
 import { makeStyles } from '@masknet/theme'
 import type { ChainId, NetworkType, SchemaType } from '@masknet/web3-shared-evm'
 import { useChainContext, useNetworks, useWeb3State } from '@masknet/web3-hooks-base'
-import { ImageIcon, NetworkIcon, useMenuConfig } from '@masknet/shared'
+import { ImageIcon, NetworkIcon, TRADER_WEB3_CONFIG, useMenuConfig } from '@masknet/shared'
 import { Icons } from '@masknet/icons'
 import type { ReasonableNetwork } from '@masknet/web3-shared-base'
-import { NetworkPluginID, PluginID } from '@masknet/shared-base'
+import { NetworkPluginID } from '@masknet/shared-base'
 import { EVMWeb3 } from '@masknet/web3-providers'
-import { useActivatedPluginSiteAdaptor } from '@masknet/plugin-infra/content-script'
 import { first } from 'lodash-es'
 
 const useStyles = makeStyles()((theme) => ({
@@ -42,8 +41,7 @@ export const NetworkSelector = memo(() => {
     const networks = useNetworks(NetworkPluginID.PLUGIN_EVM)
     const { Network } = useWeb3State(NetworkPluginID.PLUGIN_EVM)
 
-    const traderDefinition = useActivatedPluginSiteAdaptor.visibility.useAnyMode(PluginID.Trader)
-    const chainIdList = traderDefinition?.enableRequirement.web3?.[NetworkPluginID.PLUGIN_EVM]?.supportedChainIds ?? []
+    const chainIdList = TRADER_WEB3_CONFIG[NetworkPluginID.PLUGIN_EVM]?.supportedChainIds ?? []
 
     const actualNetworks = useMemo(
         () => networks.filter((x) => chainIdList.includes(x.chainId)),

--- a/packages/plugin-infra/src/manager/site-adaptor.ts
+++ b/packages/plugin-infra/src/manager/site-adaptor.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { isEqual } from 'lodash-es'
 import { unreachable } from '@masknet/kit'
 import { useValueRef } from '@masknet/shared-base-ui'
-import { type EnhanceableSite, ValueRefWithReady } from '@masknet/shared-base'
+import { type EnhanceableSite, ValueRefWithReady, Sniffings } from '@masknet/shared-base'
 import { createManager } from './manage.js'
 import { getPluginDefine } from './store.js'
 import type { Plugin } from '../types.js'
@@ -16,6 +16,16 @@ events.on('activateChanged', () => (activatedSub.value = [...activated.plugins])
 
 const minimalModeSub = new ValueRefWithReady<string[]>([], isEqual)
 events.on('minimalModeChanged', () => (minimalModeSub.value = [...minimalMode]))
+
+/**
+ * On the popup page, the plugin is not loaded.
+ * So in order for the valueRef not to remain pending,
+ * manually assigning the value solves this problem
+ */
+if (Sniffings.is_popup_page) {
+    activatedSub.value = []
+    minimalModeSub.value = []
+}
 
 export function useActivatedPluginsSiteAdaptor(minimalModeEqualsTo: 'any' | boolean) {
     const minimalMode = useValueRef(minimalModeSub)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-0000

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
