### PR TITLE
chore: remove dead alchemy-proxy.r2d2.to CSP entry

### DIFF
--- a/security/content-security-policy.json
+++ b/security/content-security-policy.json
@@ -34,7 +34,6 @@
         "https://dsearch.mask.r2d2.to/",
         "https://twitter-handler-proxy.r2d2.to",
         "https://nftscan-proxy.r2d2.to",
-        "https://alchemy-proxy.r2d2.to",
         "https://opensea-proxy.r2d2.to",
         // !!! if they don't have a whitelist, our CSP will be bypassed
         "https://cors-next.r2d2.to/",


### PR DESCRIPTION
## Summary

Remove the `https://alchemy-proxy.r2d2.to` entry from the CSP `connect-src` whitelist in `security/content-security-policy.json`.

## Why

This host is never requested anywhere in the codebase — no provider constants, RPC URLs, or fetch calls reference it. The only Alchemy usages go directly to `*.g.alchemy.com` (e.g. `packages/web3-constants/evm/rpc.json`, `packages/plugins/RedPacket/.../getSolanaProvider.ts`).

The CSP entry was dead config, allowing a host that is never contacted. Removing it tightens the CSP.