### PR TITLE
feat(book): extract ToolboxHint, SwitchLogoIcon, MaskBadgeIcon into injected-ui

### DIFF
--- a/apps/book/src/demos/injection/facebook/ToolboxHint.demo.tsx
+++ b/apps/book/src/demos/injection/facebook/ToolboxHint.demo.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { ToolboxHint } from '@masknet/injected-ui/ToolboxHint'
+
+export const meta = {
+    title: 'ToolboxHint',
+    description:
+        'The "Mask Network" entry injected into the left rail on Facebook (packages/injected-ui/src/ToolboxHint.tsx).',
+}
+
+export default function ToolboxHintFacebookDemo() {
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start', maxWidth: 280 }}>
+            <Typography variant="body2" color="text.secondary">
+                Clicked {clicked} time(s)
+            </Typography>
+            <ToolboxHint iconSize={32} onClick={() => setClicked((c) => c + 1)} />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/minds/ToolboxHint.demo.tsx
+++ b/apps/book/src/demos/injection/minds/ToolboxHint.demo.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { ToolboxHint } from '@masknet/injected-ui/ToolboxHint'
+
+export const meta = {
+    title: 'ToolboxHint',
+    description:
+        'The "Mask Network" entry injected into the sidebar on Minds (packages/injected-ui/src/ToolboxHint.tsx), shown in its compact ("mini") form.',
+}
+
+export default function ToolboxHintMindsDemo() {
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <Typography variant="body2" color="text.secondary">
+                Clicked {clicked} time(s)
+            </Typography>
+            <ToolboxHint mini onClick={() => setClicked((c) => c + 1)} />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/twitter/MaskBadgeIcon.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/MaskBadgeIcon.demo.tsx
@@ -1,0 +1,29 @@
+import { Stack, Typography } from '@mui/material'
+import { MaskBadgeIcon } from '@masknet/injected-ui/MaskBadgeIcon'
+
+export const meta = {
+    title: 'MaskBadgeIcon',
+    description:
+        'Marks a linked account as Mask-enabled next to its name on X/Twitter — profile, floating bio card, and posts (packages/injected-ui/src/MaskBadgeIcon.tsx).',
+}
+
+export default function MaskBadgeIconDemo() {
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                <Typography sx={{ fontWeight: 700 }}>Vitalik Buterin</Typography>
+                <MaskBadgeIcon size={24} />
+                <Typography variant="caption" color="text.secondary">
+                    size 24 (profile)
+                </Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                <Typography sx={{ fontWeight: 700 }}>Vitalik Buterin</Typography>
+                <MaskBadgeIcon size={20} />
+                <Typography variant="caption" color="text.secondary">
+                    size 20 (floating bio)
+                </Typography>
+            </Stack>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/twitter/SwitchLogoIcon.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/SwitchLogoIcon.demo.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { FormControlLabel, Stack, Switch, Typography } from '@mui/material'
+import { SwitchLogoIcon } from '@masknet/injected-ui/SwitchLogoIcon'
+
+export const meta = {
+    title: 'SwitchLogoIcon',
+    description:
+        'The click target overlaid on top of X\'s own logo that opens the switch-logo dialog (packages/injected-ui/src/SwitchLogoIcon.tsx). Hover the box below to reveal it.',
+}
+
+export default function SwitchLogoIconDemo() {
+    const [minimal, setMinimal] = useState(false)
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <FormControlLabel
+                control={<Switch checked={minimal} onChange={(_, checked) => setMinimal(checked)} />}
+                label="Minimal mode (hides the click target)"
+            />
+            <Typography variant="body2" color="text.secondary">
+                Clicked {clicked} time(s)
+            </Typography>
+            <div
+                style={{
+                    position: 'relative',
+                    width: 40,
+                    height: 40,
+                    borderRadius: '50%',
+                    background: 'var(--book-accent, #1d9bf0)',
+                }}>
+                <SwitchLogoIcon minimal={minimal} onClick={() => setClicked((c) => c + 1)} />
+            </div>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/twitter/SwitchLogoIcon.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/SwitchLogoIcon.demo.tsx
@@ -5,7 +5,7 @@ import { SwitchLogoIcon } from '@masknet/injected-ui/SwitchLogoIcon'
 export const meta = {
     title: 'SwitchLogoIcon',
     description:
-        'The click target overlaid on top of X\'s own logo that opens the switch-logo dialog (packages/injected-ui/src/SwitchLogoIcon.tsx). Hover the box below to reveal it.',
+        "The click target overlaid on top of X's own logo that opens the switch-logo dialog (packages/injected-ui/src/SwitchLogoIcon.tsx). Hover the box below to reveal it.",
 }
 
 export default function SwitchLogoIconDemo() {

--- a/apps/book/src/demos/injection/twitter/ToolboxHint.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/ToolboxHint.demo.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { ToolboxHint } from '@masknet/injected-ui/ToolboxHint'
+
+export const meta = {
+    title: 'ToolboxHint',
+    description:
+        'The "Mask Network" entry injected into the sidebar/toolbox on X/Twitter (packages/injected-ui/src/ToolboxHint.tsx). Only the application slot is decoupled here — the wallet slot needs live chain state.',
+}
+
+export default function ToolboxHintTwitterDemo() {
+    const [clicked, setClicked] = useState(0)
+    const [guideDismissed, setGuideDismissed] = useState(false)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start', maxWidth: 280, paddingTop: '48px', paddingLeft: '48px' }}>
+            <Typography variant="body2" color="text.secondary">
+                Clicked {clicked} time(s){guideDismissed ? ' — guide dismissed' : ''}
+            </Typography>
+            <ToolboxHint
+                onClick={() => setClicked((c) => c + 1)}
+                guide={
+                    guideDismissed ? undefined : (
+                        {
+                            step: 1,
+                            total: 4,
+                            tip: 'Explore multi-chain dApps.',
+                            visible: true,
+                            onSkip: () => setGuideDismissed(true),
+                            onNext: () => setGuideDismissed(true),
+                            onTry: () => {
+                                setGuideDismissed(true)
+                                setClicked((c) => c + 1)
+                            },
+                        }
+                    )
+                }
+            />
+        </Stack>
+    )
+}

--- a/packages/injected-ui/package.json
+++ b/packages/injected-ui/package.json
@@ -20,6 +20,21 @@
       "types": "./dist/PostDialogHint.d.ts",
       "mask-src": "./src/PostDialogHint.tsx",
       "default": "./dist/PostDialogHint.js"
+    },
+    "./ToolboxHint": {
+      "types": "./dist/ToolboxHint.d.ts",
+      "mask-src": "./src/ToolboxHint.tsx",
+      "default": "./dist/ToolboxHint.js"
+    },
+    "./SwitchLogoIcon": {
+      "types": "./dist/SwitchLogoIcon.d.ts",
+      "mask-src": "./src/SwitchLogoIcon.tsx",
+      "default": "./dist/SwitchLogoIcon.js"
+    },
+    "./MaskBadgeIcon": {
+      "types": "./dist/MaskBadgeIcon.d.ts",
+      "mask-src": "./src/MaskBadgeIcon.tsx",
+      "default": "./dist/MaskBadgeIcon.js"
     }
   },
   "dependencies": {

--- a/packages/injected-ui/src/MaskBadgeIcon.tsx
+++ b/packages/injected-ui/src/MaskBadgeIcon.tsx
@@ -1,0 +1,21 @@
+import { Icons } from '@masknet/icons'
+
+export interface MaskBadgeIconProps {
+    size: number
+}
+
+/**
+ * The small Mask badge injected next to a linked account's name/avatar on X/Twitter (profile,
+ * floating bio card, and posts) to mark it as Mask-enabled.
+ */
+export function MaskBadgeIcon({ size }: MaskBadgeIconProps) {
+    return (
+        <Icons.MaskBlue
+            size={size}
+            style={{
+                verticalAlign: 'text-bottom',
+                marginLeft: 6,
+            }}
+        />
+    )
+}

--- a/packages/injected-ui/src/SwitchLogoIcon.tsx
+++ b/packages/injected-ui/src/SwitchLogoIcon.tsx
@@ -1,0 +1,55 @@
+import { makeStyles } from '@masknet/theme'
+import { Icons } from '@masknet/icons'
+
+const useStyles = makeStyles()(() => ({
+    switchIcon: {
+        position: 'absolute',
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        left: 0,
+        top: 0,
+    },
+    iconBox: {
+        position: 'relative',
+        flex: 1,
+    },
+    icon: {
+        position: 'absolute',
+        right: 5,
+        bottom: 5,
+        width: 20,
+        height: 20,
+    },
+    hover: {
+        opacity: 0,
+        '&:hover': {
+            opacity: 1,
+        },
+    },
+    hidden: {
+        opacity: 0,
+    },
+}))
+
+export interface SwitchLogoIconProps {
+    /** Hides the click target (the SwitchLogo plugin is minimal-mode for this account). */
+    minimal?: boolean
+    onClick?: () => void
+}
+
+/**
+ * The small click target overlaid on top of X's own logo that opens the switch-logo dialog.
+ * Pure UI: the actual logo swap is an imperative DOM mutation against the live page and stays in
+ * the container, see packages/plugins/SwitchLogo/src/SiteAdaptor/SwitchLogoButton.tsx.
+ */
+export function SwitchLogoIcon({ minimal, onClick }: SwitchLogoIconProps) {
+    const { classes, cx } = useStyles()
+    return (
+        <div className={classes.switchIcon}>
+            <div className={cx(classes.iconBox, minimal ? classes.hidden : classes.hover)}>
+                <Icons.SwitchLogo className={classes.icon} onClickCapture={onClick} />
+            </div>
+        </div>
+    )
+}

--- a/packages/injected-ui/src/ToolboxHint.tsx
+++ b/packages/injected-ui/src/ToolboxHint.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react'
+import {
+    Box,
+    ListItemButton as MuiListItemButton,
+    ListItemIcon as MuiListItemIcon,
+    ListItemText as MuiListItemText,
+    Typography as MuiTypography,
+    type ListItemButtonProps,
+    type ListItemIconProps,
+    type ListItemTextProps,
+    type SxProps,
+    type Theme,
+    type TypographyProps,
+} from '@mui/material'
+import { Icons } from '@masknet/icons'
+import { makeStyles } from '@masknet/theme'
+import { GuideStep, type GuideStepProps } from './GuideStep.js'
+
+const useStyles = makeStyles()(() => ({
+    title: {
+        display: 'flex',
+        alignItems: 'center',
+    },
+}))
+
+export interface ToolboxHintGuideProps
+    extends Pick<
+        GuideStepProps,
+        'total' | 'step' | 'tip' | 'visible' | 'onSkip' | 'onNext' | 'onTry' | 'skipLabel' | 'nextLabel' | 'tryLabel'
+    > {}
+
+export interface ToolboxHintProps {
+    sx?: SxProps<Theme>
+    Container?: React.ComponentType<React.PropsWithChildren>
+    ListItemButton?: React.ComponentType<Pick<ListItemButtonProps, 'onClick' | 'children'>>
+    ListItemText?: React.ComponentType<Pick<ListItemTextProps, 'primary'>>
+    ListItemIcon?: React.ComponentType<Pick<ListItemIconProps, 'children'>>
+    Typography?: React.ComponentType<Pick<TypographyProps, 'children' | 'className'>>
+    iconSize?: number
+    mini?: boolean
+    onClick?: () => void
+    title?: ReactNode
+    /** Renders the onboarding tooltip around the entry when provided; omit to skip it entirely. */
+    guide?: ToolboxHintGuideProps
+}
+
+/**
+ * The "Mask Network" entry injected into a platform's own toolbox/sidebar (the application slot —
+ * the wallet slot needs live chain state and isn't decoupled here).
+ * Pure UI: the click handler and guide-tour state are resolved by the caller, see
+ * packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx.
+ */
+export function ToolboxHint(props: ToolboxHintProps) {
+    const {
+        ListItemButton = MuiListItemButton,
+        ListItemIcon = MuiListItemIcon,
+        Container = 'div',
+        Typography = MuiTypography,
+        iconSize = 24,
+        mini,
+        ListItemText = MuiListItemText,
+        onClick,
+        title = 'Mask Network',
+        guide,
+        ...rest
+    } = props
+    const { classes } = useStyles()
+
+    const Entry = (
+        <Container {...rest}>
+            <ListItemButton onClick={onClick}>
+                <ListItemIcon>
+                    <Icons.MaskBlue size={iconSize} />
+                </ListItemIcon>
+                {mini ? null : (
+                    <ListItemText
+                        primary={
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
+                                }}>
+                                <Typography className={classes.title}>{title}</Typography>
+                            </Box>
+                        }
+                    />
+                )}
+            </ListItemButton>
+        </Container>
+    )
+
+    return guide ? <GuideStep {...guide}>{Entry}</GuideStep> : Entry
+}

--- a/packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
+++ b/packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
@@ -29,7 +29,8 @@ import {
 import { WalletIcon, SelectProviderModal, WalletStatusModal } from '@masknet/shared'
 import { Icons } from '@masknet/icons'
 import { makeStyles } from '@masknet/theme'
-import GuideStep from '../GuideStep/index.js'
+import { ToolboxHint as ToolboxHintUI } from '@masknet/injected-ui/ToolboxHint'
+import GuideStep, { useGuideStepState } from '../GuideStep/index.js'
 import { useOpenApplicationBoardDialog } from '../shared/openApplicationBoardDialog.js'
 import { Trans } from '@lingui/react/macro'
 
@@ -63,46 +64,25 @@ export function ToolboxHintUnstyled(props: ToolboxHintProps) {
 }
 
 function ToolboxHintForApplication(props: ToolboxHintProps) {
-    const {
-        ListItemButton = MuiListItemButton,
-        ListItemIcon = MuiListItemIcon,
-        Container = 'div',
-        Typography = MuiTypography,
-        iconSize = 24,
-        mini,
-        ListItemText = MuiListItemText,
-        ...rest
-    } = props
-    const { classes } = useStyles()
-
+    const { category, ...rest } = props
     const openApplicationBoardDialog = useOpenApplicationBoardDialog()
+    const guideState = useGuideStepState({ step: 1, total: 4 })
 
     return (
-        <GuideStep step={1} total={4} tip={<Trans>Explore multi-chain dApps.</Trans>}>
-            <Container {...rest}>
-                <ListItemButton onClick={openApplicationBoardDialog}>
-                    <ListItemIcon>
-                        <Icons.MaskBlue size={iconSize} />
-                    </ListItemIcon>
-                    {mini ? null : (
-                        <ListItemText
-                            primary={
-                                <Box
-                                    sx={{
-                                        display: 'flex',
-                                        justifyContent: 'space-between',
-                                        alignItems: 'center',
-                                    }}>
-                                    <Typography className={classes.title}>
-                                        <Trans>Mask Network</Trans>
-                                    </Typography>
-                                </Box>
-                            }
-                        />
-                    )}
-                </ListItemButton>
-            </Container>
-        </GuideStep>
+        <ToolboxHintUI
+            {...rest}
+            onClick={openApplicationBoardDialog}
+            title={<Trans>Mask Network</Trans>}
+            guide={{
+                step: 1,
+                total: 4,
+                tip: <Trans>Explore multi-chain dApps.</Trans>,
+                skipLabel: <Trans>Skip</Trans>,
+                nextLabel: <Trans>Next</Trans>,
+                tryLabel: <Trans>Try</Trans>,
+                ...guideState,
+            }}
+        />
     )
 }
 

--- a/packages/mask/content-script/site-adaptors/twitter.com/injection/MaskIcon.tsx
+++ b/packages/mask/content-script/site-adaptors/twitter.com/injection/MaskIcon.tsx
@@ -1,6 +1,6 @@
 import { memoize, noop } from 'lodash-es'
 import { DOMProxy, LiveSelector, MutationObserverWatcher } from '@dimensiondev/holoflows-kit'
-import { Icons } from '@masknet/icons'
+import { MaskBadgeIcon as Icon } from '@masknet/injected-ui/MaskBadgeIcon'
 import { memoizePromise } from '@masknet/kit'
 import type { PostInfo } from '@masknet/plugin-infra/content-script'
 import { EnhanceableSite, ProfileIdentifier } from '@masknet/shared-base'
@@ -10,17 +10,6 @@ import { startWatch, type WatchOptions } from '../../../utils/startWatch.js'
 import { attachReactTreeWithContainer } from '../../../utils/shadow-root/renderInShadowRoot.js'
 import { bioPageUserIDSelector, bioPageUserNickNameSelector, floatingBioCardSelector } from '../utils/selector.js'
 
-function Icon(props: { size: number }) {
-    return (
-        <Icons.MaskBlue
-            size={props.size}
-            style={{
-                verticalAlign: 'text-bottom',
-                marginLeft: 6,
-            }}
-        />
-    )
-}
 function _(main: () => LiveSelector<HTMLElement, true>, size: number, options: WatchOptions) {
     const watcher = new MutationObserverWatcher(main()).useForeach((ele, _, meta) => {
         let remover = noop

--- a/packages/plugins/SwitchLogo/package.json
+++ b/packages/plugins/SwitchLogo/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@masknet/icons": "workspace:^",
+    "@masknet/injected-ui": "workspace:^",
     "@masknet/plugin-infra": "workspace:^",
     "@masknet/shared": "workspace:^",
     "@masknet/shared-base": "workspace:^",

--- a/packages/plugins/SwitchLogo/src/SiteAdaptor/SwitchLogoButton.tsx
+++ b/packages/plugins/SwitchLogo/src/SiteAdaptor/SwitchLogoButton.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useLayoutEffect } from 'react'
 import { LiveSelector } from '@dimensiondev/holoflows-kit'
-import { Icons } from '@masknet/icons'
-import { makeStyles } from '@masknet/theme'
+import { SwitchLogoIcon } from '@masknet/injected-ui/SwitchLogoIcon'
 import { useValueRef } from '@masknet/shared-base-ui'
 import { CrossIsolationMessages, PluginID, SwitchLogoType, switchLogoSettings } from '@masknet/shared-base'
 import { useIsMinimalMode, useLastRecognizedIdentity } from '@masknet/plugin-infra/content-script'
@@ -25,39 +24,7 @@ const defaultXIcon = `
 `
 const LetterHTML = LogoSelector.evaluate()?.innerHTML
 
-const useStyles = makeStyles()(() => ({
-    switchIcon: {
-        position: 'absolute',
-        display: 'flex',
-        width: '100%',
-        height: '100%',
-        left: 0,
-        top: 0,
-    },
-    iconBox: {
-        position: 'relative',
-        flex: 1,
-    },
-    icon: {
-        position: 'absolute',
-        right: 5,
-        bottom: 5,
-        width: 20,
-        height: 20,
-    },
-    hover: {
-        opacity: 0,
-        '&:hover': {
-            opacity: 1,
-        },
-    },
-    hidden: {
-        opacity: 0,
-    },
-}))
-
 export function SwitchLogoButton() {
-    const { classes, cx } = useStyles()
     const current = useLastRecognizedIdentity()
     const logoType = useValueRef(switchLogoSettings[current?.identifier?.userId || ''])
     const isMinimalMode = useIsMinimalMode(PluginID.SwitchLogo)
@@ -80,11 +47,5 @@ export function SwitchLogoButton() {
         CrossIsolationMessages.events.switchLogoDialogUpdated.sendToLocal({ open: true })
     }, [isMinimalMode])
 
-    return (
-        <div className={classes.switchIcon}>
-            <div className={cx(classes.iconBox, isMinimalMode ? classes.hidden : classes.hover)}>
-                <Icons.SwitchLogo className={classes.icon} onClickCapture={onClick} />
-            </div>
-        </div>
-    )
+    return <SwitchLogoIcon minimal={isMinimalMode} onClick={onClick} />
 }

--- a/packages/plugins/SwitchLogo/tsconfig.json
+++ b/packages/plugins/SwitchLogo/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": ["src", "src/**/*.json"],
   "references": [
+    { "path": "../../injected-ui/tsconfig.json" },
     { "path": "../../plugin-infra/tsconfig.json" },
     { "path": "../../shared/tsconfig.json" },
     { "path": "../../shared-base-ui/tsconfig.json" },

--- a/packages/shared-base-ui/src/locale/en-US.po
+++ b/packages/shared-base-ui/src/locale/en-US.po
@@ -4048,6 +4048,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5496,6 +5497,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr ""
@@ -6379,6 +6381,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 msgid "Try"
 msgstr ""
 

--- a/packages/shared-base-ui/src/locale/ja-JP.po
+++ b/packages/shared-base-ui/src/locale/ja-JP.po
@@ -4053,6 +4053,7 @@ msgstr "ニュース"
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5501,6 +5502,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "スキップ"
@@ -6384,6 +6386,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 msgid "Try"
 msgstr "試してみる"
 

--- a/packages/shared-base-ui/src/locale/ko-KR.po
+++ b/packages/shared-base-ui/src/locale/ko-KR.po
@@ -4053,6 +4053,7 @@ msgstr "뉴스"
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5501,6 +5502,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "넘어가기"
@@ -6384,6 +6386,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 msgid "Try"
 msgstr "시도"
 

--- a/packages/shared-base-ui/src/locale/zh-CN.po
+++ b/packages/shared-base-ui/src/locale/zh-CN.po
@@ -4053,6 +4053,7 @@ msgstr "新闻"
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5501,6 +5502,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "跳过"
@@ -6384,6 +6386,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 msgid "Try"
 msgstr "试一下"
 

--- a/packages/shared-base-ui/src/locale/zh-TW.po
+++ b/packages/shared-base-ui/src/locale/zh-TW.po
@@ -4053,6 +4053,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/popups/pages/Wallet/ContactList/index.tsx
 #: packages/mask/popups/pages/Wallet/Transfer/FungibleTokenSection.tsx
 msgid "Next"
@@ -5501,6 +5502,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 #: packages/mask/dashboard/pages/SetupPersona/SignUp/index.tsx
 msgid "Skip"
 msgstr "跳過"
@@ -6384,6 +6386,7 @@ msgstr ""
 
 #: packages/mask/content-script/components/GuideStep/index.tsx
 #: packages/mask/content-script/components/InjectedComponents/PostDialogHint.tsx
+#: packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
 msgid "Try"
 msgstr "試一下"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1447,6 +1447,9 @@ importers:
       '@masknet/icons':
         specifier: workspace:^
         version: link:../../icons
+      '@masknet/injected-ui':
+        specifier: workspace:^
+        version: link:../../injected-ui
       '@masknet/plugin-infra':
         specifier: workspace:^
         version: link:../../plugin-infra


### PR DESCRIPTION
## Description

Follow-up to #12445 — extracts three more pure-UI pieces from the site-adaptor injections into `packages/injected-ui` (still one export per component, no barrel `index.ts`) so they show up in the book's `injection` category, in response to "are you sure all injected components are listed?" (they weren't — this narrows the gap a bit further, though plenty is still left, see below).

- **`ToolboxHint`** — the "Mask Network" entry injected into a platform's own toolbox/sidebar. Only the *application* slot is decoupled (fixed onClick + optional guide-tour props); the *wallet* slot needs live chain state (`useChainContext`, balance/provider hooks) and is untouched in `packages/mask`. Twitter, Facebook, and Minds all render the application slot through the same shared production component (`packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx`), so this one change covers all three — no per-platform call-site changes needed.
- **`SwitchLogoIcon`** — the small click target overlaid on X's own logo that opens the switch-logo dialog. The actual logo swap (`node.setHTMLUnsafe(...)`) is an imperative DOM mutation against the live page's own logo element, so that part stays in the container (`packages/plugins/SwitchLogo/src/SiteAdaptor/SwitchLogoButton.tsx`); only the overlay icon + click handling moved out.
- **`MaskBadgeIcon`** — the small badge marking a linked account as Mask-enabled next to its name on X/Twitter (profile, floating bio card, posts). This one was already fully pure, just inlined in `MaskIcon.tsx`.

As before, none of the real hooks/state (`useOpenApplicationBoardDialog`, `useGuideStepState`, `useLastRecognizedIdentity`, `useIsMinimalMode`) moved — they're still called by the production containers, which now just pass the results down as props to the pure components.

### What's still not in the book

I went through the rest of the injection files across all four platforms again. Most of what's left is not decoupleable the same way:

- Twitter's Badges, Tips buttons, ProfileCover, ProfileCard, and Facebook/Minds' ProfileCover, ProfileContent are all wired to `createInjectHooksRenderer`/`useActivatedPluginsSiteAdaptor` from `@masknet/plugin-infra` — a plugin-registration/visibility system that would need a real set of registered plugins to render anything, not just mock props.
- PostInspector, PostReplacer, SearchResultInspector, CommentBox, Calendar are effectively whole other features (decryption pipeline, the Calendar plugin) rather than small injected widgets.
- Instagram's `Avatar`/`ProfileTab` are also plugin-infra + web3-hooks-based.

So the book's `injection` section is still a partial picture, now 6 components instead of 3, across Twitter/Facebook/Minds (Instagram remains uncovered).

### Verification

Same constraint as before — no working `pnpm install` in my sandbox, so I relied on careful source reading (traced every hook the moved code touches: `useSubscriptionMaybe` degrades gracefully on an unset subscription, `useIsMinimalMode`'s `assertLocation()` only throws on popup/dashboard pages, both fine for the book). I'll watch CI on this PR and fix anything real that comes up, same as #12445.

## Type of change

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

`pnpm book` shows three new entries under Injection: Twitter/Facebook/Minds → ToolboxHint, Twitter → SwitchLogoIcon, Twitter → MaskBadgeIcon.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file. (n/a for the pure `packages/injected-ui` components by design; the real `<Trans>`-translated strings still live in the container components in `packages/mask`.)

If this PR depends on external APIs: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED8N1kMNKJ5vinunnvcWY6


---
_Generated by [Claude Code](https://claude.ai/code/session_01ED8N1kMNKJ5vinunnvcWY6)_