### PR TITLE
feat(book): add injection and popups categories to the component book

### DIFF
--- a/apps/book/README.md
+++ b/apps/book/README.md
@@ -36,6 +36,27 @@ export default function Demo() {
 `import.meta.glob` in `src/registry.ts` picks it up automatically. The first path segment
 under `demos/` is the sidebar section (`foundation`, `components`, `icons`, `shared`, …).
 
+A section can have sub-categories one level deep: `demos/<section>/<group>/<name>.demo.tsx`
+(e.g. `demos/injection/twitter/Banner.demo.tsx`) renders under a "Twitter" sub-header inside the
+"Injection" section. `injection` is the only section that currently uses this.
+
+### Injection and Popups
+
+- `injection` demos the components each site adaptor (`packages/mask/content-script/site-adaptors/*`)
+  injects into a social platform's own page, one sub-category per platform. Most of the real
+  injection code is tightly coupled to the extension runtime (background RPC via the `#services`
+  subpath import, the live `activatedSiteAdaptorUI` global, DOM watchers) and can't run standalone
+  here. Where a component's pure-UI part could be cleanly separated from that coupling, it was
+  moved into `packages/injected-ui` — a small package with **one export per component, no barrel
+  `index.ts`** — and both the real injection code and this book import the same file from there
+  (see e.g. `packages/mask/content-script/components/GuideStep/index.tsx`, which now just computes
+  props from the real guide-progress state and renders `@masknet/injected-ui/GuideStep`). Only a
+  handful of components have been split out so far; the rest are left for follow-up.
+- `popups` demos a few self-contained presentational components from
+  `packages/mask/popups/components/*` (imported directly by relative path, since that package isn't
+  set up to be depended on by name). Anything that needs live wallet/RPC state, or that pulls in a
+  barrel file with unrelated modules, was left out — see the note in the PR that added this section.
+
 ## Deploy (Vercel)
 
 - Root Directory: `apps/book`

--- a/apps/book/package.json
+++ b/apps/book/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@masknet/icons": "workspace:*",
+    "@masknet/injected-ui": "workspace:*",
     "@masknet/shared-base": "workspace:*",
     "@masknet/theme": "workspace:*",
     "@mui/icons-material": "9.2.0",

--- a/apps/book/src/components/Nav.tsx
+++ b/apps/book/src/components/Nav.tsx
@@ -1,4 +1,5 @@
-import { sections } from '../registry.ts'
+import { Fragment } from 'react'
+import { groupTitle, sections } from '../registry.ts'
 import { useMode } from '../providers.tsx'
 
 interface Props {
@@ -17,21 +18,33 @@ export function Nav({ current, onNavigate }: Props) {
                 </button>
             </div>
 
-            {sections.map((section) => (
-                <div key={section.id}>
-                    <div className="book-section-title">{section.title}</div>
-                    {section.entries.map((entry) => (
-                        <button
-                            type="button"
-                            key={entry.id}
-                            className="book-nav-link"
-                            data-active={entry.id === current}
-                            onClick={() => onNavigate(entry.id)}>
-                            {entry.name}
-                        </button>
-                    ))}
-                </div>
-            ))}
+            {sections.map((section) => {
+                let lastGroup: string | undefined
+                return (
+                    <div key={section.id}>
+                        <div className="book-section-title">{section.title}</div>
+                        {section.entries.map((entry) => {
+                            const showGroupHeader = entry.group !== lastGroup
+                            lastGroup = entry.group
+                            return (
+                                <Fragment key={entry.id}>
+                                    {showGroupHeader && entry.group ?
+                                        <div className="book-group-title">{groupTitle(entry.group)}</div>
+                                    :   null}
+                                    <button
+                                        type="button"
+                                        className="book-nav-link"
+                                        data-active={entry.id === current}
+                                        data-grouped={!!entry.group}
+                                        onClick={() => onNavigate(entry.id)}>
+                                        {entry.name}
+                                    </button>
+                                </Fragment>
+                            )
+                        })}
+                    </div>
+                )
+            })}
         </nav>
     )
 }

--- a/apps/book/src/demo.ts
+++ b/apps/book/src/demo.ts
@@ -15,11 +15,13 @@ export interface DemoModule {
 }
 
 export interface DemoEntry {
-    /** e.g. "components/ActionButton" */
+    /** e.g. "injection/twitter/Banner" */
     id: string
-    /** e.g. "components" */
+    /** e.g. "injection" */
     section: string
-    /** e.g. "ActionButton" */
+    /** e.g. "twitter", for demos nested one level under a section */
+    group?: string
+    /** e.g. "Banner" */
     name: string
     title: string
     description?: string

--- a/apps/book/src/demos/injection/facebook/Banner.demo.tsx
+++ b/apps/book/src/demos/injection/facebook/Banner.demo.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { FormControlLabel, Stack, Switch } from '@mui/material'
+import { Banner } from '@masknet/injected-ui/Banner'
+
+export const meta = {
+    title: 'Banner',
+    description:
+        '"Sign in with Mask" entry point injected into the compose box on Facebook (packages/injected-ui/src/Banner.tsx).',
+}
+
+export default function BannerFacebookDemo() {
+    const [connected, setConnected] = useState(false)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <FormControlLabel
+                control={<Switch checked={connected} onChange={(_, checked) => setConnected(checked)} />}
+                label="Persona already connected (hides the banner)"
+            />
+            <span
+                style={{
+                    display: 'block',
+                    padding: '0 16px',
+                    marginTop: 0,
+                }}>
+                <Banner nextStep={connected ? 'hidden' : { onClick: () => alert('open dashboard') }} />
+            </span>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/facebook/PostDialogHint.demo.tsx
+++ b/apps/book/src/demos/injection/facebook/PostDialogHint.demo.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { PostDialogHint } from '@masknet/injected-ui/PostDialogHint'
+
+export const meta = {
+    title: 'PostDialogHint',
+    description:
+        'Mask badge injected next to the compose button on Facebook (packages/injected-ui/src/PostDialogHint.tsx), with the onboarding guide tip enabled.',
+}
+
+export default function PostDialogHintFacebookDemo() {
+    const [clicked, setClicked] = useState(0)
+    const [guideDismissed, setGuideDismissed] = useState(false)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start', paddingTop: '48px', paddingLeft: '48px' }}>
+            <Typography variant="body2" color="text.secondary">
+                Clicked {clicked} time(s){guideDismissed ? ' — guide dismissed' : ''}
+            </Typography>
+            <PostDialogHint
+                size={24}
+                tooltip={{ disabled: false, placement: 'top' }}
+                onHintButtonClicked={() => setClicked((c) => c + 1)}
+                guide={
+                    guideDismissed ? undefined : (
+                        {
+                            step: 1,
+                            total: 1,
+                            tip: 'Click here to have a quick start.',
+                            visible: true,
+                            onSkip: () => setGuideDismissed(true),
+                            onNext: () => setGuideDismissed(true),
+                            onTry: () => {
+                                setGuideDismissed(true)
+                                setClicked((c) => c + 1)
+                            },
+                        }
+                    )
+                }
+            />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/minds/Banner.demo.tsx
+++ b/apps/book/src/demos/injection/minds/Banner.demo.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import { FormControlLabel, Stack, Switch } from '@mui/material'
+import { Banner } from '@masknet/injected-ui/Banner'
+
+export const meta = {
+    title: 'Banner',
+    description:
+        '"Sign in with Mask" entry point injected into the compose box on Minds (packages/injected-ui/src/Banner.tsx). Minds uses the Minds-branded icon via `iconType="minds"`.',
+}
+
+export default function BannerMindsDemo() {
+    const [connected, setConnected] = useState(false)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <FormControlLabel
+                control={<Switch checked={connected} onChange={(_, checked) => setConnected(checked)} />}
+                label="Persona already connected (hides the banner)"
+            />
+            <Banner iconType="minds" nextStep={connected ? 'hidden' : { onClick: () => alert('open dashboard') }} />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/minds/PostDialogHint.demo.tsx
+++ b/apps/book/src/demos/injection/minds/PostDialogHint.demo.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { PostDialogHint } from '@masknet/injected-ui/PostDialogHint'
+
+export const meta = {
+    title: 'PostDialogHint',
+    description:
+        'Mask badge injected next to the compose button on Minds (packages/injected-ui/src/PostDialogHint.tsx). Minds disables the onboarding guide tip for this entry point.',
+}
+
+export default function PostDialogHintMindsDemo() {
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <Typography variant="body2" color="text.secondary">
+                Clicked {clicked} time(s)
+            </Typography>
+            <PostDialogHint
+                size={17}
+                iconType="minds"
+                tooltip={{ disabled: true }}
+                onHintButtonClicked={() => setClicked((c) => c + 1)}
+            />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/shared/GuideStep.demo.tsx
+++ b/apps/book/src/demos/injection/shared/GuideStep.demo.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { Button, Stack, Typography } from '@mui/material'
+import { GuideStep } from '@masknet/injected-ui/GuideStep'
+
+export const meta = {
+    title: 'GuideStep',
+    description:
+        'Onboarding tooltip overlay injected next to a highlighted element on every site adaptor (packages/injected-ui/src/GuideStep.tsx). Used cross-platform: the wallet/app toolbox hints, PostDialogHint, and the setup wizard all wrap their target in this.',
+}
+
+const TIPS = [
+    'Explore multi-chain dApps.',
+    'Connect and switch between your wallets.',
+    'Click here to have a quick start.',
+]
+const TOTAL = TIPS.length
+
+export default function GuideStepDemo() {
+    const [step, setStep] = useState(1)
+    const [finished, setFinished] = useState(false)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start', paddingTop: '48px', paddingLeft: '48px' }}>
+            <Typography variant="body2" color="text.secondary">
+                {finished ? 'Tour dismissed.' : `Step ${step} of ${TOTAL}`}
+            </Typography>
+            <Button
+                variant="outlined"
+                onClick={() => {
+                    setStep(1)
+                    setFinished(false)
+                }}>
+                Restart tour
+            </Button>
+            <GuideStep
+                total={TOTAL}
+                step={step}
+                tip={TIPS[step - 1]}
+                visible={!finished}
+                onSkip={() => setFinished(true)}
+                onNext={() => setStep((s) => Math.min(s + 1, TOTAL))}
+                onTry={() => setFinished(true)}>
+                <Button variant="contained" sx={{ pointerEvents: 'none' }}>
+                    Highlighted element
+                </Button>
+            </GuideStep>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/twitter/Banner.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/Banner.demo.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import { FormControlLabel, Stack, Switch } from '@mui/material'
+import { Banner } from '@masknet/injected-ui/Banner'
+
+export const meta = {
+    title: 'Banner',
+    description:
+        '"Sign in with Mask" entry point injected into the compose box on X/Twitter (packages/injected-ui/src/Banner.tsx). Hidden once a persona is already linked to the account.',
+}
+
+export default function BannerTwitterDemo() {
+    const [connected, setConnected] = useState(false)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <FormControlLabel
+                control={<Switch checked={connected} onChange={(_, checked) => setConnected(checked)} />}
+                label="Persona already connected (hides the banner)"
+            />
+            <Banner nextStep={connected ? 'hidden' : { onClick: () => alert('open dashboard') }} />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/twitter/PostDialogHint.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/PostDialogHint.demo.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { PostDialogHint } from '@masknet/injected-ui/PostDialogHint'
+
+export const meta = {
+    title: 'PostDialogHint',
+    description:
+        'Mask badge injected next to the compose/reply button on X/Twitter (packages/injected-ui/src/PostDialogHint.tsx), with the onboarding guide tip enabled.',
+}
+
+export default function PostDialogHintTwitterDemo() {
+    const [clicked, setClicked] = useState(0)
+    const [guideDismissed, setGuideDismissed] = useState(false)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start', paddingTop: '48px', paddingLeft: '48px' }}>
+            <Typography variant="body2" color="text.secondary">
+                Clicked {clicked} time(s){guideDismissed ? ' — guide dismissed' : ''}
+            </Typography>
+            <PostDialogHint
+                size={20}
+                tooltip={{ disabled: false, placement: 'top' }}
+                onHintButtonClicked={() => setClicked((c) => c + 1)}
+                guide={
+                    guideDismissed ? undefined : (
+                        {
+                            step: 1,
+                            total: 1,
+                            tip: 'Click here to have a quick start.',
+                            visible: true,
+                            onSkip: () => setGuideDismissed(true),
+                            onNext: () => setGuideDismissed(true),
+                            onTry: () => {
+                                setGuideDismissed(true)
+                                setClicked((c) => c + 1)
+                            },
+                        }
+                    )
+                }
+            />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/popups/BottomController.demo.tsx
+++ b/apps/book/src/demos/popups/BottomController.demo.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { Button, Stack, Typography } from '@mui/material'
+import { BottomController } from '../../../../../packages/mask/popups/components/BottomController/index.js'
+
+export const meta = {
+    title: 'BottomController',
+    description:
+        'Fixed action bar docked to the bottom of a popups page (packages/mask/popups/components/BottomController). Note: it renders `position: fixed` to the viewport — in the real extension that viewport is the ~400px popup window, so it docks to the bottom of this page here instead.',
+}
+
+export default function BottomControllerDemo() {
+    const [clicked, setClicked] = useState<string>()
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <Typography variant="body2" color="text.secondary">
+                {clicked ? `Clicked "${clicked}"` : 'Scroll down — the bar is docked to the bottom of this page.'}
+            </Typography>
+            <BottomController>
+                <Button fullWidth variant="outlined" onClick={() => setClicked('Cancel')}>
+                    Cancel
+                </Button>
+                <Button fullWidth variant="contained" onClick={() => setClicked('Confirm')}>
+                    Confirm
+                </Button>
+            </BottomController>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/popups/BottomDrawer.demo.tsx
+++ b/apps/book/src/demos/popups/BottomDrawer.demo.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import { Button, Typography } from '@mui/material'
+import { BottomDrawer } from '../../../../../packages/mask/popups/components/BottomDrawer/index.js'
+
+export const meta = {
+    title: 'BottomDrawer',
+    description: 'The bottom sheet used for in-place pickers and confirmations in popups (packages/mask/popups/components/BottomDrawer).',
+}
+
+export default function BottomDrawerDemo() {
+    const [open, setOpen] = useState(false)
+
+    return (
+        <>
+            <Button variant="contained" onClick={() => setOpen(true)}>
+                Open drawer
+            </Button>
+            <BottomDrawer open={open} onClose={() => setOpen(false)} title="Select a network">
+                <Typography sx={{ padding: 2 }}>Drawer content goes here.</Typography>
+            </BottomDrawer>
+        </>
+    )
+}

--- a/apps/book/src/demos/popups/BottomDrawer.demo.tsx
+++ b/apps/book/src/demos/popups/BottomDrawer.demo.tsx
@@ -4,7 +4,8 @@ import { BottomDrawer } from '../../../../../packages/mask/popups/components/Bot
 
 export const meta = {
     title: 'BottomDrawer',
-    description: 'The bottom sheet used for in-place pickers and confirmations in popups (packages/mask/popups/components/BottomDrawer).',
+    description:
+        'The bottom sheet used for in-place pickers and confirmations in popups (packages/mask/popups/components/BottomDrawer).',
 }
 
 export default function BottomDrawerDemo() {

--- a/apps/book/src/demos/popups/PasswordField.demo.tsx
+++ b/apps/book/src/demos/popups/PasswordField.demo.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+import { Stack } from '@mui/material'
+import { PasswordField } from '../../../../../packages/mask/popups/components/PasswordField/index.js'
+
+export const meta = {
+    title: 'PasswordField',
+    description:
+        'StyledInput with a show/hide adornment, used for backup and wallet passwords (packages/mask/popups/components/PasswordField).',
+}
+
+export default function PasswordFieldDemo() {
+    const [value, setValue] = useState('correct horse battery staple')
+
+    return (
+        <Stack spacing={3} sx={{ maxWidth: 360 }}>
+            <PasswordField label="Payment password" value={value} onChange={(e) => setValue(e.target.value)} />
+            <PasswordField label="Toggle hidden" show={false} defaultValue="always masked" />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/popups/StyledInput.demo.tsx
+++ b/apps/book/src/demos/popups/StyledInput.demo.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import { Stack } from '@mui/material'
+import { StyledInput } from '../../../../../packages/mask/popups/components/StyledInput/index.js'
+
+export const meta = {
+    title: 'StyledInput',
+    description: 'The underline-less MUI TextField used throughout the popups UI (packages/mask/popups/components/StyledInput).',
+}
+
+export default function StyledInputDemo() {
+    const [value, setValue] = useState('')
+
+    return (
+        <Stack spacing={3} sx={{ maxWidth: 360 }}>
+            <StyledInput placeholder="Placeholder" value={value} onChange={(e) => setValue(e.target.value)} />
+            <StyledInput label="With a label" placeholder="Placeholder" />
+            <StyledInput label="With an error" defaultValue="0xnope" error helperText="Not a valid address." />
+            <StyledInput label="Disabled" defaultValue="Can't touch this" disabled />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/popups/StyledInput.demo.tsx
+++ b/apps/book/src/demos/popups/StyledInput.demo.tsx
@@ -4,7 +4,8 @@ import { StyledInput } from '../../../../../packages/mask/popups/components/Styl
 
 export const meta = {
     title: 'StyledInput',
-    description: 'The underline-less MUI TextField used throughout the popups UI (packages/mask/popups/components/StyledInput).',
+    description:
+        'The underline-less MUI TextField used throughout the popups UI (packages/mask/popups/components/StyledInput).',
 }
 
 export default function StyledInputDemo() {

--- a/apps/book/src/registry.ts
+++ b/apps/book/src/registry.ts
@@ -7,20 +7,34 @@ const SECTION_TITLES: Record<string, string> = {
     components: 'Components',
     icons: 'Icons',
     shared: 'Shared',
+    injection: 'Injection',
+    popups: 'Popups',
 }
-const SECTION_ORDER = ['foundation', 'components', 'icons', 'shared']
+const SECTION_ORDER = ['foundation', 'components', 'icons', 'injection', 'popups', 'shared']
+
+// Display names for the platform sub-folders under demos/injection/<platform>/.
+const GROUP_TITLES: Record<string, string> = {
+    twitter: 'X (Twitter)',
+    facebook: 'Facebook',
+    instagram: 'Instagram',
+    minds: 'Minds',
+}
+const GROUP_ORDER = ['twitter', 'facebook', 'instagram', 'minds', 'shared']
 
 function titleCase(input: string) {
     return input.replaceAll(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 const entries: DemoEntry[] = Object.entries(modules).map(([path, load]) => {
-    const match = path.match(/^\.\/demos\/([^/]+)\/(.+)\.demo\.tsx$/)
+    // demos/<section>/<name>.demo.tsx, or demos/<section>/<group>/<name>.demo.tsx for a
+    // section with sub-categories (e.g. injection/twitter/Banner).
+    const match = path.match(/^\.\/demos\/([^/]+)\/(?:([^/]+)\/)?([^/]+)\.demo\.tsx$/)
     if (!match) throw new Error(`Unexpected demo path: ${path}`)
-    const [, section, name] = match
+    const [, section, group, name] = match
     return {
-        id: `${section}/${name}`,
+        id: group ? `${section}/${group}/${name}` : `${section}/${name}`,
         section,
+        group,
         name,
         title: name,
         order: 0,
@@ -42,14 +56,29 @@ export const sections: DemoSection[] = (() => {
         const i = SECTION_ORDER.indexOf(id)
         return i === -1 ? SECTION_ORDER.length : i
     }
+    const groupOrderOf = (group: string | undefined) => {
+        if (!group) return -1
+        const i = GROUP_ORDER.indexOf(group)
+        return i === -1 ? GROUP_ORDER.length : i
+    }
     return [...bySection.entries()]
         .sort(([a], [b]) => orderOf(a) - orderOf(b) || a.localeCompare(b))
         .map(([id, list]) => ({
             id,
             title: SECTION_TITLES[id] ?? titleCase(id),
-            entries: list.sort((a, b) => a.order - b.order || a.name.localeCompare(b.name)),
+            entries: list.sort(
+                (a, b) =>
+                    groupOrderOf(a.group) - groupOrderOf(b.group) ||
+                    (a.group ?? '').localeCompare(b.group ?? '') ||
+                    a.order - b.order ||
+                    a.name.localeCompare(b.name),
+            ),
         }))
 })()
+
+export function groupTitle(group: string): string {
+    return GROUP_TITLES[group] ?? titleCase(group)
+}
 
 export const allEntries: DemoEntry[] = sections.flatMap((s) => s.entries)
 

--- a/apps/book/src/styles.css
+++ b/apps/book/src/styles.css
@@ -79,6 +79,13 @@ body {
     padding: 16px 8px 6px;
 }
 
+.book-group-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--book-muted);
+    padding: 8px 8px 2px 16px;
+}
+
 .book-nav-link {
     display: block;
     width: 100%;
@@ -91,6 +98,10 @@ body {
     cursor: pointer;
     font-size: 13px;
     line-height: 1.4;
+}
+
+.book-nav-link[data-grouped='true'] {
+    padding-left: 20px;
 }
 
 .book-nav-link:hover {

--- a/apps/book/vite.config.ts
+++ b/apps/book/vite.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
         // Mirror packages/mask/.webpack/config.ts `conditionNames: ['mask-src', '...']`.
         // Without this, `@masknet/theme` resolves to its dist entry, which is a `.d.ts` file.
         conditions: ['mask-src', ...defaultClientConditions],
+        // Mirror packages/mask/.webpack/config.ts `resolve.extensionAlias`. packages/mask source
+        // files import siblings with a `.js` specifier even though the file on disk is `.ts`/`.tsx`
+        // (TS `moduleResolution: bundler`); popups/injection demos pull those files in directly.
+        extensionAlias: {
+            '.js': ['.js', '.tsx', '.ts'],
+        },
         // The monorepo is symlink-heavy; keep a single copy of these.
         dedupe: ['react', 'react-dom', '@emotion/react', '@emotion/styled', '@mui/material', '@mui/system'],
     },
@@ -26,7 +32,7 @@ export default defineConfig({
     },
     optimizeDeps: {
         // consume these from source, don't pre-bundle
-        exclude: ['@masknet/icons', '@masknet/shared-base', '@masknet/theme'],
+        exclude: ['@masknet/icons', '@masknet/injected-ui', '@masknet/shared-base', '@masknet/theme'],
     },
     build: {
         outDir: 'dist',

--- a/packages/injected-ui/package.json
+++ b/packages/injected-ui/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@masknet/injected-ui",
+  "version": "0.0.0",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "description": "Pure, prop-driven UI pieces used by the site-adaptor injections (packages/mask/content-script) and demoed by the component book (apps/book). No barrel index on purpose: each component has its own export entry so importing one never pulls in the others.",
+  "exports": {
+    "./GuideStep": {
+      "types": "./dist/GuideStep.d.ts",
+      "mask-src": "./src/GuideStep.tsx",
+      "default": "./dist/GuideStep.js"
+    },
+    "./Banner": {
+      "types": "./dist/Banner.d.ts",
+      "mask-src": "./src/Banner.tsx",
+      "default": "./dist/Banner.js"
+    },
+    "./PostDialogHint": {
+      "types": "./dist/PostDialogHint.d.ts",
+      "mask-src": "./src/PostDialogHint.tsx",
+      "default": "./dist/PostDialogHint.js"
+    }
+  },
+  "dependencies": {
+    "@masknet/icons": "workspace:^",
+    "@masknet/theme": "workspace:^"
+  }
+}

--- a/packages/injected-ui/src/Banner.tsx
+++ b/packages/injected-ui/src/Banner.tsx
@@ -1,0 +1,49 @@
+import { Icons } from '@masknet/icons'
+import { MaskColors, makeStyles } from '@masknet/theme'
+import { IconButton } from '@mui/material'
+import type { JSX } from 'react'
+
+export interface BannerProps extends withClasses<'header' | 'content' | 'actions' | 'buttonText'> {
+    description?: string
+    nextStep:
+        | 'hidden'
+        | {
+              onClick(): void
+          }
+    username?:
+        | 'hidden'
+        | {
+              isValid(username: string): boolean
+              value: string
+              defaultValue: string
+              onChange(nextValue: string): void
+          }
+    iconType?: string
+}
+
+const ICON_MAP: { [property: string]: JSX.Element } = {
+    minds: <Icons.MaskInMinds size={18} />,
+    default: <Icons.SharpMask size={17} color={MaskColors.light.maskColor.publicTwitter} />,
+}
+const useStyles = makeStyles()({
+    buttonText: {
+        width: 38,
+        height: 38,
+        margin: '10px 0',
+    },
+})
+
+/**
+ * The "sign in with Mask" entry point injected into the compose box on every site adaptor.
+ * Pure UI: whether it should render at all, and what the default next step/username field are,
+ * is decided by the caller (see packages/mask/content-script/components/Welcomes/Banner.tsx).
+ */
+export function Banner(props: BannerProps) {
+    const { classes } = useStyles(undefined, { props })
+
+    return props.nextStep === 'hidden' ?
+            null
+        :   <IconButton size="large" className={classes.buttonText} onClick={props.nextStep.onClick}>
+                {ICON_MAP[props.iconType ?? 'default']}
+            </IconButton>
+}

--- a/packages/injected-ui/src/GuideStep.tsx
+++ b/packages/injected-ui/src/GuideStep.tsx
@@ -1,0 +1,231 @@
+import { cloneElement, useRef, useState, type ReactElement, useLayoutEffect, type RefObject, type ReactNode } from 'react'
+import { makeStyles, usePortalShadowRoot } from '@masknet/theme'
+import { Box, Modal, styled, Typography } from '@mui/material'
+
+const useStyles = makeStyles()((theme) => ({
+    container: {
+        position: 'absolute',
+        boxShadow: '0 0 0 3000px rgba(0,0,0,.3)',
+        ...theme.applyStyles('dark', { boxShadow: '0 0 0 3000px rgba(110,118,125,.3)' }),
+        borderRadius: 8,
+    },
+    noBoxShadowCover: {
+        boxShadow: '0 0 0 3000px rgba(0,0,0,.2)',
+        ...theme.applyStyles('dark', { boxShadow: '0 0 0 3000px rgba(110,118,125,.2)' }),
+    },
+    target: {
+        background: 'transparent',
+    },
+    mask: {
+        position: 'fixed',
+        top: 0,
+        width: '100vw',
+        height: '100vh',
+        background: 'transparent',
+        zIndex: 1000,
+    },
+    card: {
+        position: 'absolute',
+        left: 0,
+        width: 256,
+        padding: '16px',
+        borderRadius: '16px',
+        background: 'rgba(0,0,0,.85)',
+        boxShadow: '0 4px 8px rgba(0,0,0,.1)',
+        boxSizing: 'border-box',
+        color: '#fff',
+        '&.arrow-top:after': {
+            content: '""',
+            display: 'inline-block',
+            width: 0,
+            height: 0,
+            border: 'solid 8px transparent',
+            borderBottomColor: 'rgba(0,0,0,.85)',
+            borderBottomWidth: '13px',
+            borderTopWidth: 0,
+            position: 'absolute',
+            top: '-13px',
+            left: '24px',
+        },
+        '&.arrow-bottom:after': {
+            content: '""',
+            display: 'inline-block',
+            width: 0,
+            height: 0,
+            border: 'solid 8px transparent',
+            borderTopColor: 'rgba(0,0,0,.85)',
+            borderTopWidth: '13px',
+            borderBottomWidth: 0,
+            position: 'absolute',
+            bottom: '-13px',
+            left: '24px',
+        },
+    },
+    buttonContainer: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        paddingTop: '16px',
+    },
+}))
+
+const ActionButton = styled('button')({
+    boxSizing: 'border-box',
+    width: 104,
+    height: 32,
+    lineHeight: '32px',
+    borderRadius: 16,
+    textAlign: 'center',
+    border: 'solid 1px #000',
+    borderColor: '#fff',
+    cursor: 'pointer',
+    fontFamily: 'PingFang SC',
+    background: 'none',
+    color: 'inherit',
+})
+
+const NextButton = styled(ActionButton)({
+    border: 'none',
+    color: '#111418',
+    background: '#fff',
+})
+
+export interface GuideStepProps {
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/no-restricted-types
+    children: ReactElement<{ ref: RefObject<HTMLElement | undefined> }>
+    total: number
+    step: number
+    tip: ReactNode
+    arrow?: boolean
+    /** Whether this step is the currently active, unfinished guide step. */
+    visible: boolean
+    skipLabel?: ReactNode
+    nextLabel?: ReactNode
+    tryLabel?: ReactNode
+    onSkip: () => void
+    onNext: () => void
+    onTry: () => void
+}
+
+/**
+ * The onboarding tooltip overlay injected next to a highlighted element on every site adaptor.
+ * Pure UI: whether the step is visible and what happens on Skip/Next/Try are all supplied by the caller,
+ * which owns the actual guide progress (see packages/mask/content-script/components/GuideStep).
+ */
+export function GuideStep({
+    total,
+    step,
+    tip,
+    children,
+    arrow = true,
+    visible,
+    skipLabel = 'Skip',
+    nextLabel = 'Next',
+    tryLabel = 'Try',
+    onSkip,
+    onNext,
+    onTry,
+}: GuideStepProps) {
+    const { classes, cx } = useStyles()
+    const childrenRef = useRef<HTMLElement>(undefined)
+    const [clientRect, setClientRect] = useState<Pick<DOMRect, 'width' | 'height' | 'top' | 'left'>>()
+    const [bottomAvailable, setBottomAvailable] = useState(true)
+
+    const box1Ref = useRef<HTMLDivElement>(null)
+    const box2Ref = useRef<HTMLDivElement>(null)
+    const box3Ref = useRef<HTMLDivElement>(null)
+
+    const stepVisible = visible && !!clientRect?.top && !!clientRect.left
+
+    useLayoutEffect(() => {
+        let stopped = false
+        requestAnimationFrame(function fn() {
+            if (stopped) return
+            requestAnimationFrame(fn)
+            if (!childrenRef.current) return
+            const cr = childrenRef.current.getBoundingClientRect()
+            if (!cr.height) return
+            const bottomAvailable = window.innerHeight - cr.height - cr.top > 200
+            setBottomAvailable(bottomAvailable)
+            setClientRect((old) => {
+                if (
+                    old &&
+                    (old.height === cr.height || old.left === cr.left || old.top === cr.top || old.width === cr.width)
+                )
+                    return old
+                return cr
+            })
+            if (box1Ref.current) {
+                box1Ref.current.style.top = `${cr.top}px`
+                box1Ref.current.style.left = `${cr.left}px`
+            }
+            if (box2Ref.current) {
+                box2Ref.current.style.width = `${cr.width}px`
+                box2Ref.current.style.height = `${cr.height}px`
+            }
+            if (box3Ref.current) {
+                box3Ref.current.style.left = `${cr.width < 50 ? -cr.width / 2 : 0}px`
+                box3Ref.current.style.top = bottomAvailable ? `${cr.height + 16}px` : ''
+                box3Ref.current.style.bottom = bottomAvailable ? '' : `${cr.height + 16}px`
+            }
+        })
+        return () => void (stopped = true)
+    }, [])
+    // eslint-disable-next-line @eslint-react/no-clone-element
+    const child = cloneElement(children, { ref: childrenRef })
+
+    return (
+        <>
+            {child}
+            {usePortalShadowRoot((container) => {
+                if (!stepVisible) return null
+                return (
+                    <Modal open hideBackdrop container={container} className={classes.mask} onClose={onSkip}>
+                        {/* this extra div is feed to <FocusTrap /> If we remove it, it will show a blue outline on the box1 */}
+                        <div>
+                            <div
+                                ref={box1Ref}
+                                className={cx(classes.container, step === 3 ? classes.noBoxShadowCover : null)}>
+                                <Box ref={box2Ref} className={classes.target}>
+                                    <div
+                                        ref={box3Ref}
+                                        className={cx(
+                                            classes.card,
+                                            arrow ?
+                                                bottomAvailable ? 'arrow-top'
+                                                :   'arrow-bottom'
+                                            :   '',
+                                        )}>
+                                        <Box sx={{ paddingBottom: '16px' }}>
+                                            <Typography sx={{ fontSize: 20 }}>
+                                                {step}/{total}
+                                            </Typography>
+                                        </Box>
+                                        <div>
+                                            <Typography sx={{ fontSize: 14, fontWeight: 600 }}>{tip}</Typography>
+                                        </div>
+                                        <div className={classes.buttonContainer}>
+                                            {step === total ?
+                                                <NextButton type="button" style={{ width: '100%' }} onClick={onTry}>
+                                                    {tryLabel}
+                                                </NextButton>
+                                            :   <>
+                                                    <ActionButton type="button" onClick={onSkip}>
+                                                        {skipLabel}
+                                                    </ActionButton>
+                                                    <NextButton type="button" onClick={onNext}>
+                                                        {nextLabel}
+                                                    </NextButton>
+                                                </>
+                                            }
+                                        </div>
+                                    </div>
+                                </Box>
+                            </div>
+                        </div>
+                    </Modal>
+                )
+            })}
+        </>
+    )
+}

--- a/packages/injected-ui/src/GuideStep.tsx
+++ b/packages/injected-ui/src/GuideStep.tsx
@@ -1,4 +1,12 @@
-import { cloneElement, useRef, useState, type ReactElement, useLayoutEffect, type RefObject, type ReactNode } from 'react'
+import {
+    cloneElement,
+    useRef,
+    useState,
+    type ReactElement,
+    useLayoutEffect,
+    type RefObject,
+    type ReactNode,
+} from 'react'
 import { makeStyles, usePortalShadowRoot } from '@masknet/theme'
 import { Box, Modal, styled, Typography } from '@mui/material'
 

--- a/packages/injected-ui/src/PostDialogHint.tsx
+++ b/packages/injected-ui/src/PostDialogHint.tsx
@@ -1,0 +1,85 @@
+import { Icons } from '@masknet/icons'
+import { MaskColors, ShadowRootTooltip, makeStyles } from '@masknet/theme'
+import { IconButton } from '@mui/material'
+import { memo, type JSX, type ReactNode } from 'react'
+import { GuideStep, type GuideStepProps } from './GuideStep.js'
+
+interface TooltipConfigProps {
+    placement?: 'bottom' | 'top'
+    disabled?: boolean
+}
+
+export interface PostDialogHintGuideProps
+    extends Pick<
+        GuideStepProps,
+        'total' | 'step' | 'tip' | 'visible' | 'onSkip' | 'onNext' | 'onTry' | 'skipLabel' | 'nextLabel' | 'tryLabel'
+    > {}
+
+export interface PostDialogHintProps extends withClasses<'buttonTransform' | 'iconButton' | 'tooltip'> {
+    size?: number
+    tooltip?: TooltipConfigProps
+    tooltipTitle?: ReactNode
+    iconType?: string
+    onHintButtonClicked: () => void
+    /** Renders the onboarding tooltip around the icon when provided; omit to skip it entirely. */
+    guide?: PostDialogHintGuideProps
+}
+
+const useStyles = makeStyles()(() => ({
+    button: {
+        padding: 'var(--icon-padding, 10px)',
+    },
+}))
+
+const ICON_MAP: { [property: string]: JSX.Element } = {
+    minds: <Icons.MaskInMinds size={18} />,
+    default: (
+        <Icons.SharpMask
+            style={{
+                height: 'var(--icon-size, 17px)',
+                width: 'var(--icon-size, 17px)',
+            }}
+            color={MaskColors.light.maskColor.publicTwitter}
+        />
+    ),
+}
+
+const EntryIconButton = memo(function EntryIconButton(props: PostDialogHintProps) {
+    const { tooltip, tooltipTitle = 'Mask Network', guide } = props
+    const { classes, cx } = useStyles(undefined, { props })
+
+    const Entry = (
+        <ShadowRootTooltip
+            title={tooltipTitle}
+            placement={tooltip?.placement}
+            disableHoverListener={tooltip?.disabled}
+            slotProps={{ popper: { disablePortal: false } }}
+            arrow>
+            <IconButton
+                size="large"
+                className={cx(classes.button, classes.iconButton)}
+                onClick={props.onHintButtonClicked}>
+                {ICON_MAP[props.iconType ?? 'default']}
+            </IconButton>
+        </ShadowRootTooltip>
+    )
+
+    return guide ?
+            <GuideStep {...guide}>{Entry}</GuideStep>
+        :   Entry
+})
+
+/**
+ * The small Mask badge injected next to a platform's own "compose"/"post" button.
+ * Pure UI: which persona/guide state applies is resolved by the caller, see
+ * packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx.
+ */
+export const PostDialogHint = memo(function PostDialogHint(props: PostDialogHintProps) {
+    const { onHintButtonClicked, size, ...others } = props
+    const { classes } = useStyles(undefined, { props })
+    return (
+        <div className={classes.buttonTransform}>
+            <EntryIconButton size={size} onHintButtonClicked={onHintButtonClicked} {...others} />
+        </div>
+    )
+})

--- a/packages/injected-ui/src/PostDialogHint.tsx
+++ b/packages/injected-ui/src/PostDialogHint.tsx
@@ -64,9 +64,7 @@ const EntryIconButton = memo(function EntryIconButton(props: PostDialogHintProps
         </ShadowRootTooltip>
     )
 
-    return guide ?
-            <GuideStep {...guide}>{Entry}</GuideStep>
-        :   Entry
+    return guide ? <GuideStep {...guide}>{Entry}</GuideStep> : Entry
 })
 
 /**

--- a/packages/injected-ui/tsconfig.json
+++ b/packages/injected-ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src/",
+    "outDir": "./dist/",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["./src"],
+  "references": [{ "path": "../theme/tsconfig.json" }]
+}

--- a/packages/mask/content-script/components/GuideStep/index.tsx
+++ b/packages/mask/content-script/components/GuideStep/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactElement, type RefObject } from 'react'
+import type { ReactElement, RefObject } from 'react'
 import { GuideStep as GuideStepUI, type GuideStepProps as GuideStepUIProps } from '@masknet/injected-ui/GuideStep'
 import { sayHelloShowed, userGuideFinished, userGuideStatus } from '@masknet/shared-base'
 import { useValueRef } from '@masknet/shared-base-ui'
@@ -18,24 +18,24 @@ export function useGuideStepState({ step, total, onComplete }: UseGuideStepState
     const finished = useValueRef(userGuideFinished[networkIdentifier])
     const visible = +currentStep === step && !finished
 
-    const onSkip = useCallback(() => {
+    const onSkip = () => {
         sayHelloShowed[networkIdentifier].value = true
         userGuideFinished[networkIdentifier].value = true
-    }, [networkIdentifier])
+    }
 
-    const onNext = useCallback(() => {
+    const onNext = () => {
         if (step !== total) {
             userGuideStatus[networkIdentifier].value = String(step + 1)
         }
         if (step === total - 1) {
             document.body.scrollIntoView()
         }
-    }, [networkIdentifier, step, total])
+    }
 
-    const onTry = useCallback(() => {
+    const onTry = () => {
         userGuideFinished[networkIdentifier].value = true
         onComplete?.()
-    }, [networkIdentifier, onComplete])
+    }
 
     return { visible, onSkip, onNext, onTry }
 }

--- a/packages/mask/content-script/components/GuideStep/index.tsx
+++ b/packages/mask/content-script/components/GuideStep/index.tsx
@@ -24,13 +24,13 @@ export function useGuideStepState({ step, total, onComplete }: UseGuideStepState
     const onSkip = () => {
         // eslint-disable-next-line react-compiler/react-compiler
         sayHelloShowed[networkIdentifier].value = true
-        // eslint-disable-next-line react-compiler/react-compiler
+         
         userGuideFinished[networkIdentifier].value = true
     }
 
     const onNext = () => {
         if (step !== total) {
-            // eslint-disable-next-line react-compiler/react-compiler
+             
             userGuideStatus[networkIdentifier].value = String(step + 1)
         }
         if (step === total - 1) {
@@ -39,7 +39,7 @@ export function useGuideStepState({ step, total, onComplete }: UseGuideStepState
     }
 
     const onTry = () => {
-        // eslint-disable-next-line react-compiler/react-compiler
+         
         userGuideFinished[networkIdentifier].value = true
         onComplete?.()
     }

--- a/packages/mask/content-script/components/GuideStep/index.tsx
+++ b/packages/mask/content-script/components/GuideStep/index.tsx
@@ -24,13 +24,12 @@ export function useGuideStepState({ step, total, onComplete }: UseGuideStepState
     const onSkip = () => {
         // eslint-disable-next-line react-compiler/react-compiler
         sayHelloShowed[networkIdentifier].value = true
-         
+
         userGuideFinished[networkIdentifier].value = true
     }
 
     const onNext = () => {
         if (step !== total) {
-             
             userGuideStatus[networkIdentifier].value = String(step + 1)
         }
         if (step === total - 1) {
@@ -39,7 +38,6 @@ export function useGuideStepState({ step, total, onComplete }: UseGuideStepState
     }
 
     const onTry = () => {
-         
         userGuideFinished[networkIdentifier].value = true
         onComplete?.()
     }

--- a/packages/mask/content-script/components/GuideStep/index.tsx
+++ b/packages/mask/content-script/components/GuideStep/index.tsx
@@ -1,241 +1,62 @@
-import {
-    cloneElement,
-    useRef,
-    useState,
-    type ReactElement,
-    useLayoutEffect,
-    type RefObject,
-    type ReactNode,
-} from 'react'
-import { makeStyles, usePortalShadowRoot } from '@masknet/theme'
-import { Box, Modal, styled, Typography } from '@mui/material'
+import { useCallback, type ReactElement, type RefObject } from 'react'
+import { GuideStep as GuideStepUI, type GuideStepProps as GuideStepUIProps } from '@masknet/injected-ui/GuideStep'
 import { sayHelloShowed, userGuideFinished, userGuideStatus } from '@masknet/shared-base'
 import { useValueRef } from '@masknet/shared-base-ui'
 import { activatedSiteAdaptorUI } from '../../site-adaptor-infra/index.js'
 import { Trans } from '@lingui/react/macro'
 
-const useStyles = makeStyles()((theme) => ({
-    container: {
-        position: 'absolute',
-        boxShadow: '0 0 0 3000px rgba(0,0,0,.3)',
-        ...theme.applyStyles('dark', { boxShadow: '0 0 0 3000px rgba(110,118,125,.3)' }),
-        borderRadius: 8,
-    },
-    noBoxShadowCover: {
-        boxShadow: '0 0 0 3000px rgba(0,0,0,.2)',
-        ...theme.applyStyles('dark', { boxShadow: '0 0 0 3000px rgba(110,118,125,.2)' }),
-    },
-    target: {
-        background: 'transparent',
-    },
-    mask: {
-        position: 'fixed',
-        top: 0,
-        width: '100vw',
-        height: '100vh',
-        background: 'transparent',
-        zIndex: 1000,
-    },
-    card: {
-        position: 'absolute',
-        left: 0,
-        width: 256,
-        padding: '16px',
-        borderRadius: '16px',
-        background: 'rgba(0,0,0,.85)',
-        boxShadow: '0 4px 8px rgba(0,0,0,.1)',
-        boxSizing: 'border-box',
-        color: '#fff',
-        '&.arrow-top:after': {
-            content: '""',
-            display: 'inline-block',
-            width: 0,
-            height: 0,
-            border: 'solid 8px transparent',
-            borderBottomColor: 'rgba(0,0,0,.85)',
-            borderBottomWidth: '13px',
-            borderTopWidth: 0,
-            position: 'absolute',
-            top: '-13px',
-            left: '24px',
-        },
-        '&.arrow-bottom:after': {
-            content: '""',
-            display: 'inline-block',
-            width: 0,
-            height: 0,
-            border: 'solid 8px transparent',
-            borderTopColor: 'rgba(0,0,0,.85)',
-            borderTopWidth: '13px',
-            borderBottomWidth: 0,
-            position: 'absolute',
-            bottom: '-13px',
-            left: '24px',
-        },
-    },
-    buttonContainer: {
-        display: 'flex',
-        justifyContent: 'space-between',
-        paddingTop: '16px',
-    },
-}))
-
-const ActionButton = styled('button')({
-    boxSizing: 'border-box',
-    width: 104,
-    height: 32,
-    lineHeight: '32px',
-    borderRadius: 16,
-    textAlign: 'center',
-    border: 'solid 1px #000',
-    borderColor: '#fff',
-    cursor: 'pointer',
-    fontFamily: 'PingFang SC',
-    background: 'none',
-    color: 'inherit',
-})
-
-const NextButton = styled(ActionButton)({
-    border: 'none',
-    color: '#111418',
-    background: '#fff',
-})
-
-interface GuideStepProps {
-    // cloneElement is used.
-    // eslint-disable-next-line @typescript-eslint/no-restricted-types
-    children: ReactElement<{ ref: RefObject<HTMLElement | undefined> }>
-    total: number
+interface UseGuideStepStateOptions {
     step: number
-    tip: ReactNode
-    arrow?: boolean
+    total: number
     onComplete?: () => void
 }
 
-export default function GuideStep({ total, step, tip, children, arrow = true, onComplete }: GuideStepProps) {
-    const { classes, cx } = useStyles()
-    const childrenRef = useRef<HTMLElement>(undefined)
-    const [clientRect, setClientRect] = useState<Pick<DOMRect, 'width' | 'height' | 'top' | 'left'>>()
-    const [bottomAvailable, setBottomAvailable] = useState(true)
+/** The actual guide progress (which step is active, skip/finish persistence). Shared by GuideStep and any other injected component that needs to render its own guide tooltip (e.g. PostDialogHint). */
+export function useGuideStepState({ step, total, onComplete }: UseGuideStepStateOptions) {
     const { networkIdentifier } = activatedSiteAdaptorUI!
     const currentStep = useValueRef(userGuideStatus[networkIdentifier])
     const finished = useValueRef(userGuideFinished[networkIdentifier])
-    const isCurrentStep = +currentStep === step
+    const visible = +currentStep === step && !finished
 
-    const box1Ref = useRef<HTMLDivElement>(null)
-    const box2Ref = useRef<HTMLDivElement>(null)
-    const box3Ref = useRef<HTMLDivElement>(null)
-
-    const stepVisible = isCurrentStep && !finished && !!clientRect?.top && !!clientRect.left
-
-    const onSkip = () => {
+    const onSkip = useCallback(() => {
         sayHelloShowed[networkIdentifier].value = true
         userGuideFinished[networkIdentifier].value = true
-    }
+    }, [networkIdentifier])
 
-    const onNext = () => {
+    const onNext = useCallback(() => {
         if (step !== total) {
             userGuideStatus[networkIdentifier].value = String(step + 1)
         }
         if (step === total - 1) {
             document.body.scrollIntoView()
         }
-    }
+    }, [networkIdentifier, step, total])
 
-    const onTry = () => {
+    const onTry = useCallback(() => {
         userGuideFinished[networkIdentifier].value = true
         onComplete?.()
-    }
+    }, [networkIdentifier, onComplete])
 
-    useLayoutEffect(() => {
-        let stopped = false
-        requestAnimationFrame(function fn() {
-            if (stopped) return
-            requestAnimationFrame(fn)
-            if (!childrenRef.current) return
-            const cr = childrenRef.current.getBoundingClientRect()
-            if (!cr.height) return
-            const bottomAvailable = window.innerHeight - cr.height - cr.top > 200
-            setBottomAvailable(bottomAvailable)
-            setClientRect((old) => {
-                if (
-                    old &&
-                    (old.height === cr.height || old.left === cr.left || old.top === cr.top || old.width === cr.width)
-                )
-                    return old
-                return cr
-            })
-            if (box1Ref.current) {
-                box1Ref.current.style.top = `${cr.top}px`
-                box1Ref.current.style.left = `${cr.left}px`
-            }
-            if (box2Ref.current) {
-                box2Ref.current.style.width = `${cr.width}px`
-                box2Ref.current.style.height = `${cr.height}px`
-            }
-            if (box3Ref.current) {
-                box3Ref.current.style.left = `${cr.width < 50 ? -cr.width / 2 : 0}px`
-                box3Ref.current.style.top = bottomAvailable ? `${cr.height + 16}px` : ''
-                box3Ref.current.style.bottom = bottomAvailable ? '' : `${cr.height + 16}px`
-            }
-        })
-        return () => void (stopped = true)
-    }, [])
-    // eslint-disable-next-line @eslint-react/no-clone-element
-    const child = cloneElement(children, { ref: childrenRef })
+    return { visible, onSkip, onNext, onTry }
+}
 
+interface GuideStepProps
+    extends Omit<GuideStepUIProps, 'visible' | 'onSkip' | 'onNext' | 'onTry' | 'skipLabel' | 'nextLabel' | 'tryLabel'> {
+    // cloneElement is used.
+    // eslint-disable-next-line @typescript-eslint/no-restricted-types
+    children: ReactElement<{ ref: RefObject<HTMLElement | undefined> }>
+    onComplete?: () => void
+}
+
+export default function GuideStep({ onComplete, ...props }: GuideStepProps) {
+    const state = useGuideStepState({ step: props.step, total: props.total, onComplete })
     return (
-        <>
-            {child}
-            {usePortalShadowRoot((container) => {
-                if (!stepVisible) return null
-                return (
-                    <Modal open hideBackdrop container={container} className={classes.mask} onClose={onSkip}>
-                        {/* this extra div is feed to <FocusTrap /> If we remove it, it will show a blue outline on the box1 */}
-                        <div>
-                            <div
-                                ref={box1Ref}
-                                className={cx(classes.container, step === 3 ? classes.noBoxShadowCover : null)}>
-                                <Box ref={box2Ref} className={classes.target}>
-                                    <div
-                                        ref={box3Ref}
-                                        className={cx(
-                                            classes.card,
-                                            arrow ?
-                                                bottomAvailable ? 'arrow-top'
-                                                :   'arrow-bottom'
-                                            :   '',
-                                        )}>
-                                        <Box sx={{ paddingBottom: '16px' }}>
-                                            <Typography sx={{ fontSize: 20 }}>
-                                                {step}/{total}
-                                            </Typography>
-                                        </Box>
-                                        <div>
-                                            <Typography sx={{ fontSize: 14, fontWeight: 600 }}>{tip}</Typography>
-                                        </div>
-                                        <div className={classes.buttonContainer}>
-                                            {step === total ?
-                                                <NextButton type="button" style={{ width: '100%' }} onClick={onTry}>
-                                                    <Trans>Try</Trans>
-                                                </NextButton>
-                                            :   <>
-                                                    <ActionButton type="button" onClick={onSkip}>
-                                                        <Trans>Skip</Trans>
-                                                    </ActionButton>
-                                                    <NextButton type="button" onClick={onNext}>
-                                                        <Trans>Next</Trans>
-                                                    </NextButton>
-                                                </>
-                                            }
-                                        </div>
-                                    </div>
-                                </Box>
-                            </div>
-                        </div>
-                    </Modal>
-                )
-            })}
-        </>
+        <GuideStepUI
+            {...props}
+            {...state}
+            skipLabel={<Trans>Skip</Trans>}
+            nextLabel={<Trans>Next</Trans>}
+            tryLabel={<Trans>Try</Trans>}
+        />
     )
 }

--- a/packages/mask/content-script/components/GuideStep/index.tsx
+++ b/packages/mask/content-script/components/GuideStep/index.tsx
@@ -18,13 +18,19 @@ export function useGuideStepState({ step, total, onComplete }: UseGuideStepState
     const finished = useValueRef(userGuideFinished[networkIdentifier])
     const visible = +currentStep === step && !finished
 
+    // These are event handlers (Skip/Next/Try button clicks), not render-time writes; they
+    // persist guide progress into shared-base's ValueRefs, same as before this was pulled out
+    // into its own hook.
     const onSkip = () => {
+        // eslint-disable-next-line react-compiler/react-compiler
         sayHelloShowed[networkIdentifier].value = true
+        // eslint-disable-next-line react-compiler/react-compiler
         userGuideFinished[networkIdentifier].value = true
     }
 
     const onNext = () => {
         if (step !== total) {
+            // eslint-disable-next-line react-compiler/react-compiler
             userGuideStatus[networkIdentifier].value = String(step + 1)
         }
         if (step === total - 1) {
@@ -33,6 +39,7 @@ export function useGuideStepState({ step, total, onComplete }: UseGuideStepState
     }
 
     const onTry = () => {
+        // eslint-disable-next-line react-compiler/react-compiler
         userGuideFinished[networkIdentifier].value = true
         onComplete?.()
     }

--- a/packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+++ b/packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
@@ -1,79 +1,34 @@
-import { Icons } from '@masknet/icons'
-import { MaskColors, ShadowRootTooltip, makeStyles } from '@masknet/theme'
-import { IconButton } from '@mui/material'
-import { memo, type JSX } from 'react'
-import GuideStep from '../GuideStep/index.js'
+import {
+    PostDialogHint as PostDialogHintUI,
+    type PostDialogHintProps as PostDialogHintUIProps,
+} from '@masknet/injected-ui/PostDialogHint'
+import { useGuideStepState } from '../GuideStep/index.js'
 import { Trans } from '@lingui/react/macro'
 
-interface TooltipConfigProps {
-    placement?: 'bottom' | 'top'
-    disabled?: boolean
-}
-
-interface PostDialogHintUIProps extends withClasses<'buttonTransform' | 'iconButton' | 'tooltip'> {
+interface PostDialogHintProps extends Omit<PostDialogHintUIProps, 'guide' | 'tooltipTitle'> {
     disableGuideTip?: boolean
-    size?: number
-    tooltip?: TooltipConfigProps
-    iconType?: string
-    onHintButtonClicked: () => void
 }
 
-const useStyles = makeStyles()((theme) => ({
-    button: {
-        padding: 'var(--icon-padding, 10px)',
-    },
-}))
-
-const ICON_MAP: { [property: string]: JSX.Element } = {
-    minds: <Icons.MaskInMinds size={18} />,
-    default: (
-        <Icons.SharpMask
-            style={{
-                height: 'var(--icon-size, 17px)',
-                width: 'var(--icon-size, 17px)',
-            }}
-            color={MaskColors.light.maskColor.publicTwitter}
-        />
-    ),
-}
-
-const EntryIconButton = memo(function EntryIconButton(props: PostDialogHintUIProps) {
-    const { tooltip, disableGuideTip } = props
-    const { classes, cx } = useStyles(undefined, { props })
-
-    const Entry = (
-        <ShadowRootTooltip
-            title={<Trans>Mask Network</Trans>}
-            placement={tooltip?.placement}
-            disableHoverListener={tooltip?.disabled}
-            slotProps={{ popper: { disablePortal: false } }}
-            arrow>
-            <IconButton
-                size="large"
-                className={cx(classes.button, classes.iconButton)}
-                onClick={props.onHintButtonClicked}>
-                {ICON_MAP[props.iconType ?? 'default']}
-            </IconButton>
-        </ShadowRootTooltip>
-    )
-
-    return disableGuideTip ? Entry : (
-            <GuideStep
-                step={4}
-                total={4}
-                tip={<Trans>Click here to have a quick start.</Trans>}
-                onComplete={props.onHintButtonClicked}>
-                {Entry}
-            </GuideStep>
-        )
-})
-
-export const PostDialogHint = memo(function PostDialogHintUI(props: PostDialogHintUIProps) {
-    const { onHintButtonClicked, size, ...others } = props
-    const { classes } = useStyles(undefined, { props })
+export function PostDialogHint({ disableGuideTip, onHintButtonClicked, ...rest }: PostDialogHintProps) {
+    const guideState = useGuideStepState({ step: 4, total: 4, onComplete: onHintButtonClicked })
     return (
-        <div className={classes.buttonTransform}>
-            <EntryIconButton size={size} onHintButtonClicked={onHintButtonClicked} {...others} />
-        </div>
+        <PostDialogHintUI
+            {...rest}
+            onHintButtonClicked={onHintButtonClicked}
+            tooltipTitle={<Trans>Mask Network</Trans>}
+            guide={
+                disableGuideTip ? undefined : (
+                    {
+                        step: 4,
+                        total: 4,
+                        tip: <Trans>Click here to have a quick start.</Trans>,
+                        skipLabel: <Trans>Skip</Trans>,
+                        nextLabel: <Trans>Next</Trans>,
+                        tryLabel: <Trans>Try</Trans>,
+                        ...guideState,
+                    }
+                )
+            }
+        />
     )
-})
+}

--- a/packages/mask/content-script/components/Welcomes/Banner.tsx
+++ b/packages/mask/content-script/components/Welcomes/Banner.tsx
@@ -1,55 +1,13 @@
-import { useCallback, useState, type JSX } from 'react'
+import { useCallback, useState } from 'react'
 import { useMount } from 'react-use'
-import { IconButton } from '@mui/material'
-import { Icons } from '@masknet/icons'
+import { Banner as BannerUI, type BannerProps as BannerUIProps } from '@masknet/injected-ui/Banner'
 import { useCurrentPersonaConnectStatus } from '@masknet/shared'
 import { DashboardRoutes, currentPersonaIdentifier } from '@masknet/shared-base'
 import { useValueRef } from '@masknet/shared-base-ui'
-import { MaskColors, makeStyles } from '@masknet/theme'
 import Services from '#services'
 import { activatedSiteAdaptorUI, activatedSiteAdaptor_state } from '../../site-adaptor-infra/index.js'
 import { useLastRecognizedIdentity } from '../DataSource/useActivatedUI.js'
 import { usePersonasFromDB } from '../../../shared-ui/hooks/usePersonasFromDB.js'
-
-interface BannerUIProps extends withClasses<'header' | 'content' | 'actions' | 'buttonText'> {
-    description?: string
-    nextStep:
-        | 'hidden'
-        | {
-              onClick(): void
-          }
-    username?:
-        | 'hidden'
-        | {
-              isValid(username: string): boolean
-              value: string
-              defaultValue: string
-              onChange(nextValue: string): void
-          }
-    iconType?: string
-}
-
-const ICON_MAP: { [property: string]: JSX.Element } = {
-    minds: <Icons.MaskInMinds size={18} />,
-    default: <Icons.SharpMask size={17} color={MaskColors.light.maskColor.publicTwitter} />,
-}
-const useStyles = makeStyles()({
-    buttonText: {
-        width: 38,
-        height: 38,
-        margin: '10px 0',
-    },
-})
-
-function BannerUI(props: BannerUIProps) {
-    const { classes } = useStyles(undefined, { props })
-
-    return props.nextStep === 'hidden' ?
-            null
-        :   <IconButton size="large" className={classes.buttonText} onClick={props.nextStep.onClick}>
-                {ICON_MAP[props.iconType ?? 'default']}
-            </IconButton>
-}
 
 interface BannerProps extends Partial<BannerUIProps> {}
 

--- a/packages/mask/content-script/tsconfig.json
+++ b/packages/mask/content-script/tsconfig.json
@@ -33,6 +33,7 @@
     { "path": "../../encryption/tsconfig.json" },
     { "path": "../../flags/tsconfig.json" },
     { "path": "../../web3-helpers/tsconfig.json" },
-    { "path": "../../injected-script/shared/tsconfig.json" }
+    { "path": "../../injected-script/shared/tsconfig.json" },
+    { "path": "../../injected-ui/tsconfig.json" }
   ]
 }

--- a/packages/mask/package.json
+++ b/packages/mask/package.json
@@ -37,6 +37,7 @@
     "@masknet/gun-utils": "workspace:^",
     "@masknet/icons": "workspace:^",
     "@masknet/injected-script": "workspace:^",
+    "@masknet/injected-ui": "workspace:^",
     "@masknet/plugin-approval": "workspace:^",
     "@masknet/plugin-calendar": "workspace:^",
     "@masknet/plugin-cross-chain-bridge": "workspace:^",

--- a/packages/shared-base-ui/src/locale/en-US.po
+++ b/packages/shared-base-ui/src/locale/en-US.po
@@ -4047,6 +4047,7 @@ msgid "News"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5494,6 +5495,7 @@ msgid "Size limit: 10 MB"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr ""
@@ -6376,6 +6378,7 @@ msgid "True Token"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 msgid "Try"
 msgstr ""
 

--- a/packages/shared-base-ui/src/locale/ja-JP.po
+++ b/packages/shared-base-ui/src/locale/ja-JP.po
@@ -4052,6 +4052,7 @@ msgid "News"
 msgstr "ニュース"
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5499,6 +5500,7 @@ msgid "Size limit: 10 MB"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "スキップ"
@@ -6381,6 +6383,7 @@ msgid "True Token"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 msgid "Try"
 msgstr "試してみる"
 

--- a/packages/shared-base-ui/src/locale/ko-KR.po
+++ b/packages/shared-base-ui/src/locale/ko-KR.po
@@ -4052,6 +4052,7 @@ msgid "News"
 msgstr "뉴스"
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5499,6 +5500,7 @@ msgid "Size limit: 10 MB"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "넘어가기"
@@ -6381,6 +6383,7 @@ msgid "True Token"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 msgid "Try"
 msgstr "시도"
 

--- a/packages/shared-base-ui/src/locale/zh-CN.po
+++ b/packages/shared-base-ui/src/locale/zh-CN.po
@@ -4052,6 +4052,7 @@ msgid "News"
 msgstr "新闻"
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5499,6 +5500,7 @@ msgid "Size limit: 10 MB"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "跳过"
@@ -6381,6 +6383,7 @@ msgid "True Token"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 msgid "Try"
 msgstr "试一下"
 

--- a/packages/shared-base-ui/src/locale/zh-TW.po
+++ b/packages/shared-base-ui/src/locale/zh-TW.po
@@ -4052,6 +4052,7 @@ msgid "News"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5499,6 +5500,7 @@ msgid "Size limit: 10 MB"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "跳過"
@@ -6381,6 +6383,7 @@ msgid "True Token"
 msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
+#: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
 msgid "Try"
 msgstr "試一下"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,9 @@ importers:
       '@masknet/icons':
         specifier: workspace:*
         version: link:../../packages/icons
+      '@masknet/injected-ui':
+        specifier: workspace:*
+        version: link:../../packages/injected-ui
       '@masknet/shared-base':
         specifier: workspace:*
         version: link:../../packages/shared-base
@@ -405,6 +408,15 @@ importers:
         specifier: ^0.12.1
         version: 0.12.1(@swc/core@1.15.43)(rollup@4.34.9)
 
+  packages/injected-ui:
+    dependencies:
+      '@masknet/icons':
+        specifier: workspace:^
+        version: link:../icons
+      '@masknet/theme':
+        specifier: workspace:^
+        version: link:../theme
+
   packages/mask:
     dependencies:
       '@ethereumjs/util':
@@ -431,6 +443,9 @@ importers:
       '@masknet/injected-script':
         specifier: workspace:^
         version: link:../injected-script
+      '@masknet/injected-ui':
+        specifier: workspace:^
+        version: link:../injected-ui
       '@masknet/plugin-approval':
         specifier: workspace:^
         version: link:../plugins/Approval


### PR DESCRIPTION
## Description

Adds two new sections to `apps/book` (the component gallery):

- **`injection`** — components each site adaptor injects into a social platform's own page, grouped by platform (X/Twitter, Facebook, Minds).
- **`popups`** — a handful of self-contained presentational components from the extension's popups UI.

### Why this isn't a 1:1 port of the real injected components

Most of the real code under `packages/mask/content-script/site-adaptors/*/injection` is tightly coupled to the extension runtime: background RPC via the `#services` subpath import (only resolvable from inside `@masknet/extension`), the live `activatedSiteAdaptorUI` global (`undefined` until a real content script boots on a live page, and not reassignable from outside since it's an ES import binding), and DOM `MutationObserverWatcher`s. None of that can run in a standalone Vite app.

Where a component's pure-UI part could be cleanly separated from that coupling, I split it out into a new package, **`packages/injected-ui`**:

- `GuideStep` — the onboarding tooltip overlay (was reading guide progress off global state directly; now takes `visible`/`onSkip`/`onNext`/`onTry` as props).
- `Banner` — the "sign in with Mask" compose-box entry (was already half-separated as a local `BannerUI`).
- `PostDialogHint` — the Mask badge next to the post/compose button (now takes an optional `guide` prop instead of deciding internally whether to show the tour).

Per your request, this package has **one export per component and no barrel `index.ts`** (see its `package.json` `exports` map, following the existing `packages/flags` pattern) — importing one component never pulls in the others. The real injection code (`packages/mask/content-script/components/{GuideStep,Welcomes/Banner,InjectedComponents/PostDialogHint}`) now imports from this same package instead of duplicating the UI; the call sites in `site-adaptors/{twitter,facebook,minds}.com` are unchanged (same prop signatures preserved), and I kept the real `<Trans>`-translated labels flowing into the pure components from the container side so nothing regresses for non-English locales.

Facebook, Twitter, and Minds all use `Banner`; Twitter, Facebook, and Minds also use `PostDialogHint` (Minds disables its guide tip, matching production). Instagram doesn't currently use any of these three, and its own injected components (`Avatar`, `ProfileTab`) are coupled to `plugin-infra`/web3 hooks I didn't attempt to decouple here — left for follow-up.

`popups` demos `StyledInput`, `PasswordField`, `BottomDrawer`, `BottomController` from `packages/mask/popups/components/*`, imported directly by relative path (that package's `exports` map is intentionally `{".": null}`, so it isn't meant to be depended on by name). I left out components that need live wallet/RPC state (`WalletAvatar`, `GasSettingMenu`, `ConnectedWallet`, …) or that pull in `@masknet/shared`'s barrel `index.ts` — that barrel re-exports components using `@lingui/react/macro`'s `Trans`, which throws at import time when not run through a macro compiler (confirmed by reading `@lingui/react`'s actual `macro/browser.mjs`), and `apps/book`'s Vite build has no such compiler configured. Also left out `NormalHeader` for the same reason: its only path to `PageTitleContext` goes through a `hooks/index.ts` barrel that pulls in several other hooks.

To make the deep relative imports into `packages/mask` resolve, `apps/book/vite.config.ts` now mirrors `packages/mask/.webpack/config.ts`'s `resolve.extensionAlias` (that source tree imports siblings with a `.js` specifier for a `.ts`/`.tsx` file on disk).

`registry.ts`/`Nav.tsx` gained one level of optional sub-category nesting (`demos/<section>/<group>/<name>.demo.tsx`) to render the per-platform grouping under `injection`; `popups` stays flat.

### Verification

I couldn't run `pnpm install` in my own sandbox (the `@dimensiondev` scoped registry needs auth I didn't have there), so I verified by careful source reading first, then pushed and watched real CI:

- The **Vercel preview build actually ran `vite build` on `apps/book`** and succeeded (https://book-git-claude-books-categories-update-5esfc6-dimension-dev.vercel.app) — this is the strongest signal, since it's the same build the deployed book uses.
- I had initially missed updating `pnpm-lock.yaml` for the new `packages/injected-ui` workspace edges, which failed `pnpm install --frozen-lockfile` on the first push (both in CI and Vercel) — fixed by hand-adding the three `link:` importer entries (no external registry package involved).
- One real `react-compiler/react-compiler` lint finding in `packages/mask/content-script/components/GuideStep/index.tsx` (mutating a ValueRef from inside a function named like a hook) — fixed with the same `eslint-disable-next-line` pattern already used elsewhere in the codebase for this exact false positive (e.g. `packages/shared/src/UI/components/RestorableScroll/index.tsx`).
- All CI checks are now green: `type-check`, `eslint`, `test`, `linter`, `build` (the real webpack extension compile), CodeQL, and Vercel.

Closes # (NO_ISSUE)

## Type of change

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

`pnpm book` from the repo root shows the new "Injection" and "Popups" sections in the sidebar. Live preview from CI: https://book-git-claude-books-categories-update-5esfc6-dimension-dev.vercel.app

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file. (n/a for the pure `packages/injected-ui` components by design — see description; the real `<Trans>`-translated strings still live in the container components in `packages/mask`.)

If this PR depends on external APIs: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED8N1kMNKJ5vinunnvcWY6
