### PR TITLE
perf: cache per-tweet image parsing and t.co link resolution on x.com

### DIFF
--- a/packages/mask/content-script/site-adaptors/twitter.com/collecting/post.ts
+++ b/packages/mask/content-script/site-adaptors/twitter.com/collecting/post.ts
@@ -175,6 +175,24 @@ export function collectVerificationPost(keyword: string) {
     return null
 }
 
+// A tweet's DOM node fires onNodeMutation repeatedly (view counters, hover cards, lazy-loaded
+// media swapping placeholder -> real src, etc.) which re-invokes collectPostInfo for the same
+// tweetNode many times. Without caching, each invocation spun up a brand-new polling watcher
+// (untilElementAvailable) and re-parsed the images from scratch, stacking up redundant work per
+// tweet while scrolling. The image set for a given tweetNode is stable, so it's safe to compute
+// it once and reuse the promise on subsequent mutations.
+const postImagesCache = new WeakMap<HTMLElement, ReturnType<typeof postImagesParser>>()
+function getPostImages(tweetNode: HTMLElement) {
+    let cached = postImagesCache.get(tweetNode)
+    if (!cached) {
+        cached = untilElementAvailable(postsImageSelector(tweetNode), 10_000)
+            .then(() => postImagesParser(tweetNode))
+            .catch(() => [])
+        postImagesCache.set(tweetNode, cached)
+    }
+    return cached
+}
+
 function collectPostInfo(
     tweetNode: HTMLDivElement | null,
     info: ReturnType<typeof createRefsForCreatePostContext>,
@@ -193,8 +211,7 @@ function collectPostInfo(
 
     // decode stenographic image
     // don't add await on this
-    const images = untilElementAvailable(postsImageSelector(tweetNode), 10_000)
-        .then(() => postImagesParser(tweetNode))
+    const images = getPostImages(tweetNode)
         .then((images) => {
             for (const image of images) {
                 if (typeof image.image === 'string') info.postMetadataImages.add(image.image)
@@ -208,6 +225,28 @@ function collectPostInfo(
     info.postMessage.value = FlattenTypedMessage.NoContext(
         makeTypedMessageTuple([messages, makeTypedMessagePromise(images)]),
     )
+}
+
+// Same tweetNode mutating repeatedly also re-ran collectLinks over and over, which re-requested
+// resolveTCOLink for the same href every time. The background resolver already memoizes by URL,
+// but each call still pays for a full cross-context message round trip. t.co redirects are
+// static, so caching the in-flight/resolved promise by href here is safe and cuts that traffic
+// (it also dedupes the same link appearing across different tweets, e.g. popular/retweeted links).
+const tcoLinkCache = new Map<string, Promise<string | null>>()
+function resolveTCOLinkCached(href: string) {
+    let cached = tcoLinkCache.get(href)
+    if (!cached) {
+        cached = Services.Helper.resolveTCOLink(href).catch((error: unknown) => {
+            // Don't let a transient failure permanently poison this href for the rest of the
+            // session (mirrors the eviction-on-failure behavior of the background's own
+            // memoizePromise-wrapped resolver) — allow the next occurrence to retry. A
+            // resolved `null` (e.g. not a t.co link) is a legitimate answer and stays cached.
+            tcoLinkCache.delete(href)
+            throw error
+        })
+        tcoLinkCache.set(href, cached)
+    }
+    return cached
 }
 
 function collectLinks(
@@ -229,7 +268,7 @@ function collectLinks(
         if (seen.has(x.href)) continue
         seen.add(x.href)
         info.postMetadataMentionedLinks.set(x, x.href)
-        Services.Helper.resolveTCOLink(x.href)
+        resolveTCOLinkCached(x.href)
             .then((val) => {
                 if (cancel?.aborted) return
                 if (!val) return

--- a/packages/mask/content-script/site-adaptors/twitter.com/injection/Avatar/index.tsx
+++ b/packages/mask/content-script/site-adaptors/twitter.com/injection/Avatar/index.tsx
@@ -36,6 +36,11 @@ export async function injectAvatar(signal: AbortSignal) {
             const run = async () => {
                 const twitterId = getTwitterId(ele)
                 if (!twitterId) return
+                // onNodeMutation/onTargetChanged re-run this for the same `ele` (X mutates avatar
+                // containers often: lazy image src swaps, hover states, virtualization reuse). A
+                // fresh DOMProxy() here creates a brand-new shadow-root sibling every time, so the
+                // previous one must be torn down first or it leaks a live React tree per mutation.
+                remove()
 
                 const proxy = DOMProxy({
                     afterShadowRootInit: Flags.shadowRootInit,

--- a/packages/mask/content-script/site-adaptors/twitter.com/injection/Tips/FollowTipsButton.tsx
+++ b/packages/mask/content-script/site-adaptors/twitter.com/injection/Tips/FollowTipsButton.tsx
@@ -28,6 +28,10 @@ export function injectTipsButtonOnFollowButton(signal: AbortSignal) {
             const run = async () => {
                 const userId = getUserId(ele)
                 if (!userId) return
+                // onNodeMutation/onTargetChanged re-run this for the same `ele`. A fresh DOMProxy()
+                // here creates a brand-new shadow-root sibling every time, so the previous one must
+                // be torn down first or it leaks a live React tree on every mutation of this cell.
+                remove()
                 const proxy = DOMProxy({
                     afterShadowRootInit: Flags.shadowRootInit,
                 })

--- a/packages/mask/content-script/site-adaptors/twitter.com/injection/Tips/PostTipsButton.tsx
+++ b/packages/mask/content-script/site-adaptors/twitter.com/injection/Tips/PostTipsButton.tsx
@@ -43,6 +43,10 @@ export function injectTipsButtonOnPost(signal: AbortSignal) {
             const run = async () => {
                 const userId = getUserId(ele)
                 if (!userId) return
+                // onNodeMutation/onTargetChanged re-run this for the same `ele`. A fresh DOMProxy()
+                // here creates a brand-new shadow-root sibling every time, so the previous one must
+                // be torn down first or it leaks a live React tree on every mutation of this post.
+                remove()
                 const proxy = DOMProxy({
                     afterShadowRootInit: Flags.shadowRootInit,
                 })


### PR DESCRIPTION
## Summary
- The x.com timeline post collector re-runs `collectPostInfo`/`collectLinks` on every `onNodeMutation` of a tweet node — X's live UI fires this frequently (view counters, hover cards, lazy image src swaps), not just once per post. Each re-run previously spun up a brand-new `untilElementAvailable` polling watcher + re-parsed images from scratch, and re-requested `resolveTCOLink` (a cross-context message) for every link in the tweet, even when nothing relevant had changed. Added two small caches — image-parsing promise keyed by `tweetNode` (`WeakMap`, auto-GC'd), and resolved t.co link keyed by `href` (evicted on failure so a transient error can retry, matching the background resolver's own eviction-on-failure behavior) — so repeated mutations reuse prior work instead of redoing it.
- `injectAvatar`, `injectTipsButtonOnPost`, and `injectTipsButtonOnFollowButton` each created a fresh `DOMProxy()` inside their `onNodeMutation`/`onTargetChanged` handler for the same watched element. A new `DOMProxy` always attaches a brand-new shadow-root sibling, so every mutation of an avatar or tips-button element was injecting another live React tree next to the previous one without ever destroying it — the old `remover` was simply discarded. Over a long scroll session this accumulated orphaned DOM nodes/shadow roots/React components (each with their own data-fetching hooks) that were never cleaned up until the whole post/cell was removed. Fixed by calling the existing `remove()` before creating the new tree, matching the pattern already used correctly elsewhere (e.g. `MaskIcon`'s helper reuses the watcher-provided `DOMProxy` instead of creating a new one).
- Output values and the existing watcher/polling architecture are unchanged; this only removes redundant recomputation and a duplicate-tree leak that were contributing to noticeable scroll jank with the extension enabled.

## Test plan
- [x] Manual verification by @guanbinrui: loaded the extension, browsed x.com timeline — scroll jank noticeably improved, no regressions observed (mask icon injection, decrypted posts, image-embedded payloads, link previews/expansion, avatar decorations, tips buttons all still work as before)
- [ ] Confirm no build/type errors (`pnpm build` / `pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hAmnQwwcfT7DaWAAugciS
