### PR TITLE
fix: var()-safe lighten() for FungibleTokenInput hover

### DIFF
--- a/packages/shared/src/UI/components/FungibleTokenInput/UI.tsx
+++ b/packages/shared/src/UI/components/FungibleTokenInput/UI.tsx
@@ -1,19 +1,10 @@
 import { Trans } from '@lingui/react/macro'
 import { Icons } from '@masknet/icons'
-import { alpha, makeStyles } from '@masknet/theme'
+import { alpha, lighten, makeStyles } from '@masknet/theme'
 import type { Web3Helper } from '@masknet/web3-helpers'
 import { useNetworkContext } from '@masknet/web3-hooks-base'
 import { formatBalance } from '@masknet/web3-shared-base'
-import {
-    Box,
-    Chip,
-    chipClasses,
-    InputBase,
-    inputBaseClasses,
-    lighten,
-    Typography,
-    type InputBaseProps,
-} from '@mui/material'
+import { Box, Chip, chipClasses, InputBase, inputBaseClasses, Typography, type InputBaseProps } from '@mui/material'
 import { memo } from 'react'
 import { FormattedBalance, TokenIcon } from '../../../index.js'
 import { NetworkPluginID } from '@masknet/shared-base'

--- a/packages/theme/src/Theme/colors.ts
+++ b/packages/theme/src/Theme/colors.ts
@@ -96,6 +96,9 @@ declare module '@mui/material/styles' {
 export const alpha = (color: string, opacity: number) =>
     `color-mix(in srgb, ${color}, transparent ${(1 - opacity) * 100}%)`
 
+export const lighten = (color: string, coefficient: number) =>
+    `color-mix(in srgb, ${color}, white ${coefficient * 100}%)`
+
 export const LightMaskColors = {
     mode: 'light',
     primary: { main: '#1c68f3' },

--- a/packages/theme/src/Theme/index.ts
+++ b/packages/theme/src/Theme/index.ts
@@ -1,4 +1,4 @@
-export { MaskColors, alpha, DarkMaskColors, LightMaskColors } from './colors.js'
+export { MaskColors, alpha, DarkMaskColors, lighten, LightMaskColors } from './colors.js'
 export { MaskThemeProvider, type MaskThemeProviderProps, usePalette } from './Provider.js'
 export { MaskTheme } from './theme.js'
 export { createShadowRootTheme } from './createShadowRootTheme.js'


### PR DESCRIPTION
## Problem

`FungibleTokenInput` crashed on render:

```
Error: MUI: Unsupported `var(--mui-palette-maskColor-primary)` color.
    at decomposeColor → lighten → useStyles → FungibleTokenInputUI
```

## Root cause

Introduced by the MUI v9 upgrade (#52d5bce737), which enabled
`cssVariables: { colorSchemeSelector: 'data' }` and switched
`theme.palette.*` → `theme.vars.palette.*`. The latter is now the literal
string `var(--mui-palette-maskColor-primary)`, and MUI's `lighten()` only
parses `#nnn` / `rgb()` / `hsl()` / `color()`, so it throws. The call sits
inside `useStyles()`, so the component crashed on mount. This was the last
`lighten`/`darken` usage left on `theme.vars`.

## Change

- Add a `color-mix`-based `lighten()` to `@masknet/theme` next to the
  existing var()-safe `alpha()` (`color-mix(in srgb, ${color}, white ${coefficient * 100}%)`)
  — channel-wise identical to MUI's `lighten` for rgb colors, so the hover
  color is unchanged visually.
- Import `lighten` from `@masknet/theme` in `FungibleTokenInput` instead of
  `@mui/material` (call site unchanged).

## Verification

- `pnpm lint` clean
- Runtime (dev build, x.com): the Lucky Drop (Red Packet) dialog mounts
  `FungibleTokenInput` without the MUI error; the injected
  `.selectToken:hover` rule resolves in Chrome to exactly
  `lighten(#1C68F3, 0.1)` = `rgb(51, 119, 244)`, matching the pre-upgrade color