### PR TITLE
fix: web tab injection

### DIFF
--- a/packages/mask/content-script/site-adaptors/twitter.com/utils/selector.ts
+++ b/packages/mask/content-script/site-adaptors/twitter.com/utils/selector.ts
@@ -16,7 +16,7 @@ export function querySelectorAll<T extends E>(selector: string) {
 export function searchProfileTabListLastChildSelector() {
     // :not(:has(a[href^="/i/"])) excludes tab list in trending page. See MF-6382
     return querySelector<E>(
-        '[data-testid="primaryColumn"] div + [role="navigation"][aria-label] [data-testid="ScrollSnap-List"]:not(:has(a[href^="/i/"])) div[role="presentation"]:last-of-type a[role="tab"]',
+        '[data-testid="primaryColumn"] nav[role="navigation"][aria-label] [data-testid="ScrollSnap-List"]:not(:has(a[href^="/i/"])) div[role="presentation"]:last-of-type a[role="tab"]',
     ).closest<E>(1)
 }
 export function nextTabListSelector() {
@@ -24,7 +24,7 @@ export function nextTabListSelector() {
 }
 export function searchProfileTabPageSelector() {
     return searchProfileTabListLastChildSelector()
-        .closest(5)
+        .closest(6)
         .querySelector<E>('section > div[aria-label]:not([role="progressbar"])')
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #MF-6595

## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
