### PR TITLE
fix(web3-providers): remove duplicate 'collect' and add missing 'borrow' in LiquidityOut type

### DIFF
--- a/packages/web3-providers/src/types/RSS3.ts
+++ b/packages/web3-providers/src/types/RSS3.ts
@@ -105,7 +105,7 @@ export namespace RSS3BaseAPI {
     // Uniswap like actions: add, collect, remove
     // Aave like actions: supply, withdraw, borrow, repay
     type LiquidityIn = 'supply' | 'add' | 'repay'
-    type LiquidityOut = 'withdraw' | 'collect' | 'remove' | 'collect'
+    type LiquidityOut = 'withdraw' | 'collect' | 'remove' | 'borrow'
     interface LiquidityMetadata {
         /**
          * @example "Uniswap V2"


### PR DESCRIPTION


## Description

The LiquidityOut type had 'collect' listed twice, which is redundant in TypeScript union types. 

According to the comment above indicating "Aave like actions: supply, withdraw, borrow, repay",  the 'borrow' action was missing from the LiquidityOut type definition. 

This fix removes the duplicate 'collect' and adds the missing 'borrow' action to properly represent all Aave  liquidity output operations.



## Type of change

<!-- Please remove options that are not relevant. -->

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

<!-- Please attach screenshots if there are any visual changes. -->

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
  - [ ] I have removed all in development `console.log`s
  - [ ] I have removed all commented code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

If this PR depends on external APIs:

- [ ] I have configured those APIs with CORS headers to let extension requests get passed. <!-- If you don't have permission to modify the server, please let us know it. -->
  - chrome extension: `chrome-extension://[id]`
  - firefox extension: `moz-extension://[id]`
- [ ] I have delegated all web requests to the background service via the internal RPC bridge.
