### PR TITLE
fix: exclude prebuilt dist from swc and react-refresh loaders

### DIFF
--- a/packages/mask/.webpack/config.ts
+++ b/packages/mask/.webpack/config.ts
@@ -148,6 +148,10 @@ export async function createConfiguration(
                     test: /\.[mc]?[jt]sx?$/i,
                     parser: { worker: ['OnDemandWorker', '...'] },
                     include: join(import.meta.dirname, '../../'),
+                    // prebuilt output (e.g. the vendored @bonfida/spl-name-service) must not
+                    // run through swc/react-refresh: mixing the refresh preamble (ESM import)
+                    // into CJS files breaks webpack's module detection
+                    exclude: /[/\\]dist[/\\]/,
                     use: [
                         {
                             loader: rspack ? 'builtin:swc-loader' : require.resolve('swc-loader'),
@@ -269,6 +273,10 @@ export async function createConfiguration(
                 :   (await import('@pmmmwh/react-refresh-webpack-plugin')).default)({
                     overlay: false,
                     esModule: true,
+                    // the refresh loader prepends an ESM import preamble, which breaks
+                    // prebuilt CJS output (e.g. the vendored @bonfida/spl-name-service);
+                    // keep the plugin default node_modules exclusion
+                    exclude: [/node_modules/i, /[/\\]dist[/\\]/],
                 }),
             flags.profiling && new ProfilingPlugin(),
             // TODO: crashes rspack


### PR DESCRIPTION
## Summary

- `pnpm run dev` failed with `Module parse failed: 'import' and 'export' may appear only with 'sourceType: module'` on `packages/spl-name-service/dist/*.js` (the vendored `@bonfida/spl-name-service`, prebuilt CJS).
- Root cause 1: the TS/swc rule's `include: packages/` also matched the prebuilt dist files, running them through swc.
- Root cause 2: the react-refresh plugin prepends an ESM `import` preamble to each file it processes — and it injects its loader via `normalModuleFactory.hooks.afterResolve`, outside webpack module rules, so a rule-level exclude alone doesn't stop it. Mixing that preamble into CJS breaks webpack's module detection.

## Changes

- `packages/mask/.webpack/config.ts`:
  - exclude `/dist/` from the TS/swc rule
  - add `exclude: [/node_modules/i, /dist/]` to the react-refresh plugin (webpack & rspack variants), keeping the plugin's default `node_modules` exclusion

## Verification

- `pnpm start` (webpack dev): `compiled successfully` for both the initial build and incremental rebuilds; previously it failed with the 2 module parse errors.

> Note: `node_modules` must stay in the plugin exclude — overriding `exclude` alone replaces the plugin's default `/node_modules/i` and floods the build with ~17k errors.