### PR TITLE
feat(book): extract ToolboxHint wallet slot into injected-ui

### DIFF
--- a/apps/book/src/demos/injection/facebook/ToolboxHintWallet.demo.tsx
+++ b/apps/book/src/demos/injection/facebook/ToolboxHintWallet.demo.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { Avatar, Stack } from '@mui/material'
+import { ToolboxHint } from '@masknet/injected-ui/ToolboxHint'
+
+export const meta = {
+    title: 'ToolboxHintWallet',
+    description:
+        'The connected-wallet entry injected into the left rail on Facebook — the wallet slot of the same ToolboxHint component (packages/injected-ui/src/ToolboxHint.tsx).',
+}
+
+export default function ToolboxHintWalletFacebookDemo() {
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start', maxWidth: 280 }}>
+            <div>Clicked {clicked} time(s)</div>
+            <ToolboxHint
+                iconSize={32}
+                onClick={() => setClicked((c) => c + 1)}
+                icon={<Avatar sx={{ width: 32, height: 32 }}>W</Avatar>}
+                title="0x1234…5678"
+            />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/minds/ToolboxHintWallet.demo.tsx
+++ b/apps/book/src/demos/injection/minds/ToolboxHintWallet.demo.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import { Stack } from '@mui/material'
+import { Icons } from '@masknet/icons'
+import { ToolboxHint } from '@masknet/injected-ui/ToolboxHint'
+
+export const meta = {
+    title: 'ToolboxHintWallet',
+    description:
+        'The connected-wallet entry injected into the sidebar on Minds — the wallet slot of the same ToolboxHint component (packages/injected-ui/src/ToolboxHint.tsx), shown in its compact ("mini") form.',
+}
+
+export default function ToolboxHintWalletMindsDemo() {
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <div>Clicked {clicked} time(s)</div>
+            <ToolboxHint mini onClick={() => setClicked((c) => c + 1)} icon={<Icons.Wallet size={24} />} />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/twitter/ToolboxHintWallet.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/ToolboxHintWallet.demo.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { Avatar, FormControlLabel, Stack, Switch } from '@mui/material'
+import { Icons } from '@masknet/icons'
+import { ToolboxHint } from '@masknet/injected-ui/ToolboxHint'
+
+export const meta = {
+    title: 'ToolboxHintWallet',
+    description:
+        'The connected-wallet entry injected into the sidebar/toolbox on X/Twitter — the wallet slot of the same ToolboxHint component (packages/injected-ui/src/ToolboxHint.tsx). Needs live chain state in production; the icon/title/chain-indicator here are just mocked for the demo.',
+}
+
+export default function ToolboxHintWalletTwitterDemo() {
+    const [connected, setConnected] = useState(false)
+    const [wrongNetwork, setWrongNetwork] = useState(false)
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start', maxWidth: 280 }}>
+            <FormControlLabel
+                control={<Switch checked={connected} onChange={(_, checked) => setConnected(checked)} />}
+                label="Wallet connected"
+            />
+            <FormControlLabel
+                control={<Switch checked={wrongNetwork} onChange={(_, checked) => setWrongNetwork(checked)} />}
+                label="Wrong network (shows the chain indicator dot)"
+                disabled={!connected}
+            />
+            <div>Clicked {clicked} time(s)</div>
+            <ToolboxHint
+                onClick={() => setClicked((c) => c + 1)}
+                icon={
+                    connected ?
+                        <Avatar sx={{ width: 24, height: 24 }}>W</Avatar>
+                    :   <Icons.Wallet size={24} />
+                }
+                title={connected ? '0x1234…5678' : 'Connect Wallet'}
+                extra={
+                    wrongNetwork && connected ?
+                        <div style={{ width: 8, height: 8, borderRadius: '50%', background: 'red' }} />
+                    :   null
+                }
+            />
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/twitter/ToolboxHintWallet.demo.tsx
+++ b/apps/book/src/demos/injection/twitter/ToolboxHintWallet.demo.tsx
@@ -28,11 +28,7 @@ export default function ToolboxHintWalletTwitterDemo() {
             <div>Clicked {clicked} time(s)</div>
             <ToolboxHint
                 onClick={() => setClicked((c) => c + 1)}
-                icon={
-                    connected ?
-                        <Avatar sx={{ width: 24, height: 24 }}>W</Avatar>
-                    :   <Icons.Wallet size={24} />
-                }
+                icon={connected ? <Avatar sx={{ width: 24, height: 24 }}>W</Avatar> : <Icons.Wallet size={24} />}
                 title={connected ? '0x1234…5678' : 'Connect Wallet'}
                 extra={
                     wrongNetwork && connected ?

--- a/packages/injected-ui/src/ToolboxHint.tsx
+++ b/packages/injected-ui/src/ToolboxHint.tsx
@@ -39,15 +39,19 @@ export interface ToolboxHintProps {
     iconSize?: number
     mini?: boolean
     onClick?: () => void
+    /** Defaults to the Mask logo (the application slot); the wallet slot passes its own connected-wallet/chain icon. */
+    icon?: ReactNode
     title?: ReactNode
+    /** Rendered right after the title, e.g. the wallet slot's "wrong network" indicator dot. */
+    extra?: ReactNode
     /** Renders the onboarding tooltip around the entry when provided; omit to skip it entirely. */
     guide?: ToolboxHintGuideProps
 }
 
 /**
- * The "Mask Network" entry injected into a platform's own toolbox/sidebar (the application slot —
- * the wallet slot needs live chain state and isn't decoupled here).
- * Pure UI: the click handler and guide-tour state are resolved by the caller, see
+ * The entry injected into a platform's own toolbox/sidebar — either the "Mask Network"
+ * (application) slot or the connected-wallet (wallet) slot; both platforms register one of each.
+ * Pure UI: the icon, click handler, and guide-tour state are all resolved by the caller, see
  * packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx.
  */
 export function ToolboxHint(props: ToolboxHintProps) {
@@ -60,7 +64,9 @@ export function ToolboxHint(props: ToolboxHintProps) {
         mini,
         ListItemText = MuiListItemText,
         onClick,
+        icon = <Icons.MaskBlue size={iconSize} />,
         title = 'Mask Network',
+        extra,
         guide,
         ...rest
     } = props
@@ -69,9 +75,7 @@ export function ToolboxHint(props: ToolboxHintProps) {
     const Entry = (
         <Container {...rest}>
             <ListItemButton onClick={onClick}>
-                <ListItemIcon>
-                    <Icons.MaskBlue size={iconSize} />
-                </ListItemIcon>
+                <ListItemIcon>{icon}</ListItemIcon>
                 {mini ? null : (
                     <ListItemText
                         primary={
@@ -82,6 +86,7 @@ export function ToolboxHint(props: ToolboxHintProps) {
                                     alignItems: 'center',
                                 }}>
                                 <Typography className={classes.title}>{title}</Typography>
+                                {extra}
                             </Box>
                         }
                     />

--- a/packages/injected-ui/src/ToolboxHint.tsx
+++ b/packages/injected-ui/src/ToolboxHint.tsx
@@ -64,7 +64,7 @@ export function ToolboxHint(props: ToolboxHintProps) {
         mini,
         ListItemText = MuiListItemText,
         onClick,
-        icon = <Icons.MaskBlue size={iconSize} />,
+        icon,
         title = 'Mask Network',
         extra,
         guide,
@@ -75,7 +75,7 @@ export function ToolboxHint(props: ToolboxHintProps) {
     const Entry = (
         <Container {...rest}>
             <ListItemButton onClick={onClick}>
-                <ListItemIcon>{icon}</ListItemIcon>
+                <ListItemIcon>{icon ?? <Icons.MaskBlue size={iconSize} />}</ListItemIcon>
                 {mini ? null : (
                     <ListItemText
                         primary={

--- a/packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
+++ b/packages/mask/content-script/components/InjectedComponents/ToolboxUnstyled.tsx
@@ -5,11 +5,6 @@ import {
     type ListItemIconProps,
     type ListItemTextProps,
     type TypographyProps,
-    Typography as MuiTypography,
-    ListItemButton as MuiListItemButton,
-    ListItemIcon as MuiListItemIcon,
-    ListItemText as MuiListItemText,
-    Box,
     useTheme,
     type SxProps,
     type Theme,
@@ -30,15 +25,11 @@ import { WalletIcon, SelectProviderModal, WalletStatusModal } from '@masknet/sha
 import { Icons } from '@masknet/icons'
 import { makeStyles } from '@masknet/theme'
 import { ToolboxHint as ToolboxHintUI } from '@masknet/injected-ui/ToolboxHint'
-import GuideStep, { useGuideStepState } from '../GuideStep/index.js'
+import { useGuideStepState } from '../GuideStep/index.js'
 import { useOpenApplicationBoardDialog } from '../shared/openApplicationBoardDialog.js'
 import { Trans } from '@lingui/react/macro'
 
 const useStyles = makeStyles()(() => ({
-    title: {
-        display: 'flex',
-        alignItems: 'center',
-    },
     chainIcon: {
         fontSize: 18,
         width: 18,
@@ -87,61 +78,44 @@ function ToolboxHintForApplication(props: ToolboxHintProps) {
 }
 
 function ToolboxHintForWallet(props: ToolboxHintProps) {
-    const {
-        ListItemButton = MuiListItemButton,
-        ListItemText = MuiListItemText,
-        ListItemIcon = MuiListItemIcon,
-        Container = 'div',
-        Typography = MuiTypography,
-        iconSize = 24,
-        badgeSize = 12,
-        mini,
-        ...rest
-    } = props
+    const { category, iconSize = 24, badgeSize = 12, ...rest } = props
     const { classes } = useStyles()
     const { onClickToolbox, title, chainColor, shouldDisplayChainIndicator, account, provider } = useToolbox()
+    const guideState = useGuideStepState({ step: 2, total: 4 })
 
     const theme = useTheme()
 
     return (
-        <GuideStep step={2} total={4} tip={<Trans>Connect and switch between your wallets.</Trans>}>
-            <Container {...rest}>
-                <ListItemButton onClick={onClickToolbox}>
-                    <ListItemIcon>
-                        {account && provider ?
-                            <WalletIcon
-                                size={iconSize}
-                                badgeSize={badgeSize}
-                                mainIcon={provider.icon}
-                                badgeIconBorderColor={theme.vars.palette.background.paper}
-                            />
-                        :   <Icons.Wallet size={iconSize} />}
-                    </ListItemIcon>
-                    {mini ? null : (
-                        <ListItemText
-                            primary={
-                                <Box
-                                    sx={{
-                                        display: 'flex',
-                                        justifyContent: 'space-between',
-                                        alignItems: 'center',
-                                    }}>
-                                    <Typography className={classes.title}>{title}</Typography>
-                                    {shouldDisplayChainIndicator ?
-                                        <FiberManualRecordIcon
-                                            className={classes.chainIcon}
-                                            style={{
-                                                color: chainColor,
-                                            }}
-                                        />
-                                    :   null}
-                                </Box>
-                            }
-                        />
-                    )}
-                </ListItemButton>
-            </Container>
-        </GuideStep>
+        <ToolboxHintUI
+            {...rest}
+            iconSize={iconSize}
+            onClick={onClickToolbox}
+            title={title}
+            icon={
+                account && provider ?
+                    <WalletIcon
+                        size={iconSize}
+                        badgeSize={badgeSize}
+                        mainIcon={provider.icon}
+                        badgeIconBorderColor={theme.vars.palette.background.paper}
+                    />
+                :   <Icons.Wallet size={iconSize} />
+            }
+            extra={
+                shouldDisplayChainIndicator ?
+                    <FiberManualRecordIcon className={classes.chainIcon} style={{ color: chainColor }} />
+                :   null
+            }
+            guide={{
+                step: 2,
+                total: 4,
+                tip: <Trans>Connect and switch between your wallets.</Trans>,
+                skipLabel: <Trans>Skip</Trans>,
+                nextLabel: <Trans>Next</Trans>,
+                tryLabel: <Trans>Try</Trans>,
+                ...guideState,
+            }}
+        />
     )
 }
 


### PR DESCRIPTION
## Description

Follow-up to #12445, #12446, #12447 — continues extracting injected/popup components from the backlog into `packages/injected-ui` for the component book.

This batch generalizes `packages/injected-ui/src/ToolboxHint.tsx`, which previously only covered the "Mask Network" (application) slot injected into a platform's toolbox/sidebar. It now also covers the connected-wallet slot, which renders through the exact same component in production (`ToolboxUnstyled.tsx`) but had not been decoupled yet.

- `ToolboxHint` gains `icon`/`extra` props: `icon` defaults to the Mask logo but the wallet slot passes its own connected-wallet/chain icon; `extra` renders right after the title (used for the wallet slot's "wrong network" chain indicator dot).
- `ToolboxHintForWallet` in `ToolboxUnstyled.tsx` is rewritten to compute the wallet icon (via `@masknet/shared`'s `WalletIcon`) and the chain-indicator dot in the container, then pass them down as props — keeping `@masknet/shared` out of `packages/injected-ui` entirely, consistent with the rest of the package.
- The wallet slot is also wired through `useGuideStepState` the same way the application slot already was, so its onboarding-tour step behaves consistently.
- Adds `ToolboxHintWallet` book demos for Twitter, Facebook, and Minds under `apps/book/src/demos/injection/<platform>/`.

No new dependencies are introduced (the container already imported `WalletIcon` from `@masknet/shared`; `packages/injected-ui`'s `package.json`/`pnpm-lock.yaml` are unchanged).

As with the prior PRs, `packages/injected-ui` keeps per-component exports only (no barrel `index.ts`); a new `./ToolboxHint` export already existed from #12446 and did not need to change.

Closes # (NO_ISSUE)

## Type of change

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

The Vercel preview deploy will build the book app — visit `/injection/twitter/ToolboxHintWallet`, `/injection/facebook/ToolboxHintWallet`, and `/injection/minds/ToolboxHintWallet` (and the existing `ToolboxHint` app-slot demos, unaffected) to see the wallet-slot entry rendered with mocked connected/disconnected/wrong-network states.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file. (no new user-facing strings added — production title/labels are unchanged, only passed through as props)

If this PR depends on external APIs:

- [ ] N/A — no external API dependency in this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED8N1kMNKJ5vinunnvcWY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED8N1kMNKJ5vinunnvcWY6)_