### PR TITLE
fix(book): compile @lingui/react/macro with @lingui/swc-plugin

### DIFF
--- a/apps/book/package.json
+++ b/apps/book/package.json
@@ -25,7 +25,8 @@
   "devDependencies": {
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^4.7.0",
+    "@lingui/swc-plugin": "^6.5.1",
+    "@vitejs/plugin-react-swc": "^4.3.3",
     "vite": "^6.2.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0"

--- a/apps/book/vite.config.ts
+++ b/apps/book/vite.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { defaultClientConditions, defineConfig, searchForWorkspaceRoot } from 'vite'
-import react from '@vitejs/plugin-react'
+import reactSwc from '@vitejs/plugin-react-swc'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
 
@@ -9,8 +9,10 @@ const workspaceRoot = searchForWorkspaceRoot(process.cwd())
 export default defineConfig({
     // relative base so the built app also works when served from a sub-path
     base: './',
-    // @masknet/shared-base re-exports @masknet/base, which loads tiny-secp256k1's wasm
-    plugins: [wasm(), topLevelAwait(), react()],
+    // @masknet/shared-base re-exports @masknet/base, which loads tiny-secp256k1's wasm.
+    // The swc-plugin compiles `@lingui/react/macro` imports (e.g. shared-base-ui's CrashUI),
+    // mirroring packages/mask/.webpack/config.ts — without it the macro's runtime guard throws.
+    plugins: [wasm(), topLevelAwait(), reactSwc({ plugins: [['@lingui/swc-plugin', {}]] })],
     resolve: {
         // Mirror packages/mask/.webpack/config.ts `conditionNames: ['mask-src', '...']`.
         // Without this, `@masknet/theme` resolves to its dist entry, which is a `.d.ts` file.
@@ -31,8 +33,15 @@ export default defineConfig({
         },
     },
     optimizeDeps: {
-        // consume these from source, don't pre-bundle
-        exclude: ['@masknet/icons', '@masknet/injected-ui', '@masknet/shared-base', '@masknet/theme'],
+        // consume these from source, don't pre-bundle. @masknet/shared-base-ui must go through
+        // the transform pipeline too: esbuild pre-bundling would skip @lingui/swc-plugin.
+        exclude: [
+            '@masknet/icons',
+            '@masknet/injected-ui',
+            '@masknet/shared-base',
+            '@masknet/shared-base-ui',
+            '@masknet/theme',
+        ],
     },
     build: {
         outDir: 'dist',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,15 +292,18 @@ importers:
         specifier: 0.0.0-experimental-58af67a8f8-20240628
         version: 0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628)
     devDependencies:
+      '@lingui/swc-plugin':
+        specifier: ^6.5.1
+        version: 6.5.1(@lingui/core@6.5.0(babel-plugin-macros@3.1.0))(@swc/core@1.15.43)(typescript@5.9.2)
       '@types/react':
         specifier: ^19.2.10
         version: 19.2.10
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.10)
-      '@vitejs/plugin-react':
-        specifier: ^4.7.0
-        version: 4.7.0(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))
       vite:
         specifier: ^6.2.0
         version: 6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)
@@ -2874,10 +2877,6 @@ packages:
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@7.29.7':
-    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-replace-supers@7.29.7':
     resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
     engines: {node: '>=6.9.0'}
@@ -2971,18 +2970,6 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.25.9':
     resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-self@7.29.7':
-    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7':
-    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4683,8 +4670,8 @@ packages:
   '@rgba-image/lanczos@0.1.1':
     resolution: {integrity: sha512-MSGGU7BZmEbg1xHtNp+StARoN7R38zJnFgSEvSzB710nXsHGEaJt//z2VnPfRQTtKSKUXEnp95JSuqDlXTBrYA==}
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-commonjs@28.0.2':
     resolution: {integrity: sha512-BEFI2EDqzl+vA1rl97IDRZ61AIwGH093d9nz8+dThxJNH8oSoB7MjWvPCX3dkaK1/RCJ/1v/R1XB15FuSs0fQw==}
@@ -5430,15 +5417,6 @@ packages:
   '@types/asn1js@2.0.2':
     resolution: {integrity: sha512-t4YHCgtD+ERvH0FyxvNlYwJ2ezhqw7t+Ygh4urQ7dJER8i185JPv6oIM3ey5YQmGN6Zp9EMbpohkjZi9t3UxwA==}
 
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
@@ -6037,11 +6015,11 @@ packages:
     resolution: {integrity: sha512-XSvL5wKXBZIv7fflMqhQx936sRpEtzxeV25xAEt0rLLXzbF6RCQaRA1jrVIn8JCubMyn/y0TaidphUtilLzl1A==}
     engines: {node: '>=18'}
 
-  '@vitejs/plugin-react@4.7.0':
-    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  '@vitejs/plugin-react-swc@4.3.3':
+    resolution: {integrity: sha512-bti8ZAcvz4Lh6/e4Uk2k3aa1TiUXbbMsahuqOHvd3MveFTkKDZOA6wQVkpj7J/+tepX/wGfe+lsGh/t24HTXMQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^4 || ^5 || ^6 || ^7 || ^8
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -10358,10 +10336,6 @@ packages:
     resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
     engines: {node: '>=0.10.0'}
 
-  react-refresh@0.17.0:
-    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
-    engines: {node: '>=0.10.0'}
-
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
@@ -12818,8 +12792,6 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-plugin-utils@7.29.7': {}
-
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
@@ -12902,16 +12874,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-runtime@7.17.12(@babel/core@7.29.7)':
     dependencies:
@@ -14993,7 +14955,7 @@ snapshots:
       '@rgba-image/copy': 0.1.3
       '@rgba-image/create-image': 0.1.1
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-commonjs@28.0.2(rollup@4.34.9)':
     dependencies:
@@ -15807,23 +15769,6 @@ snapshots:
   '@types/asn1js@2.0.2':
     optional: true
 
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.6
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.7
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-
   '@types/babel__traverse@7.20.6':
     dependencies:
       '@babel/types': 7.29.7
@@ -16468,17 +16413,13 @@ snapshots:
 
   '@ver0/deep-equal@1.0.1': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))':
+  '@vitejs/plugin-react-swc@4.3.3(vite@6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
+      '@rolldown/pluginutils': 1.0.1
+      '@swc/core': 1.15.43
       vite: 6.2.0(@types/node@22.13.9)(jiti@2.7.0)(terser@5.36.0)(yaml@2.7.0)
     transitivePeerDependencies:
-      - supports-color
+      - '@swc/helpers'
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -21519,8 +21460,6 @@ snapshots:
       react-dom: 0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628)
 
   react-refresh@0.16.0: {}
-
-  react-refresh@0.17.0: {}
 
   react-router-dom@7.18.1(react-dom@0.0.0-experimental-58af67a8f8-20240628(react@0.0.0-experimental-58af67a8f8-20240628))(react@0.0.0-experimental-58af67a8f8-20240628):
     dependencies:


### PR DESCRIPTION
## Problem

Opening `http://localhost:5173/#/injection/twitter/ProfileTab` after `pnpm run book` threw:

```
Uncaught Error: The macro you imported from "@lingui/react/macro" is being executed outside the context of compilation.
This indicates that you don't configured correctly one of the "babel-plugin-macros" / "@lingui/swc-plugin" / "babel-plugin-lingui-macro"
```

`ProfileTab` (via `@masknet/shared-base-ui` → `CrashUI.tsx`) pulls `@lingui/react/macro` into the book's module graph for the first time. The extension build compiles the macro away with `@lingui/swc-plugin` (`packages/mask/.webpack/config.ts`), but the book vite config had no equivalent transform — so the `./macro` import resolved through the `browser` export condition to `browser.mjs`, the macro package's runtime guard that throws exactly this error.

## Fix

Mirror the webpack setup:

- swap `@vitejs/plugin-react` (babel) for `@vitejs/plugin-react-swc` with `plugins: [['@lingui/swc-plugin', {}]]` — Lingui v6 only ships the SWC plugin (no v6 babel macro plugin exists on npm), and the workspace already pins `@swc/core` to 1.15.43 for everyone
- exclude `@masknet/shared-base-ui` from `optimizeDeps` — esbuild pre-bundling would bypass the SWC plugin

## Verification

- `pnpm run book` → `#/injection/twitter/ProfileTab` renders; `Trans` compiles to a runtime `@lingui/react` import, no console errors
- `pnpm --filter @masknet/book build` passes
- `tsc --noEmit` delta is zero (the remaining errors are pre-existing on develop)