### PR TITLE
fix: verify chainId in tx based on provider

### DIFF
--- a/packages/mask/background/services/identity/persona/sign.ts
+++ b/packages/mask/background/services/identity/persona/sign.ts
@@ -1,5 +1,6 @@
 import { timeout } from '@masknet/kit'
 import { Signer } from '@masknet/web3-providers'
+import type { ChainId } from '@masknet/web3-shared-evm'
 import {
     type PersonaIdentifier,
     fromBase64URL,
@@ -43,6 +44,7 @@ export async function signWithPersona(
     identifier?: ECKeyIdentifier,
     origin?: string,
     silent = false,
+    chainId?: ChainId,
 ): Promise<string> {
     identifier = await getIdentifier(message.data, identifier, origin, silent)
 
@@ -50,5 +52,5 @@ export async function signWithPersona(
     const persona = (await queryPersonasWithPrivateKey()).find((x) => x.identifier === identifier)
     if (!persona?.privateKey.d) throw new Error('Persona not found')
 
-    return Signer.sign(message, Buffer.from(fromBase64URL(persona.privateKey.d)))
+    return Signer.sign(message, Buffer.from(fromBase64URL(persona.privateKey.d)), chainId)
 }

--- a/packages/mask/background/services/wallet/services/send.ts
+++ b/packages/mask/background/services/wallet/services/send.ts
@@ -1,6 +1,6 @@
 import type { JsonRpcRequest } from 'web3-types'
 import { ECKeyIdentifier, SignType } from '@masknet/shared-base'
-import { EVMRequestReadonly, EVMWeb3Readonly } from '@masknet/web3-providers'
+import { EVMRequestReadonly, EVMWalletProviders, EVMWeb3Readonly } from '@masknet/web3-providers'
 import {
     ChainId,
     createJsonRpcResponse,
@@ -25,13 +25,22 @@ export async function send(payload: JsonRpcRequest, options?: TransactionOptions
         signableMessage,
         signableTransaction,
     } = PayloadEditor.fromPayload(payload, options)
+    const isTransactionSigningMethod =
+        payload.method === EthereumMethodType.eth_sendTransaction ||
+        payload.method === EthereumMethodType.MASK_REPLACE_TRANSACTION ||
+        payload.method === EthereumMethodType.eth_signTransaction
+    const providerChainId =
+        options?.providerType && isTransactionSigningMethod ?
+            EVMWalletProviders[options.providerType].subscription.chainId.getCurrentValue()
+        :   undefined
+    const requestChainId = providerChainId ?? chainId
     const identifier = ECKeyIdentifier.from(options?.identifier).unwrapOr(undefined)
     const signTransaction = async (transaction: TransactionSerializable) => {
         const message = { type: SignType.Transaction as const, data: transaction }
         if (identifier) {
-            return signWithPersona(message, identifier)
+            return signWithPersona(message, identifier, undefined, false, providerChainId)
         } else {
-            return signWithWallet(message, owner || from!)
+            return signWithWallet(message, owner || from!, providerChainId)
         }
     }
     const signMessageOrTypedData = async (type: SignType.Message | SignType.TypedData, message: string) => {
@@ -47,12 +56,19 @@ export async function send(payload: JsonRpcRequest, options?: TransactionOptions
         case EthereumMethodType.eth_sendTransaction:
         case EthereumMethodType.MASK_REPLACE_TRANSACTION:
             if (!signableTransaction) throw new Error('No transaction to be sent.')
+            if (
+                providerChainId !== undefined &&
+                signableTransaction.chainId !== undefined &&
+                signableTransaction.chainId !== providerChainId
+            ) {
+                throw new Error('Chain ID mismatch.')
+            }
 
             try {
                 return createJsonRpcResponse(
                     pid,
                     await EVMWeb3Readonly.sendSignedTransaction(await signTransaction(signableTransaction), {
-                        chainId,
+                        chainId: requestChainId,
                         providerURL,
                     }),
                 )

--- a/packages/mask/background/services/wallet/services/wallet/index.ts
+++ b/packages/mask/background/services/wallet/services/wallet/index.ts
@@ -5,6 +5,7 @@ import { api } from '@dimensiondev/mask-wallet-core/proto'
 import { Signer } from '@masknet/web3-providers'
 import { ImportSource, toHex, type SignMessage, type Wallet } from '@masknet/shared-base'
 import { HD_PATH_WITHOUT_INDEX_ETHEREUM } from '@masknet/web3-shared-base'
+import type { ChainId } from '@masknet/web3-shared-evm'
 import * as Mask from '../maskwallet/index.js'
 import * as database from './database/index.js'
 import * as password from './password.js'
@@ -247,8 +248,8 @@ export async function resetAllWallets() {
     await database.resetAllWallets()
 }
 
-export async function signWithWallet(message: SignMessage, address: string) {
-    return Signer.sign(message, Buffer.from(toBytes(`0x${await exportPrivateKey(address)}`)))
+export async function signWithWallet(message: SignMessage, address: string, chainId?: ChainId) {
+    return Signer.sign(message, Buffer.from(toBytes(`0x${await exportPrivateKey(address)}`)), chainId)
 }
 
 export async function exportMnemonicWords(address: string, unverifiedPassword?: string) {

--- a/packages/web3-providers/src/Web3/EVM/apis/RequestAPI.ts
+++ b/packages/web3-providers/src/Web3/EVM/apis/RequestAPI.ts
@@ -1,4 +1,10 @@
-import { EthereumMethodType, PayloadEditor, type RequestArguments } from '@masknet/web3-shared-evm'
+import {
+    EthereumMethodType,
+    PayloadEditor,
+    type ChainId,
+    type RequestArguments,
+} from '@masknet/web3-shared-evm'
+import type { TransactionSerializable } from 'viem'
 import { Composer } from './ComposerAPI.js'
 import { evm } from '../../../Manager/registry.js'
 import { ConnectionOptionsAPI } from './ConnectionOptionsAPI.js'
@@ -8,6 +14,12 @@ import { EVMWalletProviders } from '../providers/index.js'
 import type { EVMConnectionOptions } from '../types/index.js'
 import { createWeb3FromProvider } from '../../../helpers/createWeb3FromProvider.js'
 import { createWeb3ProviderFromRequest } from '../../../helpers/createWeb3ProviderFromRequest.js'
+
+function assertTransactionChainId(transaction: TransactionSerializable | undefined, chainId: ChainId) {
+    if (!transaction) return
+    if (transaction.chainId !== undefined && transaction.chainId !== chainId)
+        throw new Error('Transaction chain id does not match current chain id.')
+}
 
 export class EVMRequestAPI extends EVMRequestReadonlyAPI {
     static override Default = new EVMRequestAPI()
@@ -46,7 +58,13 @@ export class EVMRequestAPI extends EVMRequestReadonlyAPI {
                                     context.write(await this.Provider?.disconnect(options.providerType))
                                     break
                                 default: {
-                                    if (!PayloadEditor.fromPayload(context.request).readonly) {
+                                    const payloadEditor = PayloadEditor.fromPayload(context.request)
+                                    if (!payloadEditor.readonly) {
+                                        assertTransactionChainId(
+                                            payloadEditor.signableTransaction,
+                                            EVMWalletProviders[options.providerType].subscription.chainId.getCurrentValue(),
+                                        )
+
                                         const web3Provider = EVMWalletProviders[
                                             options.providerType
                                         ].createWeb3Provider({

--- a/packages/web3-providers/src/Web3/EVM/apis/RequestAPI.ts
+++ b/packages/web3-providers/src/Web3/EVM/apis/RequestAPI.ts
@@ -1,9 +1,4 @@
-import {
-    EthereumMethodType,
-    PayloadEditor,
-    type ChainId,
-    type RequestArguments,
-} from '@masknet/web3-shared-evm'
+import { EthereumMethodType, PayloadEditor, type ChainId, type RequestArguments } from '@masknet/web3-shared-evm'
 import type { TransactionSerializable } from 'viem'
 import { Composer } from './ComposerAPI.js'
 import { evm } from '../../../Manager/registry.js'
@@ -62,7 +57,9 @@ export class EVMRequestAPI extends EVMRequestReadonlyAPI {
                                     if (!payloadEditor.readonly) {
                                         assertTransactionChainId(
                                             payloadEditor.signableTransaction,
-                                            EVMWalletProviders[options.providerType].subscription.chainId.getCurrentValue(),
+                                            EVMWalletProviders[
+                                                options.providerType
+                                            ].subscription.chainId.getCurrentValue(),
                                         )
 
                                         const web3Provider = EVMWalletProviders[

--- a/packages/web3-providers/src/Web3/EVM/apis/SignerAPI.ts
+++ b/packages/web3-providers/src/Web3/EVM/apis/SignerAPI.ts
@@ -1,10 +1,10 @@
 import defer * as _metamask_eth_sig_util from '@metamask/eth-sig-util'
-import { signTransaction } from '@masknet/web3-shared-evm'
+import { type ChainId, signTransaction } from '@masknet/web3-shared-evm'
 import { type SignMessage, SignType, toHex } from '@masknet/shared-base'
 import { unreachable } from '@masknet/kit'
 
 export class Signer {
-    static async sign({ type, data }: SignMessage, key: Buffer<ArrayBuffer>): Promise<string> {
+    static async sign({ type, data }: SignMessage, key: Buffer<ArrayBuffer>, chainId?: ChainId): Promise<string> {
         switch (type) {
             case SignType.Message:
                 return _metamask_eth_sig_util.personalSign({
@@ -20,10 +20,10 @@ export class Signer {
             case SignType.Transaction:
                 const transaction = data
 
-                const chainId = transaction.chainId
-                if (!chainId) throw new Error('Invalid chain id.')
+                const transactionChainId = transaction.chainId
+                if (!transactionChainId) throw new Error('Invalid chain id.')
 
-                const rawTransaction = await signTransaction(transaction, toHex(key))
+                const rawTransaction = await signTransaction(transaction, toHex(key), chainId)
                 if (!rawTransaction) throw new Error('Failed to sign transaction.')
                 return rawTransaction
 

--- a/packages/web3-providers/src/Web3/EVM/interceptors/Popups.ts
+++ b/packages/web3-providers/src/Web3/EVM/interceptors/Popups.ts
@@ -57,6 +57,7 @@ export class Popups implements Middleware<ConnectionContext> {
                     arguments: context.requestArguments,
                     options: {
                         silent: context.silent,
+                        providerType: context.providerType,
                         providerURL: context.providerURL,
                         gasOptionType: context.gasOptionType,
                     },

--- a/packages/web3-providers/src/entry.ts
+++ b/packages/web3-providers/src/entry.ts
@@ -19,7 +19,7 @@ export { RedPacket } from './RedPacket/index.js'
 export { SnapshotSearch } from './Snapshot/index.js'
 export { Snapshot } from './Snapshot/index.js'
 
-export { MaskWalletProviderInstance as MaskWalletProvider } from './Web3/EVM/providers/index.js'
+export { EVMWalletProviders, MaskWalletProviderInstance as MaskWalletProvider } from './Web3/EVM/providers/index.js'
 
 // Web3
 export { getConnection } from './Web3/Router/apis/getConnection.js'

--- a/packages/web3-shared/evm/src/helpers/signTransaction.ts
+++ b/packages/web3-shared/evm/src/helpers/signTransaction.ts
@@ -1,6 +1,8 @@
 import { signTransaction as viem_signTransaction } from 'viem/accounts'
 import type { Hex, TransactionSerializable } from 'viem'
 
-export function signTransaction(transaction: TransactionSerializable, privateKey: Hex) {
+export function signTransaction(transaction: TransactionSerializable, privateKey: Hex, chainId?: number) {
+    if (chainId !== undefined && transaction.chainId !== chainId)
+        throw new Error('Transaction chain id does not match current chain id.')
     return viem_signTransaction({ privateKey, transaction })
 }

--- a/packages/web3-shared/evm/src/types/index.ts
+++ b/packages/web3-shared/evm/src/types/index.ts
@@ -387,6 +387,7 @@ export interface RequestOptions {
     silent?: boolean
     owner?: string
     identifier?: string
+    providerType?: ProviderType
     providerURL?: string
     gasOptionType?: GasOptionType
     maxFeePerGas?: string
@@ -428,6 +429,7 @@ export interface TransactionOptions {
     chainId?: ChainId
     owner?: string
     identifier?: string
+    providerType?: ProviderType
     providerURL?: string
 
     // popups control


### PR DESCRIPTION
This issue was reported by a BugRap user. (If you're reading this and would like your contribution to be acknowledged (public your name), please comment on the original issue.)

The report was closed because it is not a security issue right now.

Wallet is currently not exposed to external websites, and all usage is internal, so hostile payloads cannot be constructed to trigger this path. This PR is for defensive programming only.