### PR TITLE
feat(book): extract PostCommentChip + PostVisibilityBadge into injected-ui

### DIFF
--- a/apps/book/src/demos/injection/shared/PostCommentChip.demo.tsx
+++ b/apps/book/src/demos/injection/shared/PostCommentChip.demo.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@mui/material'
+import { PostCommentChip } from '@masknet/injected-ui/PostCommentChip'
+
+export const meta = {
+    title: 'PostCommentChip',
+    description:
+        "The chip shown under a post once Mask decrypts an encrypted comment (packages/injected-ui/src/PostCommentChip.tsx). The container (PostComments.tsx) owns the actual decryption and only renders this once it resolves.",
+}
+
+export default function PostCommentChipDemo() {
+    return (
+        <Stack spacing={2} sx={{ alignItems: 'flex-start' }}>
+            <PostCommentChip>This is a decrypted comment.</PostCommentChip>
+        </Stack>
+    )
+}

--- a/apps/book/src/demos/injection/shared/PostCommentChip.demo.tsx
+++ b/apps/book/src/demos/injection/shared/PostCommentChip.demo.tsx
@@ -4,7 +4,7 @@ import { PostCommentChip } from '@masknet/injected-ui/PostCommentChip'
 export const meta = {
     title: 'PostCommentChip',
     description:
-        "The chip shown under a post once Mask decrypts an encrypted comment (packages/injected-ui/src/PostCommentChip.tsx). The container (PostComments.tsx) owns the actual decryption and only renders this once it resolves.",
+        'The chip shown under a post once Mask decrypts an encrypted comment (packages/injected-ui/src/PostCommentChip.tsx). The container (PostComments.tsx) owns the actual decryption and only renders this once it resolves.',
 }
 
 export default function PostCommentChipDemo() {

--- a/apps/book/src/demos/injection/shared/PostVisibilityBadge.demo.tsx
+++ b/apps/book/src/demos/injection/shared/PostVisibilityBadge.demo.tsx
@@ -13,7 +13,11 @@ export default function PostVisibilityBadgeDemo() {
 
     return (
         <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
-            <PostVisibilityBadge variant="onlyYou" label="Only visible to yourself" onClick={() => setClicked((c) => c + 1)} />
+            <PostVisibilityBadge
+                variant="onlyYou"
+                label="Only visible to yourself"
+                onClick={() => setClicked((c) => c + 1)}
+            />
             <PostVisibilityBadge variant="everyone" label="All Mask Network users" />
             <div>Clicked {clicked} time(s)</div>
         </Stack>

--- a/apps/book/src/demos/injection/shared/PostVisibilityBadge.demo.tsx
+++ b/apps/book/src/demos/injection/shared/PostVisibilityBadge.demo.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import { Stack } from '@mui/material'
+import { PostVisibilityBadge } from '@masknet/injected-ui/PostVisibilityBadge'
+
+export const meta = {
+    title: 'PostVisibilityBadge',
+    description:
+        "The pill shown on a decrypted post indicating who else it's visible to (packages/injected-ui/src/PostVisibilityBadge.tsx). The 'onlyYou' variant is clickable to open the recipient picker; once recipients are selected the container swaps it for RecipientsToolTip instead.",
+}
+
+export default function PostVisibilityBadgeDemo() {
+    const [clicked, setClicked] = useState(0)
+
+    return (
+        <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+            <PostVisibilityBadge variant="onlyYou" label="Only visible to yourself" onClick={() => setClicked((c) => c + 1)} />
+            <PostVisibilityBadge variant="everyone" label="All Mask Network users" />
+            <div>Clicked {clicked} time(s)</div>
+        </Stack>
+    )
+}

--- a/packages/injected-ui/package.json
+++ b/packages/injected-ui/package.json
@@ -80,6 +80,16 @@
       "types": "./dist/RecipientsToolTip.d.ts",
       "mask-src": "./src/RecipientsToolTip.tsx",
       "default": "./dist/RecipientsToolTip.js"
+    },
+    "./PostCommentChip": {
+      "types": "./dist/PostCommentChip.d.ts",
+      "mask-src": "./src/PostCommentChip.tsx",
+      "default": "./dist/PostCommentChip.js"
+    },
+    "./PostVisibilityBadge": {
+      "types": "./dist/PostVisibilityBadge.d.ts",
+      "mask-src": "./src/PostVisibilityBadge.tsx",
+      "default": "./dist/PostVisibilityBadge.js"
     }
   },
   "dependencies": {

--- a/packages/injected-ui/src/PostCommentChip.tsx
+++ b/packages/injected-ui/src/PostCommentChip.tsx
@@ -1,0 +1,41 @@
+import type { PropsWithChildren } from 'react'
+import { Chip, type ChipProps } from '@mui/material'
+import { Lock } from '@mui/icons-material'
+import { makeStyles } from '@masknet/theme'
+
+const useStyle = makeStyles()({
+    root: {
+        height: 'auto',
+        width: 'calc(98% - 10px)',
+        padding: '6px',
+    },
+    label: {
+        width: '90%',
+        overflowWrap: 'break-word',
+        whiteSpace: 'normal',
+        textOverflow: 'clip',
+    },
+})
+
+export interface PostCommentChipProps extends PropsWithChildren {
+    ChipProps?: ChipProps
+}
+
+/**
+ * The decrypted-comment chip shown under a post once Mask decrypts an encrypted comment.
+ * See packages/mask/content-script/components/InjectedComponents/PostComments.tsx, which owns
+ * the actual decryption (usePostInfoDecryptComment) and only renders this once it resolves.
+ */
+export function PostCommentChip(props: PostCommentChipProps) {
+    const { classes } = useStyle(undefined, { props: props.ChipProps || {} })
+    return (
+        <Chip
+            data-testid="comment_field"
+            icon={<Lock />}
+            label={props.children}
+            color="secondary"
+            {...props.ChipProps}
+            classes={{ root: classes.root, label: classes.label }}
+        />
+    )
+}

--- a/packages/injected-ui/src/PostVisibilityBadge.tsx
+++ b/packages/injected-ui/src/PostVisibilityBadge.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { Typography, useTheme } from '@mui/material'
+import { makeStyles } from '@masknet/theme'
+import { Icons } from '@masknet/icons'
+
+const useStyles = makeStyles<{ clickable: boolean }>()((theme, { clickable }) => ({
+    visibilityBox: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: theme.spacing(0.5, 1),
+        background: theme.vars.palette.maskColor.bg,
+        borderRadius: '999px',
+        cursor: clickable ? 'pointer' : 'default',
+    },
+    iconAdd: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginLeft: 8,
+        background: theme.vars.palette.maskColor.primary,
+        borderRadius: '50%',
+        height: 16,
+        width: 16,
+    },
+}))
+
+export interface PostVisibilityBadgeProps {
+    /** 'onlyYou' shows the clickable "+" affordance to open the recipient picker; 'everyone' is static. */
+    variant: 'onlyYou' | 'everyone'
+    label: ReactNode
+    onClick?: () => void
+}
+
+/**
+ * The small pill shown on a decrypted post indicating who else it's visible to, when the poster
+ * hasn't shared it with any specific recipients yet. See
+ * packages/mask/content-script/components/InjectedComponents/DecryptedPost/DecryptedPostSuccess.tsx,
+ * which swaps this out for RecipientsToolTip once recipients are selected.
+ */
+export function PostVisibilityBadge(props: PostVisibilityBadgeProps) {
+    const { variant, label, onClick } = props
+    const { classes } = useStyles({ clickable: variant === 'onlyYou' })
+    const theme = useTheme()
+    return (
+        <section className={classes.visibilityBox} onClick={variant === 'onlyYou' ? onClick : undefined}>
+            <Typography color="textPrimary" sx={{ fontSize: 12, fontWeight: 500 }}>
+                {label}
+            </Typography>
+            {variant === 'onlyYou' ?
+                <div className={classes.iconAdd}>
+                    <Icons.Plus size={12} color={theme.vars.palette.maskColor.white} />
+                </div>
+            :   null}
+        </section>
+    )
+}

--- a/packages/mask/content-script/components/InjectedComponents/DecryptedPost/DecryptedPostSuccess.tsx
+++ b/packages/mask/content-script/components/InjectedComponents/DecryptedPost/DecryptedPostSuccess.tsx
@@ -1,6 +1,5 @@
 import Services from '#services'
 import { Trans } from '@lingui/react/macro'
-import { Icons } from '@masknet/icons'
 import { delay } from '@masknet/kit'
 import {
     PostInfoContext,
@@ -10,9 +9,7 @@ import {
     usePostInfoVersion,
 } from '@masknet/plugin-infra/content-script'
 import { EMPTY_LIST, MaskMessages, type ProfileIdentifier, type ProfileInformation } from '@masknet/shared-base'
-import { makeStyles } from '@masknet/theme'
 import type { TypedMessage } from '@masknet/typed-message'
-import { Typography, useTheme } from '@mui/material'
 import { memo, useContext, useEffect, useState } from 'react'
 import { activatedSiteAdaptorUI } from '../../../site-adaptor-infra/index.js'
 import type { LazyRecipients } from '../../CompositionDialog/CompositionUI.js'
@@ -23,6 +20,7 @@ import { DecryptedUIPluginRendererWithSuggestion } from '../DecryptedPostMetadat
 import { SelectProfileDialog } from '../SelectPeopleDialog.js'
 import { getAuthorDifferentMessage } from './authorDifferentMessage.js'
 import { RecipientsToolTip } from '@masknet/injected-ui/RecipientsToolTip'
+import { PostVisibilityBadge } from '@masknet/injected-ui/PostVisibilityBadge'
 
 interface DecryptPostSuccessBaseProps {
     message: TypedMessage
@@ -72,34 +70,9 @@ const DecryptPostSuccessBase = memo(function DecryptPostSuccessNoShare(
     )
 })
 
-const useStyles = makeStyles<{ canAppendShareTarget: boolean }>()((theme, { canAppendShareTarget }) => {
-    return {
-        visibilityBox: {
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            padding: theme.spacing(0.5, 1),
-            background: theme.vars.palette.maskColor.bg,
-            borderRadius: '999px',
-            cursor: canAppendShareTarget ? 'pointer' : 'default',
-        },
-        iconAdd: {
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            marginLeft: 8,
-            background: theme.vars.palette.maskColor.primary,
-            borderRadius: '50%',
-            height: 16,
-            width: 16,
-        },
-    }
-})
 export const DecryptPostSuccess = memo(function DecryptPostSuccess(props: DecryptPostSuccessProps) {
     const canAppendShareTarget = useCanAppendShareTarget(props.whoAmI)
-    const { classes } = useStyles({ canAppendShareTarget })
     const [showDialog, setShowDialog] = useState(false)
-    const theme = useTheme()
     const recipients = useRecipientsList()
     const { value: selectedRecipients = EMPTY_LIST, retry } = useSelectedRecipientsList()
 
@@ -109,14 +82,11 @@ export const DecryptPostSuccess = memo(function DecryptPostSuccess(props: Decryp
                 <>
                     {selectedRecipients.length ?
                         <RecipientsToolTip recipients={selectedRecipients} openDialog={() => setShowDialog(true)} />
-                    :   <section className={classes.visibilityBox} onClick={() => setShowDialog(true)}>
-                            <Typography color="textPrimary" sx={{ fontSize: 12, fontWeight: 500 }}>
-                                <Trans>Only visible to yourself</Trans>
-                            </Typography>
-                            <div className={classes.iconAdd}>
-                                <Icons.Plus size={12} color={theme.vars.palette.maskColor.white} />
-                            </div>
-                        </section>
+                    :   <PostVisibilityBadge
+                            variant="onlyYou"
+                            label={<Trans>Only visible to yourself</Trans>}
+                            onClick={() => setShowDialog(true)}
+                        />
                     }
 
                     {showDialog ?
@@ -129,11 +99,7 @@ export const DecryptPostSuccess = memo(function DecryptPostSuccess(props: Decryp
                         />
                     :   null}
                 </>
-            :   <section className={classes.visibilityBox}>
-                    <Typography color="textPrimary" sx={{ fontSize: 12, fontWeight: 500 }}>
-                        <Trans>All Mask Network users</Trans>
-                    </Typography>
-                </section>
+            :   <PostVisibilityBadge variant="everyone" label={<Trans>All Mask Network users</Trans>} />
         :   null
     return <DecryptPostSuccessBase {...props}>{rightActions}</DecryptPostSuccessBase>
 })

--- a/packages/mask/content-script/components/InjectedComponents/PostComments.tsx
+++ b/packages/mask/content-script/components/InjectedComponents/PostComments.tsx
@@ -1,40 +1,10 @@
 import { useEffect } from 'react'
 import { useAsync } from 'react-use'
-import { Chip } from '@mui/material'
-import type { ChipProps } from '@mui/material/Chip'
-import { Lock } from '@mui/icons-material'
 import type { ValueRef } from '@masknet/shared-base'
 import { useValueRef } from '@masknet/shared-base-ui'
-import { makeStyles } from '@masknet/theme'
 import { usePostInfoDecryptComment } from '@masknet/plugin-infra/content-script'
+import { PostCommentChip } from '@masknet/injected-ui/PostCommentChip'
 
-const useStyle = makeStyles()({
-    root: {
-        height: 'auto',
-        width: 'calc(98% - 10px)',
-        padding: '6px',
-    },
-    label: {
-        width: '90%',
-        overflowWrap: 'break-word',
-        whiteSpace: 'normal',
-        textOverflow: 'clip',
-    },
-})
-type PostCommentDecryptedProps = React.PropsWithChildren<{ ChipProps?: ChipProps }>
-function PostCommentDecrypted(props: PostCommentDecryptedProps) {
-    const { classes } = useStyle(undefined, { props: props.ChipProps || {} })
-    return (
-        <Chip
-            data-testid="comment_field"
-            icon={<Lock />}
-            label={props.children}
-            color="secondary"
-            {...props.ChipProps}
-            classes={{ root: classes.root, label: classes.label }}
-        />
-    )
-}
 export interface PostCommentProps {
     comment: ValueRef<string>
     needZip(): void
@@ -47,6 +17,6 @@ export function PostComment(props: PostCommentProps) {
     const { value } = useAsync(async () => decrypt?.(comment), [decrypt, comment])
 
     useEffect(() => void (value && needZip()), [value, needZip])
-    if (value) return <PostCommentDecrypted>{value}</PostCommentDecrypted>
+    if (value) return <PostCommentChip>{value}</PostCommentChip>
     return null
 }


### PR DESCRIPTION
## Description

Follow-up to #12445–#12451 — a closer look at two components from the previously-reported "blocked" list, which turned out to have a separable pure piece after all, without needing to mock any live post-decryption context.

- **`PostComments.tsx` (`PostComment`)**: the actual decryption (`usePostInfoDecryptComment`) has to stay live, but the chip it renders once decryption resolves was already a fully self-contained nested function with no live imports. Pulled out as `PostCommentChip`.
- **`DecryptedPostSuccess.tsx`**: the two small "who can see this" pill states (clickable "only visible to yourself" / static "all Mask Network users") were pure MUI+theme, just reading a `canAppendShareTarget` flag computed from live post-info hooks that stays in the container. Pulled out as `PostVisibilityBadge`; the `RecipientsToolTip` case (already extracted in #12451) is unchanged.

`PostReplacer.tsx`, `DecryptedPost.tsx`, and `DecryptedPostSuccess`'s own `AppendShareDetail`/`SelectProfileDialog` wiring stay as containers — their visible output already reduces to already-extracted or already-public components (`AdditionalContent`, `TypedMessageRender`), with no further separable piece.

I also looked at `PermissionBoundary.tsx` and `SelectPeopleDialog.tsx` for this round and neither yielded anything: `PermissionBoundary` has no fixed visual of its own (it's a conditional switch between two caller-supplied `ReactNode`s), and `SelectPeopleDialog`'s `SelectProfileUI` does its own live address lookup (`useLookupAddress`) and site-specific contact fetching (`useContacts`) internally, not just at the dialog-chrome level — pulling those out would cascade into a much larger refactor than this pass covers.

No new dependencies are introduced.

As with the prior PRs, `packages/injected-ui` keeps per-component exports only (no barrel `index.ts`).

Closes # (NO_ISSUE)

## Type of change

- [ ] Documentation
- [ ] Code refactoring (Restructuring existing code w/o changing its observable behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (a fix or feature that would make something no longer possible to do/require old user must upgrade their Mask Network to this new version)

## Previews

The Vercel preview deploy will build the book app — visit `/injection/shared/PostCommentChip` and `/injection/shared/PostVisibilityBadge` to see both rendered.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file. (no new user-facing strings added — existing production copy is unchanged, only moved between files/passed as props)

If this PR depends on external APIs:

- [ ] N/A — no external API dependency in this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED8N1kMNKJ5vinunnvcWY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ED8N1kMNKJ5vinunnvcWY6)_