### PR TITLE
fix: restore icon centering after MUI v9 upgrade

### DIFF
--- a/packages/icons/utils/internal.js
+++ b/packages/icons/utils/internal.js
@@ -33,6 +33,9 @@ export function __createIcon(name, variants, intrinsicSize = [24, 24]) {
                 )
             const base = {
                 display: 'inline-block',
+                // To align icon center: zero out the strut so the svg child fills the span.
+                fontSize: 0,
+                lineHeight: 0,
                 backgroundRepeat: 'no-repeat',
                 backgroundPosition: 'center',
                 flexShrink: 0,
@@ -56,8 +59,6 @@ export function __createIcon(name, variants, intrinsicSize = [24, 24]) {
             ref,
             'data-icon': name,
             sx: Array.isArray(sx) ? [iconStyle, ...sx] : [iconStyle, sx],
-            // To align icon center.
-            fontSize: 0,
         }
         // background image can't be correctly resolved on Firefly in ShadowDOM.
         // This is a workaround.


### PR DESCRIPTION
## Summary

- Icons with dynamic color support (`s: true`, svg rendered as a **child** of the icon span — e.g. `Icons.MaskBlue`) drifted a few px **down** inside text-sized containers after the MUI v9 upgrade.
- Root cause: `__createIcon` passed `fontSize: 0` as a **system prop** to `Box`. MUI v5 converted system props to CSS (`font-size: 0`), zeroing the strut so the svg filled the span. Since 52d5bce737 (5.15.20 → 9.2.0), `Box` only styles through `sx` — the prop leaked to the DOM as a useless `font-size="0"` attribute, the strut came back, and the inline svg got pushed below the baseline. Smaller `size` made it more visible (e.g. `MaskBlue size={16}` in the ProfileCard avatar badge sitting in an IconButton with `font-size: 24px`).
- Fix in `packages/icons/utils/internal.js`:
  - move `fontSize: 0` into the `sx` base style (restores v5 semantics under v9);
  - add `lineHeight: 0` to guard against host pages inheriting an absolute `line-height`;
  - drop the dead prop (also removes the React dev warning about the unrecognized `fontSize` prop).

## Impact

`__createIcon` is the single factory for all generated icons, so this fixes every `s: true` icon at once. Background-image variants (no child element) are unaffected by `fontSize`/`lineHeight`. The `SvgIcon`-based `createIcon()` in `utils/index.js` is unaffected.

## Verification

- [x] Rebuilt dev extension, reloaded x.com profile page and inspected the injected shadow-root UI:
  - icon spans compute `font-size: 0px; line-height: 0px`; no `font-size` DOM attribute remains;
  - `MaskBlue size={16}` in the avatar badge: svg center vs button center delta = **0px** (was offset before);
  - `MaskBlue size={24}` dialog header icon likewise centered;
  - console no longer logs the `React does not recognize the "fontSize" prop` warning.
- [x] eslint on the changed file passes; commitlint passes.