### PR TITLE
fix: mf-6014 don't replace tweets that have embed images

### DIFF
--- a/packages/mask/content-script/site-adaptors/twitter.com/injection/PostReplacer.tsx
+++ b/packages/mask/content-script/site-adaptors/twitter.com/injection/PostReplacer.tsx
@@ -8,15 +8,19 @@ function resolveLangNode(node: HTMLElement) {
 }
 
 export function injectPostReplacerAtTwitter(signal: AbortSignal, current: PostInfo) {
-    const isPromotionPost = !!current.rootNode?.querySelector('svg path[d$="996V8h7v7z"]')
-    const isCollapsedPost = !!current.rootNode?.querySelector('[data-testid="tweet-text-show-more-link"]')
+    const rootNode = current.rootNode
+    if (!rootNode) return
+    const isPromotionPost = !!rootNode.querySelector('svg path[d$="996V8h7v7z"]')
+    const isCollapsedPost = !!rootNode.querySelector('[data-testid="tweet-text-show-more-link"]')
     if (isPromotionPost || isCollapsedPost) return
 
-    const hasVideo = !!current.rootNode?.closest('[data-testid="tweet"]')?.querySelector('video')
+    const hasVideo = !!rootNode.closest('[data-testid="tweet"]')?.querySelector('video')
     if (hasVideo) return
+    const hasEmbedImage = !!rootNode.querySelector('[data-testid="tweetText"] [data-testid="tweetPhoto"]')
+    if (hasEmbedImage) return
 
     const tags = Array.from(
-        current.rootNode?.querySelectorAll<HTMLAnchorElement>(
+        rootNode.querySelectorAll<HTMLAnchorElement>(
             ['a[role="link"][href*="cashtag_click"]', 'a[role="link"][href*="hashtag_click"]'].join(','),
         ) ?? [],
     )


### PR DESCRIPTION
close mf-6014
close mf-6242

this was made by @swkatmask in #11425 but for an unknown reason unmerged.
I have tested that this fixes the issue