### PR TITLE
feat(book): component gallery Vite app in apps/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ quick-lint-js.config
 
 .claude
 .pnpm-store/
+.gstack/

--- a/apps/book/.gitignore
+++ b/apps/book/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+.vite
+*.tsbuildinfo

--- a/apps/book/README.md
+++ b/apps/book/README.md
@@ -1,0 +1,43 @@
+# @masknet/book
+
+A lightweight component gallery ("book") for Maskbook's shared UI packages. Plain Vite + React SPA — no Storybook.
+
+## Run
+
+```bash
+pnpm book          # dev server (from repo root)
+pnpm book:build    # static build → apps/book/dist
+```
+
+Or from this folder: `pnpm dev` / `pnpm build` / `pnpm preview`.
+
+## How it works
+
+- Components are imported from source (`@masknet/theme`, `@masknet/icons`, …) via the `mask-src`
+  export condition, set in `vite.config.ts` (`resolve.conditions`). This mirrors
+  `packages/mask/.webpack/config.ts`.
+- Global providers (`MaskThemeProvider`, snackbar, dialog stacking) live in `src/providers.tsx`.
+- Routing is a ~20-line hash router (`src/router.ts`) — deploys anywhere with no rewrite config.
+
+## Add a demo
+
+Create `src/demos/<section>/<Name>.demo.tsx`:
+
+```tsx
+import { ActionButton } from '@masknet/theme'
+
+export const meta = { title: 'ActionButton', description: 'optional one-liner' }
+
+export default function Demo() {
+    return <ActionButton variant="contained">Confirm</ActionButton>
+}
+```
+
+`import.meta.glob` in `src/registry.ts` picks it up automatically. The first path segment
+under `demos/` is the sidebar section (`foundation`, `components`, `icons`, `shared`, …).
+
+## Deploy (Vercel)
+
+- Root Directory: `apps/book`
+- Build / install commands come from `apps/book/vercel.json` (they `cd` to the repo root so
+  the pnpm workspace resolves). Enable "Include source files outside of the Root Directory".

--- a/apps/book/README.md
+++ b/apps/book/README.md
@@ -29,7 +29,7 @@ import { ActionButton } from '@masknet/theme'
 export const meta = { title: 'ActionButton', description: 'optional one-liner' }
 
 export default function Demo() {
-    return <ActionButton variant="contained">Confirm</ActionButton>
+  return <ActionButton variant="contained">Confirm</ActionButton>
 }
 ```
 

--- a/apps/book/index.html
+++ b/apps/book/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Mask Component Book</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/apps/book/package.json
+++ b/apps/book/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@masknet/book",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@masknet/icons": "workspace:*",
+    "@masknet/shared-base": "workspace:*",
+    "@masknet/theme": "workspace:*",
+    "@mui/icons-material": "9.2.0",
+    "@mui/lab": "9.0.0-beta.6",
+    "@mui/material": "9.2.0",
+    "@mui/system": "9.2.0",
+    "@emotion/react": "11.14.0",
+    "@emotion/styled": "11.14.1",
+    "react": "0.0.0-experimental-58af67a8f8-20240628",
+    "react-dom": "0.0.0-experimental-58af67a8f8-20240628"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.10",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^4.7.0",
+    "vite": "^6.2.0",
+    "vite-plugin-top-level-await": "^1.6.0",
+    "vite-plugin-wasm": "^3.6.0"
+  }
+}

--- a/apps/book/src/App.tsx
+++ b/apps/book/src/App.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { Nav } from './components/Nav.tsx'
+import { Canvas } from './components/Canvas.tsx'
+import { allEntries, findEntry } from './registry.ts'
+import { useRoute } from './router.ts'
+
+export function App() {
+    const [route, navigate] = useRoute()
+    const entry = findEntry(route)
+
+    // land on the first demo if the hash is empty or stale
+    useEffect(() => {
+        if (!entry && allEntries.length > 0) navigate(allEntries[0].id)
+    }, [entry, navigate])
+
+    return (
+        <div className="book-shell">
+            <Nav current={route} onNavigate={navigate} />
+            <Canvas entry={entry} />
+        </div>
+    )
+}

--- a/apps/book/src/components/Canvas.tsx
+++ b/apps/book/src/components/Canvas.tsx
@@ -1,0 +1,50 @@
+import { Suspense, lazy, useMemo } from 'react'
+import type { DemoEntry } from '../demo.ts'
+
+interface Props {
+    entry: DemoEntry | undefined
+}
+
+export function Canvas({ entry }: Props) {
+    if (!entry) {
+        return (
+            <div className="book-main">
+                <div className="book-empty">Pick a component from the sidebar.</div>
+            </div>
+        )
+    }
+    return <DemoView key={entry.id} entry={entry} />
+}
+
+function DemoView({ entry }: { entry: DemoEntry }) {
+    const Body = useMemo(
+        () =>
+            lazy(async () => {
+                const mod = await entry.load()
+                const Demo = mod.default
+                const description = mod.meta?.description
+                return {
+                    default: () => (
+                        <>
+                            <header className="book-main-header">
+                                <h1>{mod.meta?.title ?? entry.name}</h1>
+                                {description ? <p>{description}</p> : null}
+                            </header>
+                            <div className="book-canvas">
+                                <Demo />
+                            </div>
+                        </>
+                    ),
+                }
+            }),
+        [entry],
+    )
+
+    return (
+        <div className="book-main">
+            <Suspense fallback={<div className="book-empty">Loading…</div>}>
+                <Body />
+            </Suspense>
+        </div>
+    )
+}

--- a/apps/book/src/components/Canvas.tsx
+++ b/apps/book/src/components/Canvas.tsx
@@ -28,7 +28,9 @@ function DemoView({ entry }: { entry: DemoEntry }) {
                         <>
                             <header className="book-main-header">
                                 <h1>{mod.meta?.title ?? entry.name}</h1>
-                                {description ? <p>{description}</p> : null}
+                                {description ?
+                                    <p>{description}</p>
+                                :   null}
                             </header>
                             <div className="book-canvas">
                                 <Demo />

--- a/apps/book/src/components/Nav.tsx
+++ b/apps/book/src/components/Nav.tsx
@@ -1,0 +1,37 @@
+import { sections } from '../registry.ts'
+import { useMode } from '../providers.tsx'
+
+interface Props {
+    current: string
+    onNavigate: (id: string) => void
+}
+
+export function Nav({ current, onNavigate }: Props) {
+    const { mode, toggle } = useMode()
+    return (
+        <nav className="book-sidebar">
+            <div className="book-brand">
+                <span>Mask Component Book</span>
+                <button type="button" className="book-theme-toggle" onClick={toggle}>
+                    {mode === 'light' ? '◐ Light' : '◑ Dark'}
+                </button>
+            </div>
+
+            {sections.map((section) => (
+                <div key={section.id}>
+                    <div className="book-section-title">{section.title}</div>
+                    {section.entries.map((entry) => (
+                        <button
+                            type="button"
+                            key={entry.id}
+                            className="book-nav-link"
+                            data-active={entry.id === current}
+                            onClick={() => onNavigate(entry.id)}>
+                            {entry.name}
+                        </button>
+                    ))}
+                </div>
+            ))}
+        </nav>
+    )
+}

--- a/apps/book/src/demo.ts
+++ b/apps/book/src/demo.ts
@@ -1,0 +1,34 @@
+import type { ComponentType } from 'react'
+
+export interface DemoMeta {
+    /** Display name in the nav. Defaults to the file basename. */
+    title?: string
+    /** Optional one-liner shown above the demo. */
+    description?: string
+    /** Sort weight inside a section (lower first). Defaults to 0. */
+    order?: number
+}
+
+export interface DemoModule {
+    default: ComponentType
+    meta?: DemoMeta
+}
+
+export interface DemoEntry {
+    /** e.g. "components/ActionButton" */
+    id: string
+    /** e.g. "components" */
+    section: string
+    /** e.g. "ActionButton" */
+    name: string
+    title: string
+    description?: string
+    order: number
+    load: () => Promise<DemoModule>
+}
+
+export interface DemoSection {
+    id: string
+    title: string
+    entries: DemoEntry[]
+}

--- a/apps/book/src/demos/components/ActionButton.demo.tsx
+++ b/apps/book/src/demos/components/ActionButton.demo.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { Stack } from '@mui/material'
+import { ActionButton } from '@masknet/theme'
+
+export const meta = {
+    title: 'ActionButton',
+    description: 'MUI Button with a built-in loading state (packages/theme/src/Components/ActionButton).',
+}
+
+export default function ActionButtonDemo() {
+    const [loading, setLoading] = useState(false)
+
+    return (
+        <Stack spacing={3} sx={{ alignItems: 'flex-start' }}>
+            <Stack direction="row" spacing={2}>
+                <ActionButton variant="contained">Contained</ActionButton>
+                <ActionButton variant="outlined">Outlined</ActionButton>
+                <ActionButton variant="text">Text</ActionButton>
+                <ActionButton variant="contained" color="error">
+                    Danger
+                </ActionButton>
+            </Stack>
+
+            <Stack direction="row" spacing={2}>
+                <ActionButton variant="contained" loading>
+                    Loading
+                </ActionButton>
+                <ActionButton variant="contained" disabled>
+                    Disabled
+                </ActionButton>
+                <ActionButton variant="contained" width={220}>
+                    Fixed width 220
+                </ActionButton>
+            </Stack>
+
+            <ActionButton
+                variant="contained"
+                loading={loading}
+                onClick={() => {
+                    setLoading(true)
+                    setTimeout(() => setLoading(false), 1500)
+                }}>
+                Click to load for 1.5s
+            </ActionButton>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/components/Alert.demo.tsx
+++ b/apps/book/src/demos/components/Alert.demo.tsx
@@ -1,0 +1,18 @@
+import { Stack } from '@mui/material'
+import { MaskAlert } from '@masknet/theme'
+
+export const meta = {
+    title: 'MaskAlert',
+    description: 'Themed wrapper around MUI Alert.',
+}
+
+export default function AlertDemo() {
+    return (
+        <Stack spacing={2} sx={{ maxWidth: 520 }}>
+            <MaskAlert severity="success">Your transaction was confirmed.</MaskAlert>
+            <MaskAlert severity="info">A new persona backup is available.</MaskAlert>
+            <MaskAlert severity="warning">Gas price is unusually high right now.</MaskAlert>
+            <MaskAlert severity="error">Failed to decrypt this post.</MaskAlert>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/components/Indicators.demo.tsx
+++ b/apps/book/src/demos/components/Indicators.demo.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { CheckBoxIndicator, RadioIndicator } from '@masknet/theme'
+
+export const meta = {
+    title: 'Radio / CheckBox indicators',
+    description: 'Icon-only controlled indicators (no MUI input wrapper).',
+}
+
+export default function IndicatorsDemo() {
+    const [radio, setRadio] = useState(true)
+    const [check, setCheck] = useState(false)
+
+    return (
+        <Stack spacing={4}>
+            <Stack spacing={1}>
+                <Typography variant="subtitle2">RadioIndicator</Typography>
+                <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+                    <span onClick={() => setRadio(true)} style={{ cursor: 'pointer' }}>
+                        <RadioIndicator checked={radio} size={20} />
+                    </span>
+                    <span onClick={() => setRadio(false)} style={{ cursor: 'pointer' }}>
+                        <RadioIndicator checked={!radio} size={20} />
+                    </span>
+                </Stack>
+            </Stack>
+
+            <Stack spacing={1}>
+                <Typography variant="subtitle2">CheckBoxIndicator</Typography>
+                <span onClick={() => setCheck((v) => !v)} style={{ cursor: 'pointer' }}>
+                    <CheckBoxIndicator checked={check} size={20} />
+                </span>
+            </Stack>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/components/LoadingBase.demo.tsx
+++ b/apps/book/src/demos/components/LoadingBase.demo.tsx
@@ -1,0 +1,20 @@
+import { Stack, Typography } from '@mui/material'
+import { LoadingBase } from '@masknet/theme'
+
+export const meta = {
+    title: 'LoadingBase',
+    description: 'The spinner used across the extension. Accepts icon props (size, color).',
+}
+
+export default function LoadingBaseDemo() {
+    return (
+        <Stack direction="row" spacing={4} sx={{ alignItems: 'center' }}>
+            {[16, 24, 36, 48].map((size) => (
+                <Stack key={size} spacing={1} sx={{ alignItems: 'center' }}>
+                    <LoadingBase size={size} />
+                    <Typography variant="caption">{size}px</Typography>
+                </Stack>
+            ))}
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/components/Tabs.demo.tsx
+++ b/apps/book/src/demos/components/Tabs.demo.tsx
@@ -1,0 +1,43 @@
+import { Tab } from '@mui/material'
+import { TabContext, TabPanel } from '@mui/lab'
+import { MaskTabList, useTabs } from '@masknet/theme'
+
+export const meta = {
+    title: 'Tabs (MaskTabList)',
+    description: 'MaskTabList + useTabs + @mui/lab TabContext/TabPanel. Variants: base, round, flexible.',
+}
+
+function Example({ variant }: { variant: 'base' | 'round' | 'flexible' }) {
+    const [tab, onChange, tabs] = useTabs('overview', 'activity', 'settings')
+    return (
+        <TabContext value={tab}>
+            <MaskTabList variant={variant} onChange={onChange} aria-label={`${variant} tabs`}>
+                <Tab label="Overview" value={tabs.overview} />
+                <Tab label="Activity" value={tabs.activity} />
+                <Tab label="Settings" value={tabs.settings} />
+            </MaskTabList>
+            <TabPanel value={tabs.overview}>Overview panel</TabPanel>
+            <TabPanel value={tabs.activity}>Activity panel</TabPanel>
+            <TabPanel value={tabs.settings}>Settings panel</TabPanel>
+        </TabContext>
+    )
+}
+
+export default function TabsDemo() {
+    return (
+        <div style={{ display: 'grid', gap: 32, maxWidth: 520 }}>
+            <div>
+                <h4>base</h4>
+                <Example variant="base" />
+            </div>
+            <div>
+                <h4>round</h4>
+                <Example variant="round" />
+            </div>
+            <div>
+                <h4>flexible</h4>
+                <Example variant="flexible" />
+            </div>
+        </div>
+    )
+}

--- a/apps/book/src/demos/components/TextField.demo.tsx
+++ b/apps/book/src/demos/components/TextField.demo.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { Stack } from '@mui/material'
+import { MaskTextField } from '@masknet/theme'
+
+export const meta = {
+    title: 'MaskTextField',
+    description: 'Labelled text field with the Mask input styling.',
+}
+
+export default function TextFieldDemo() {
+    const [value, setValue] = useState('')
+
+    return (
+        <Stack spacing={3} sx={{ maxWidth: 360 }}>
+            <MaskTextField label="Wallet name" placeholder="e.g. Main wallet" />
+            <MaskTextField
+                label="Amount"
+                type="number"
+                required
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+            />
+            <MaskTextField label="Recipient" defaultValue="0x0000…dead" error helperText="Invalid address" />
+            <MaskTextField label="Disabled" value="read only" disabled />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/foundation/colors.demo.tsx
+++ b/apps/book/src/demos/foundation/colors.demo.tsx
@@ -1,0 +1,25 @@
+import { useTheme } from '@mui/material'
+
+export const meta = {
+    title: 'Color palette',
+    description: 'theme.vars.palette.maskColor — the active palette follows the sidebar Light/Dark toggle.',
+}
+
+export default function ColorsDemo() {
+    const theme = useTheme()
+    const maskColor = theme.vars.palette.maskColor as Record<string, string>
+
+    return (
+        <div className="book-demo-grid">
+            {Object.entries(maskColor).map(([name, value]) => (
+                <div className="book-swatch" key={name}>
+                    <div className="chip" style={{ background: value }} />
+                    <div className="label">
+                        <div>{name}</div>
+                        <code>{value}</code>
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/apps/book/src/demos/foundation/shadows.demo.tsx
+++ b/apps/book/src/demos/foundation/shadows.demo.tsx
@@ -1,0 +1,61 @@
+import { Box, Paper, Stack, Typography, useTheme } from '@mui/material'
+
+export const meta = {
+    title: 'Shadows & elevation',
+    description: 'theme.vars.palette.shadow.* tokens plus MUI Paper elevation.',
+}
+
+export default function ShadowsDemo() {
+    const theme = useTheme()
+    const shadow = theme.vars.palette.shadow as Record<string, string>
+
+    return (
+        <Stack spacing={4}>
+            <div>
+                <Typography variant="subtitle2" gutterBottom>
+                    Mask shadow tokens
+                </Typography>
+                <div className="book-demo-grid">
+                    {Object.entries(shadow).map(([name, value]) => (
+                        <Box
+                            key={name}
+                            sx={{
+                                width: 200,
+                                height: 96,
+                                borderRadius: 2,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                bgcolor: 'background.paper',
+                                boxShadow: value,
+                            }}>
+                            {name}
+                        </Box>
+                    ))}
+                </div>
+            </div>
+
+            <div>
+                <Typography variant="subtitle2" gutterBottom>
+                    MUI elevation
+                </Typography>
+                <div className="book-demo-grid">
+                    {[0, 1, 2, 4, 8, 16, 24].map((elevation) => (
+                        <Paper
+                            key={elevation}
+                            elevation={elevation}
+                            sx={{
+                                width: 140,
+                                height: 90,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                            }}>
+                            elevation={elevation}
+                        </Paper>
+                    ))}
+                </div>
+            </div>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/foundation/typography.demo.tsx
+++ b/apps/book/src/demos/foundation/typography.demo.tsx
@@ -1,0 +1,34 @@
+import { Stack, Typography } from '@mui/material'
+
+export const meta = {
+    title: 'Typography',
+    description: 'MUI Typography variants rendered with the Mask theme.',
+}
+
+const variants = [
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'subtitle1',
+    'subtitle2',
+    'body1',
+    'body2',
+    'button',
+    'caption',
+    'overline',
+] as const
+
+export default function TypographyDemo() {
+    return (
+        <Stack spacing={1.5}>
+            {variants.map((variant) => (
+                <Typography key={variant} variant={variant}>
+                    {variant} — The quick brown fox jumps over the lazy dog
+                </Typography>
+            ))}
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/icons/gallery.demo.tsx
+++ b/apps/book/src/demos/icons/gallery.demo.tsx
@@ -1,0 +1,90 @@
+import { useDeferredValue, useMemo, useState } from 'react'
+import { Icons } from '@masknet/icons'
+
+export const meta = {
+    title: 'Icon gallery',
+    description: 'Every export from @masknet/icons. Type to filter; click to copy the name.',
+}
+
+const ALL = Object.keys(Icons)
+    .filter((name) => /^[A-Z]/.test(name))
+    .sort()
+
+export default function IconGalleryDemo() {
+    const [query, setQuery] = useState('')
+    const deferred = useDeferredValue(query)
+    const [copied, setCopied] = useState<string | null>(null)
+
+    const list = useMemo(() => {
+        const q = deferred.trim().toLowerCase()
+        return q ? ALL.filter((name) => name.toLowerCase().includes(q)) : ALL
+    }, [deferred])
+
+    return (
+        <div>
+            <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={`Filter ${ALL.length} icons…`}
+                style={{
+                    width: 280,
+                    padding: '8px 10px',
+                    marginBottom: 16,
+                    borderRadius: 8,
+                    border: '1px solid var(--book-border)',
+                    background: 'transparent',
+                    color: 'inherit',
+                }}
+            />
+            <div style={{ marginBottom: 12, color: 'var(--book-muted)', fontSize: 12 }}>
+                {list.length} shown{copied ? ` · copied "${copied}"` : ''}
+            </div>
+            <div
+                style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))',
+                    gap: 8,
+                }}>
+                {list.map((name) => {
+                    const Icon = (Icons as Record<string, React.ComponentType<{ size?: number }>>)[name]
+                    return (
+                        <button
+                            key={name}
+                            type="button"
+                            title={name}
+                            onClick={() => {
+                                navigator.clipboard?.writeText(name)
+                                setCopied(name)
+                            }}
+                            style={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                gap: 6,
+                                padding: '12px 6px',
+                                border: '1px solid var(--book-border)',
+                                borderRadius: 10,
+                                background: 'transparent',
+                                color: 'inherit',
+                                cursor: 'pointer',
+                                overflow: 'hidden',
+                            }}>
+                            <Icon size={24} />
+                            <span
+                                style={{
+                                    fontSize: 10,
+                                    color: 'var(--book-muted)',
+                                    maxWidth: '100%',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                }}>
+                                {name}
+                            </span>
+                        </button>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/apps/book/src/main.tsx
+++ b/apps/book/src/main.tsx
@@ -1,0 +1,16 @@
+import './styles.css'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App.tsx'
+import { Providers } from './providers.tsx'
+
+const root = document.getElementById('root')
+if (!root) throw new Error('#root not found')
+
+createRoot(root).render(
+    <StrictMode>
+        <Providers>
+            <App />
+        </Providers>
+    </StrictMode>,
+)

--- a/apps/book/src/providers.tsx
+++ b/apps/book/src/providers.tsx
@@ -1,0 +1,59 @@
+import { createContext, use, useEffect, useMemo, useState, type PropsWithChildren } from 'react'
+import { DialogStackingProvider, DisableShadowRootContext, MaskThemeProvider } from '@masknet/theme'
+
+export type PaletteMode = 'light' | 'dark'
+
+interface ModeContext {
+    mode: PaletteMode
+    setMode: (mode: PaletteMode) => void
+    toggle: () => void
+}
+
+const ModeContext = createContext<ModeContext>({
+    mode: 'light',
+    setMode: () => {},
+    toggle: () => {},
+})
+
+export function useMode(): ModeContext {
+    return use(ModeContext)
+}
+
+const STORAGE_KEY = 'mask-book:palette'
+
+function readInitialMode(): PaletteMode {
+    try {
+        const saved = globalThis.localStorage?.getItem(STORAGE_KEY)
+        if (saved === 'light' || saved === 'dark') return saved
+    } catch {}
+    return globalThis.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function Providers({ children }: PropsWithChildren) {
+    const [mode, setMode] = useState<PaletteMode>(readInitialMode)
+
+    useEffect(() => {
+        try {
+            globalThis.localStorage?.setItem(STORAGE_KEY, mode)
+        } catch {}
+        // MaskTheme uses `cssVariables.colorSchemeSelector: 'data'`
+        document.documentElement.dataset.muiColorScheme = mode
+        document.documentElement.style.colorScheme = mode
+    }, [mode])
+
+    const ctx = useMemo<ModeContext>(
+        () => ({ mode, setMode, toggle: () => setMode((m) => (m === 'light' ? 'dark' : 'light')) }),
+        [mode],
+    )
+
+    return (
+        <ModeContext value={ctx}>
+            {/* The gallery renders in the normal DOM, not the extension's shadow roots. */}
+            <DisableShadowRootContext value={true}>
+                <MaskThemeProvider palette={mode}>
+                    <DialogStackingProvider>{children}</DialogStackingProvider>
+                </MaskThemeProvider>
+            </DisableShadowRootContext>
+        </ModeContext>
+    )
+}

--- a/apps/book/src/registry.ts
+++ b/apps/book/src/registry.ts
@@ -1,0 +1,59 @@
+import type { DemoEntry, DemoModule, DemoSection } from './demo.ts'
+
+const modules = import.meta.glob<DemoModule>('./demos/**/*.demo.tsx')
+
+const SECTION_TITLES: Record<string, string> = {
+    foundation: 'Foundation',
+    components: 'Components',
+    icons: 'Icons',
+    shared: 'Shared',
+}
+const SECTION_ORDER = ['foundation', 'components', 'icons', 'shared']
+
+function titleCase(input: string) {
+    return input.replaceAll(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+const entries: DemoEntry[] = Object.entries(modules).map(([path, load]) => {
+    const match = path.match(/^\.\/demos\/([^/]+)\/(.+)\.demo\.tsx$/)
+    if (!match) throw new Error(`Unexpected demo path: ${path}`)
+    const [, section, name] = match
+    return {
+        id: `${section}/${name}`,
+        section,
+        name,
+        title: name,
+        order: 0,
+        load: async () => {
+            const mod = await load()
+            return mod
+        },
+    }
+})
+
+export const sections: DemoSection[] = (() => {
+    const bySection = new Map<string, DemoEntry[]>()
+    for (const entry of entries) {
+        const list = bySection.get(entry.section) ?? []
+        list.push(entry)
+        bySection.set(entry.section, list)
+    }
+    const orderOf = (id: string) => {
+        const i = SECTION_ORDER.indexOf(id)
+        return i === -1 ? SECTION_ORDER.length : i
+    }
+    return [...bySection.entries()]
+        .sort(([a], [b]) => orderOf(a) - orderOf(b) || a.localeCompare(b))
+        .map(([id, list]) => ({
+            id,
+            title: SECTION_TITLES[id] ?? titleCase(id),
+            entries: list.sort((a, b) => a.order - b.order || a.name.localeCompare(b.name)),
+        }))
+})()
+
+export const allEntries: DemoEntry[] = sections.flatMap((s) => s.entries)
+
+export function findEntry(id: string | undefined): DemoEntry | undefined {
+    if (!id) return undefined
+    return allEntries.find((e) => e.id === id)
+}

--- a/apps/book/src/router.ts
+++ b/apps/book/src/router.ts
@@ -1,0 +1,19 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
+/** Current route id, e.g. "components/ActionButton". Empty string means "home". */
+function getRoute(): string {
+    return decodeURIComponent(globalThis.location.hash.replace(/^#\/?/, ''))
+}
+
+function subscribe(onChange: () => void): () => void {
+    globalThis.addEventListener('hashchange', onChange)
+    return () => globalThis.removeEventListener('hashchange', onChange)
+}
+
+export function useRoute(): [string, (id: string) => void] {
+    const route = useSyncExternalStore(subscribe, getRoute, () => '')
+    const navigate = useCallback((id: string) => {
+        globalThis.location.hash = `#/${id}`
+    }, [])
+    return [route, navigate]
+}

--- a/apps/book/src/styles.css
+++ b/apps/book/src/styles.css
@@ -1,0 +1,165 @@
+:root {
+    --book-bg: #ffffff;
+    --book-fg: #111418;
+    --book-muted: #6b7280;
+    --book-border: #e5e7eb;
+    --book-sidebar-bg: #f7f8fa;
+    --book-accent: #1c68f3;
+    --book-canvas-bg: #ffffff;
+}
+
+[data-mui-color-scheme='dark'] {
+    --book-bg: #0f1114;
+    --book-fg: #e8eaed;
+    --book-muted: #9aa0a6;
+    --book-border: #2a2d31;
+    --book-sidebar-bg: #16181c;
+    --book-accent: #5b8def;
+    --book-canvas-bg: #121417;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+    height: 100%;
+    margin: 0;
+}
+
+body {
+    background: var(--book-bg);
+    color: var(--book-fg);
+    font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+        'Segoe UI Emoji';
+    font-size: 14px;
+}
+
+.book-shell {
+    display: grid;
+    grid-template-columns: 264px 1fr;
+    height: 100%;
+}
+
+.book-sidebar {
+    background: var(--book-sidebar-bg);
+    border-right: 1px solid var(--book-border);
+    overflow-y: auto;
+    padding: 16px 12px 40px;
+}
+
+.book-brand {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 8px 16px;
+    font-weight: 700;
+    font-size: 15px;
+}
+
+.book-theme-toggle {
+    border: 1px solid var(--book-border);
+    background: transparent;
+    color: inherit;
+    border-radius: 8px;
+    padding: 4px 8px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.book-section-title {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--book-muted);
+    padding: 16px 8px 6px;
+}
+
+.book-nav-link {
+    display: block;
+    width: 100%;
+    text-align: left;
+    border: none;
+    background: transparent;
+    color: inherit;
+    padding: 6px 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1.4;
+}
+
+.book-nav-link:hover {
+    background: color-mix(in srgb, var(--book-accent) 12%, transparent);
+}
+
+.book-nav-link[data-active='true'] {
+    background: color-mix(in srgb, var(--book-accent) 18%, transparent);
+    color: var(--book-accent);
+    font-weight: 600;
+}
+
+.book-main {
+    overflow-y: auto;
+    background: var(--book-canvas-bg);
+}
+
+.book-main-header {
+    padding: 20px 28px 12px;
+    border-bottom: 1px solid var(--book-border);
+}
+
+.book-main-header h1 {
+    margin: 0;
+    font-size: 18px;
+}
+
+.book-main-header p {
+    margin: 6px 0 0;
+    color: var(--book-muted);
+}
+
+.book-canvas {
+    padding: 28px;
+}
+
+.book-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--book-muted);
+}
+
+.book-demo-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.book-swatch {
+    border: 1px solid var(--book-border);
+    border-radius: 10px;
+    overflow: hidden;
+    width: 160px;
+}
+
+.book-swatch .chip {
+    height: 64px;
+}
+
+.book-swatch .label {
+    padding: 8px 10px;
+    font-size: 12px;
+}
+
+.book-swatch .label code {
+    color: var(--book-muted);
+    font-size: 11px;
+    word-break: break-all;
+}

--- a/apps/book/tsconfig.json
+++ b/apps/book/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "customConditions": ["mask-src"],
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/book/vercel.json
+++ b/apps/book/vercel.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd ../.. && pnpm --filter @masknet/book build",
-  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "outputDirectory": "dist"
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "buildCommand": "cd ../.. && pnpm --filter @masknet/book build",
+    "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
+    "outputDirectory": "dist"
 }

--- a/apps/book/vercel.json
+++ b/apps/book/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd ../.. && pnpm --filter @masknet/book build",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
+  "outputDirectory": "dist"
+}

--- a/apps/book/vite.config.ts
+++ b/apps/book/vite.config.ts
@@ -1,0 +1,41 @@
+import { fileURLToPath } from 'node:url'
+import { defaultClientConditions, defineConfig, searchForWorkspaceRoot } from 'vite'
+import react from '@vitejs/plugin-react'
+import wasm from 'vite-plugin-wasm'
+import topLevelAwait from 'vite-plugin-top-level-await'
+
+const workspaceRoot = searchForWorkspaceRoot(process.cwd())
+
+export default defineConfig({
+    // relative base so the built app also works when served from a sub-path
+    base: './',
+    // @masknet/shared-base re-exports @masknet/base, which loads tiny-secp256k1's wasm
+    plugins: [wasm(), topLevelAwait(), react()],
+    resolve: {
+        // Mirror packages/mask/.webpack/config.ts `conditionNames: ['mask-src', '...']`.
+        // Without this, `@masknet/theme` resolves to its dist entry, which is a `.d.ts` file.
+        conditions: ['mask-src', ...defaultClientConditions],
+        // The monorepo is symlink-heavy; keep a single copy of these.
+        dedupe: ['react', 'react-dom', '@emotion/react', '@emotion/styled', '@mui/material', '@mui/system'],
+    },
+    server: {
+        fs: {
+            // allow importing package sources that live outside apps/book
+            allow: [workspaceRoot],
+        },
+    },
+    optimizeDeps: {
+        // consume these from source, don't pre-bundle
+        exclude: ['@masknet/icons', '@masknet/shared-base', '@masknet/theme'],
+    },
+    build: {
+        outDir: 'dist',
+        emptyOutDir: true,
+        sourcemap: true,
+    },
+    define: {
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+    },
+    // silence resolve of the workspace tsconfig path aliases we don't use here
+    root: fileURLToPath(new URL('.', import.meta.url)),
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "start": "dev",
     "start-rspack": "dev-rspack",
     "start:fx": "dev --manifest firefox-mv3",
+    "book": "pnpm --filter @masknet/book dev",
+    "book:build": "pnpm --filter @masknet/book build",
     "codegen": "gulp codegen-watch",
     "build": "build",
     "build-rspack": "build-rspack",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,61 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.13.9)(@vitest/ui@4.1.10)(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))
 
+  apps/book:
+    dependencies:
+      '@emotion/react':
+        specifier: 11.14.0
+        version: 11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628)
+      '@emotion/styled':
+        specifier: 11.14.1
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628)
+      '@masknet/icons':
+        specifier: workspace:*
+        version: link:../../packages/icons
+      '@masknet/shared-base':
+        specifier: workspace:*
+        version: link:../../packages/shared-base
+      '@masknet/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
+      '@mui/icons-material':
+        specifier: 9.2.0
+        version: 9.2.0(@mui/material@9.2.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628)
+      '@mui/lab':
+        specifier: 9.0.0-beta.6
+        version: 9.0.0-beta.6(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@mui/material@9.2.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
+      '@mui/material':
+        specifier: 9.2.0
+        version: 9.2.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
+      '@mui/system':
+        specifier: 9.2.0
+        version: 9.2.0(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628))(@types/react@19.2.10)(react@0.0.0-experimental-58af67a8f8-20240628)
+      react:
+        specifier: 0.0.0-experimental-58af67a8f8-20240628
+        version: 0.0.0-experimental-58af67a8f8-20240628
+      react-dom:
+        specifier: 0.0.0-experimental-58af67a8f8-20240628
+        version: 0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.10
+        version: 19.2.10
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.10)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))
+      vite:
+        specifier: ^6.2.0
+        version: 6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.6.0
+        version: 1.6.0(rollup@4.34.9)(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))
+      vite-plugin-wasm:
+        specifier: ^3.6.0
+        version: 3.6.0(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))
+
   packages/backup-format:
     dependencies:
       '@masknet/shared-base':
@@ -591,7 +646,7 @@ importers:
         version: 3.0.2(patch_hash=94efdc8000831bca496b1a3702560d127b8b4ba024a4a26d2a4fe325f2baedae)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
       react-avatar-editor:
         specifier: ^13.0.2
-        version: 13.0.2(@babel/core@7.27.1)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
+        version: 13.0.2(@babel/core@7.29.7)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
       react-draggable:
         specifier: ^4.4.6
         version: 4.4.6(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
@@ -1851,7 +1906,7 @@ importers:
         version: 1.5.4
       react-avatar-editor:
         specifier: ^13.0.2
-        version: 13.0.2(@babel/core@7.27.1)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
+        version: 13.0.2(@babel/core@7.29.7)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628)
       react-hook-form:
         specifier: ^7.52.0
         version: 7.53.0(react@0.0.0-experimental-58af67a8f8-20240628)
@@ -2691,12 +2746,20 @@ packages:
     resolution: {integrity: sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.26.0':
     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.27.1':
     resolution: {integrity: sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.26.2':
@@ -2721,6 +2784,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.29.7':
@@ -2750,6 +2817,10 @@ packages:
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.26.0':
     resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
     engines: {node: '>=6.9.0'}
@@ -2762,12 +2833,22 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-optimise-call-expression@7.29.7':
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.27.1':
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-replace-supers@7.29.7':
@@ -2812,12 +2893,20 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helpers@7.26.0':
     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helpers@7.27.1':
     resolution: {integrity: sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.26.2':
@@ -2855,6 +2944,18 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.25.9':
     resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3857,6 +3958,9 @@ packages:
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.1':
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
@@ -4771,6 +4875,9 @@ packages:
   '@rgba-image/lanczos@0.1.1':
     resolution: {integrity: sha512-MSGGU7BZmEbg1xHtNp+StARoN7R38zJnFgSEvSzB710nXsHGEaJt//z2VnPfRQTtKSKUXEnp95JSuqDlXTBrYA==}
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rollup/plugin-commonjs@28.0.2':
     resolution: {integrity: sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -5461,6 +5568,9 @@ packages:
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
+  '@swc/wasm@1.16.2':
+    resolution: {integrity: sha512-X7Y8nRO6YrDx/2Q3ERTVpRDtxuuw+zlzMxa7VYIHt8P1S0hBT9CYit5b85BwdwGoLtOe3zpLvRSFVyXSCdW9rQ==}
+
   '@tanstack/eslint-plugin-query@5.101.2':
     resolution: {integrity: sha512-cPE99s3XZwlObfn8lCezT4j4JLj2CVzpIEywx0H4hzfPsX/o9QhdwaOwcDXxrQAqx2ds7TbvTinxhB8B/ywb6w==}
     peerDependencies:
@@ -5511,6 +5621,15 @@ packages:
 
   '@types/asn1js@2.0.2':
     resolution: {integrity: sha512-t4YHCgtD+ERvH0FyxvNlYwJ2ezhqw7t+Ygh4urQ7dJER8i185JPv6oIM3ey5YQmGN6Zp9EMbpohkjZi9t3UxwA==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
@@ -6109,6 +6228,12 @@ packages:
   '@ver0/deep-equal@1.0.1':
     resolution: {integrity: sha512-XSvL5wKXBZIv7fflMqhQx936sRpEtzxeV25xAEt0rLLXzbF6RCQaRA1jrVIn8JCubMyn/y0TaidphUtilLzl1A==}
     engines: {node: '>=18'}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -10518,6 +10643,10 @@ packages:
     resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
     engines: {node: '>=0.10.0'}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
@@ -11742,6 +11871,11 @@ packages:
   utila@0.4.0:
     resolution: {integrity: sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -11801,6 +11935,16 @@ packages:
   vinyl@3.0.0:
     resolution: {integrity: sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==}
     engines: {node: '>=10.13.0'}
+
+  vite-plugin-top-level-await@1.6.0:
+    resolution: {integrity: sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==}
+    peerDependencies:
+      vite: '>=2.8'
+
+  vite-plugin-wasm@3.6.0:
+    resolution: {integrity: sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8
 
   vite@6.2.0:
     resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
@@ -12772,6 +12916,8 @@ snapshots:
 
   '@babel/compat-data@7.27.2': {}
 
+  '@babel/compat-data@7.29.7': {}
+
   '@babel/core@7.26.0':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -12804,6 +12950,26 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -12856,6 +13022,14 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.5
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
@@ -12869,9 +13043,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.27.1)':
+  '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.3
@@ -12892,12 +13066,19 @@ snapshots:
 
   '@babel/helper-module-imports@7.25.9':
     dependencies:
-      '@babel/traverse': 7.27.1
-      '@babel/types': 7.27.1
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
@@ -12922,11 +13103,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-optimise-call-expression@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.27.1)':
     dependencies:
@@ -12960,6 +13152,8 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helpers@7.26.0':
     dependencies:
       '@babel/template': 7.27.2
@@ -12969,6 +13163,11 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.27.1
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.26.2':
     dependencies:
@@ -13004,14 +13203,24 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-runtime@7.17.12(@babel/core@7.27.1)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.27.1
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-runtime@7.17.12(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.27.1)
-      babel-plugin-polyfill-corejs3: 0.5.2(@babel/core@7.27.1)
-      babel-plugin-polyfill-regenerator: 0.3.1(@babel/core@7.27.1)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.5.2(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.3.1(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -13058,10 +13267,10 @@ snapshots:
 
   '@babel/traverse@7.26.9':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.27.1
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
-      '@babel/template': 7.27.2
+      '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       debug: 4.4.3
       globals: 11.12.0
@@ -14196,6 +14405,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.1': {}
 
   '@jridgewell/set-array@1.2.1': {}
@@ -14698,7 +14912,7 @@ snapshots:
       '@types/debug': 4.1.7
       debug: 4.4.3
       pony-cause: 2.1.10
-      semver: 7.7.2
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -15289,6 +15503,8 @@ snapshots:
       '@rgba-image/common': 0.1.13
       '@rgba-image/copy': 0.1.3
       '@rgba-image/create-image': 0.1.1
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/plugin-commonjs@28.0.2(rollup@4.34.9)':
     dependencies:
@@ -16050,6 +16266,8 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
+  '@swc/wasm@1.16.2': {}
+
   '@tanstack/eslint-plugin-query@5.101.2(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/utils': 8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.2)
@@ -16099,6 +16317,23 @@ snapshots:
 
   '@types/asn1js@2.0.2':
     optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.6
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.20.6':
     dependencies:
@@ -16744,6 +16979,18 @@ snapshots:
 
   '@ver0/deep-equal@1.0.1': {}
 
+  '@vitejs/plugin-react@4.7.0(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -17339,27 +17586,27 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
-  babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.27.1):
+  babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.26.2
-      '@babel/core': 7.27.1
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.27.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.29.7)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.5.2(@babel/core@7.27.1):
+  babel-plugin-polyfill-corejs3@0.5.2(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.27.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.29.7)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.3.1(@babel/core@7.27.1):
+  babel-plugin-polyfill-regenerator@0.3.1(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.27.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -21452,7 +21699,7 @@ snapshots:
       ky: 1.7.2
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.7.2
+      semver: 7.8.5
 
   package-manager-detector@0.2.5: {}
 
@@ -21502,7 +21749,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -21824,9 +22071,9 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-avatar-editor@13.0.2(@babel/core@7.27.1)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628):
+  react-avatar-editor@13.0.2(@babel/core@7.29.7)(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628):
     dependencies:
-      '@babel/plugin-transform-runtime': 7.17.12(@babel/core@7.27.1)
+      '@babel/plugin-transform-runtime': 7.17.12(@babel/core@7.29.7)
       '@babel/runtime': 7.26.0
       prop-types: 15.8.1
       react: 0.0.0-experimental-58af67a8f8-20240628
@@ -21918,6 +22165,8 @@ snapshots:
       react-dom: 0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628)
 
   react-refresh@0.16.0: {}
+
+  react-refresh@0.17.0: {}
 
   react-router-dom@7.18.1(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628):
     dependencies:
@@ -23196,6 +23445,8 @@ snapshots:
 
   utila@0.4.0: {}
 
+  uuid@10.0.0: {}
+
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
@@ -23301,6 +23552,21 @@ snapshots:
       remove-trailing-separator: 1.1.0
       replace-ext: 2.0.0
       teex: 1.0.1
+
+  vite-plugin-top-level-await@1.6.0(rollup@4.34.9)(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)):
+    dependencies:
+      '@rollup/plugin-virtual': 3.0.2(rollup@4.34.9)
+      '@swc/core': 1.15.43
+      '@swc/wasm': 1.16.2
+      uuid: 10.0.0
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - rollup
+
+  vite-plugin-wasm@3.6.0(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)):
+    dependencies:
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)
 
   vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - apps/*
   - packages/*
   - packages/typed-message/base
   - packages/typed-message/react


### PR DESCRIPTION
## What

Adds `apps/book` — a plain Vite + React SPA that renders Maskbook's shared UI components. **Not Storybook** (removed in #10977); this is hand-rolled and deliberately small. Plan discussion in #12439.

Components are imported from source via the `mask-src` export condition, so the gallery tracks the packages with no build step of their own.

## How it works

- **Auto-discovery** — drop a `*.demo.tsx` under `src/demos/<section>/`; `import.meta.glob` in `src/registry.ts` picks it up. First path segment = sidebar section.
- **Resolve** — `vite.config.ts` sets `resolve.conditions: ['mask-src']`, mirroring `packages/mask/.webpack/config.ts`. Without it `@masknet/theme` resolves to a `.d.ts`.
- **Providers** (`src/providers.tsx`) — `MaskThemeProvider` + light/dark toggle (localStorage), `DialogStackingProvider`, and `DisableShadowRootContext` so components render in the normal DOM instead of the extension's shadow roots.
- **Router** — ~20-line hash router; no rewrite config needed to deploy.
- **wasm** — `vite-plugin-wasm` is required because `@masknet/shared-base` re-exports `@masknet/base`, which loads `tiny-secp256k1`'s wasm.

## Sections

| Section | Demos |
|---|---|
| Foundation | colors (live `maskColor` swatches), typography, shadows |
| Components | ActionButton, Alert, Indicators, LoadingBase, Tabs (base/round/flexible), TextField |
| Icons | full `@masknet/icons` gallery — 405 icons, filter + click-to-copy |

## Wiring

- `pnpm-workspace.yaml`: add `apps/*`
- root `package.json`: `pnpm book` (dev), `pnpm book:build`
- `apps/book/vercel.json` for deploy (Root Directory `apps/book`; build/install commands `cd` to repo root for the workspace)

## Verification

- `pnpm book:build` passes (main chunk ~1.1 MB / 298 KB gzip, from the `@masknet/base` graph)
- Toured all 10 routes in headless Chromium: no console errors, light + dark both render
- Fixed one issue found in testing: this MUI fork's `Stack` takes `alignItems` only via `sx`, not as a prop — it was leaking to the DOM

## Not in scope

Injection and Plugins sections need a mock layer (background `Services.*`, site-adaptor context, web3 providers) — tracked as P4/P5 in #12439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SLkuieqJXCMg1xoL98jij
