### PR TITLE
Make Mask Component Book UI mobile friendly

### DIFF
--- a/apps/book/src/App.tsx
+++ b/apps/book/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Nav } from './components/Nav.tsx'
 import { Canvas } from './components/Canvas.tsx'
 import { allEntries, findEntry } from './registry.ts'
@@ -7,15 +7,33 @@ import { useRoute } from './router.ts'
 export function App() {
     const [route, navigate] = useRoute()
     const entry = findEntry(route)
+    const [navOpen, setNavOpen] = useState(false)
 
     // land on the first demo if the hash is empty or stale
     useEffect(() => {
         if (!entry && allEntries.length > 0) navigate(allEntries[0].id)
     }, [entry, navigate])
 
+    // close the mobile drawer whenever a demo is picked
+    const handleNavigate = (id: string) => {
+        navigate(id)
+        setNavOpen(false)
+    }
+
     return (
-        <div className="book-shell">
-            <Nav current={route} onNavigate={navigate} />
+        <div className="book-shell" data-nav-open={navOpen}>
+            <button
+                type="button"
+                className="book-menu-button"
+                aria-label={navOpen ? 'Close navigation' : 'Open navigation'}
+                aria-expanded={navOpen}
+                onClick={() => setNavOpen((open) => !open)}>
+                {navOpen ? '✕' : '☰'}
+            </button>
+            <Nav current={route} onNavigate={handleNavigate} />
+            {navOpen ?
+                <div className="book-backdrop" onClick={() => setNavOpen(false)} />
+            :   null}
             <Canvas entry={entry} />
         </div>
     )

--- a/apps/book/src/styles.css
+++ b/apps/book/src/styles.css
@@ -44,6 +44,14 @@ body {
     height: 100%;
 }
 
+.book-menu-button {
+    display: none;
+}
+
+.book-backdrop {
+    display: none;
+}
+
 .book-sidebar {
     background: var(--book-sidebar-bg);
     border-right: 1px solid var(--book-border);
@@ -173,4 +181,80 @@ body {
     color: var(--book-muted);
     font-size: 11px;
     word-break: break-all;
+}
+
+@media (max-width: 768px) {
+    .book-shell {
+        grid-template-columns: 1fr;
+        position: relative;
+        overflow: hidden;
+    }
+
+    .book-menu-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: fixed;
+        top: 10px;
+        left: 12px;
+        z-index: 30;
+        width: 40px;
+        height: 40px;
+        border-radius: 8px;
+        border: 1px solid var(--book-border);
+        background: var(--book-sidebar-bg);
+        color: var(--book-fg);
+        font-size: 18px;
+        line-height: 1;
+        cursor: pointer;
+    }
+
+    .book-sidebar {
+        position: fixed;
+        inset: 0 20% 0 0;
+        max-width: 280px;
+        z-index: 25;
+        transform: translateX(-100%);
+        transition: transform 0.2s ease;
+        box-shadow: 2px 0 16px rgba(0, 0, 0, 0.2);
+    }
+
+    .book-shell[data-nav-open='true'] .book-sidebar {
+        transform: translateX(0);
+    }
+
+    .book-backdrop {
+        display: block;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+        z-index: 20;
+    }
+
+    .book-brand {
+        padding-left: 52px;
+    }
+
+    .book-nav-link {
+        padding: 10px 8px;
+        font-size: 14px;
+    }
+
+    .book-main-header {
+        padding: 60px 16px 12px;
+    }
+
+    .book-canvas {
+        padding: 16px;
+        overflow-x: auto;
+    }
+
+    .book-demo-grid {
+        gap: 12px;
+    }
+
+    .book-swatch {
+        width: calc(50% - 6px);
+        min-width: 130px;
+    }
 }


### PR DESCRIPTION
Collapse the fixed two-column layout into a single column below 768px,
turning the sidebar into an off-canvas drawer toggled by a hamburger
button, with a tap-to-close backdrop and larger touch targets for nav
links. Canvas padding and the swatch grid also shrink to fit small
screens.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WG8vviHrCxNuMhLCXwmvrU