### PR TITLE
fix(book): emit icon assets as files so they render in the prod build

### DIFF
--- a/apps/book/vite.config.ts
+++ b/apps/book/vite.config.ts
@@ -32,6 +32,11 @@ export default defineConfig({
         outDir: 'dist',
         emptyOutDir: true,
         sourcemap: true,
+        // @masknet/icons renders most icons as `background-image: url(<icon>)` with an
+        // UNQUOTED url(). Vite's inlined `data:image/svg+xml,<url-encoded>` URIs contain
+        // characters that break an unquoted url(), so most icons vanish in the prod build
+        // (dev is fine — files are served raw). Emit every icon as its own file instead.
+        assetsInlineLimit: 0,
     },
     define: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),


### PR DESCRIPTION
## Problem

In the deployed (`vite build`) component book, ~300 icons render blank — e.g. https://book-5fproh1cv-dimension-dev.vercel.app/#/icons/gallery . The dev server is fine, so it only shows up in the production build.

## Cause

`@masknet/icons` renders most icons as `background-image: url(<icon>)` with an **unquoted** `url()`. Vite's default `assetsInlineLimit` (4 KB) inlines the sub-4KB icon SVGs as `data:image/svg+xml,<url-encoded>` URIs, and those contain characters that terminate an unquoted `url()` early — so the background image resolves to nothing.

Only the ~19 icons larger than 4 KB (mostly `.png`) were emitted as files and survived. Dev serves every SVG as a real file, which is why it looked fine locally.

## Fix

Set `build.assetsInlineLimit: 0` in `apps/book/vite.config.ts` so every icon ships as its own hashed file. 449 icon assets are emitted instead of 19.

## Verification

- `pnpm --filter @masknet/book build` then `vite preview`, checked in a headless browser: icons resolve to `/assets/<name>-<hash>.svg` with 200s, gallery renders identically to dev (colored brand icons, inline-color icons, all present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SLkuieqJXCMg1xoL98jij
