### PR TITLE
fix: prefer DOM avatar in twitter profile card

### DIFF
--- a/packages/backup-format/tests/encryption.ts
+++ b/packages/backup-format/tests/encryption.ts
@@ -36,6 +36,8 @@ test('V1 data can be decrypted', async () => {
     expect(new Uint8Array(decrypted)).toEqual(rawData)
 })
 
+// Two KDF-bound operations (encrypt + decrypt) can exceed vitest's 5s default
+// on CI runners where bigint-buffer falls back to pure JS.
 test('decrypt(password, encrypt(password, data)) === data', async () => {
     const password = Uint8Array.from('password'.split('').map((x) => x.codePointAt(0)))
     const data = new Uint8Array([4, 5, 6])
@@ -43,7 +45,7 @@ test('decrypt(password, encrypt(password, data)) === data', async () => {
     const result = await encryptBackup(password, data)
     const decrypted = await decryptBackup(password, result)
     expect(new Uint8Array(decrypted)).toEqual(data)
-})
+}, 20_000)
 
 test('New data uses the V1 container', async () => {
     const password = Uint8Array.from('password'.split('').map((x) => x.codePointAt(0)))

--- a/packages/mask/content-script/site-adaptors/twitter.com/injection/ProfileCard/index.tsx
+++ b/packages/mask/content-script/site-adaptors/twitter.com/injection/ProfileCard/index.tsx
@@ -53,10 +53,12 @@ function ProfileCardHolder() {
         select: (user) => {
             if (!user) return null
             const legacy = user.legacy
+            const domAvatar = document.querySelector(`a[href="/${CSS.escape(legacy.screen_name)}/photo"] img`)
             return {
                 identifier: ProfileIdentifier.of(twitterBase.networkIdentifier, legacy.screen_name).unwrapOr(undefined),
                 nickname: legacy.name,
-                avatar: legacy.profile_image_url_https,
+                // DOM avatar is more accurate, avatar from api could be outdate
+                avatar: domAvatar?.getAttribute('src') || legacy.profile_image_url_https,
                 bio: legacy.description,
                 homepage: legacy.entities.url?.urls?.[0]?.expanded_url,
             } as SocialIdentity


### PR DESCRIPTION
## Problem

The Web3 profile card's avatar comes from `FireflyTwitter.getUserInfo` → `legacy.profile_image_url_https`. That API serves long-lived cached snapshots, and Twitter **deletes** profile images when a user changes their avatar — so the cached URL 404s, `<Image>` hits `onError`, and the card renders the mask-light fallback.

Repro (hover card on `@suji_yan`):

- API avatar: `.../1755533702241964032/zsuAW0vI_normal.jpg` → **404**
- page DOM avatar: `.../2059408043180544000/Kr_FNdBv_400x400.jpg` → loads fine

## Fix

Mirror the logic `collecting/identity.ts` already uses for the visiting identity (with the same rationale — *"DOM avatar is more accurate, avatar from api could be outdate"*): when the profile page for that handle is open, prefer the DOM avatar `a[href="/<handle>/photo"] img`; fall back to the API URL otherwise (hover cards on timelines).

The `select` is local to this component, so the shared `['twitter', 'profile', handle]` react-query cache is untouched.

Root-cause fix on the backend (snapshot TTL): DimensionDev/Mask-X-Backend#5882