### PR TITLE
fix(twitter): align injected profile tab styles

### DIFF
--- a/packages/mask/content-script/site-adaptors/twitter.com/injection/ProfileTab.tsx
+++ b/packages/mask/content-script/site-adaptors/twitter.com/injection/ProfileTab.tsx
@@ -19,7 +19,6 @@ import {
     nextTabListSelector,
     searchAppBarBackSelector,
     searchNameTag,
-    searchNewTweetButtonSelector,
     searchProfileEmptySelector,
     searchProfileTabListLastChildSelector,
     searchProfileTabListSelector,
@@ -28,16 +27,21 @@ import {
     searchProfileTabSelector,
 } from '../utils/selector.js'
 
+const TWITTER_TAB_INDICATOR_SELECTOR = ':scope > div > div[dir] > div:last-child'
+
 function getStyleProps() {
     const EMPTY_STYLE = {} as CSSStyleDeclaration
     const eleTab = searchProfileTabSelector().evaluate()?.querySelector(':scope div > div')
     const style = eleTab ? window.getComputedStyle(eleTab) : EMPTY_STYLE
     const paddingEle = searchProfileTabSelector().evaluate()
     const paddingCss = paddingEle ? window.getComputedStyle(paddingEle) : EMPTY_STYLE
-    const eleNewTweetButton = searchNewTweetButtonSelector().evaluate()
-    const newTweetButtonColorStyle = eleNewTweetButton ? window.getComputedStyle(eleNewTweetButton) : EMPTY_STYLE
     const eleBackButton = searchAppBarBackSelector().evaluate()
     const backButtonColorStyle = eleBackButton ? window.getComputedStyle(eleBackButton) : EMPTY_STYLE
+    const selectedTab = searchProfileTabListSelector()
+        .evaluate()
+        .find((tab) => tab.getAttribute('aria-selected') === 'true')
+    const selectedTabIndicator = selectedTab?.querySelector(TWITTER_TAB_INDICATOR_SELECTOR)
+    const selectedTabIndicatorStyle = selectedTabIndicator ? window.getComputedStyle(selectedTabIndicator) : EMPTY_STYLE
 
     return {
         color: style.color,
@@ -47,7 +51,7 @@ function getStyleProps() {
         paddingX: paddingCss.paddingLeft || '16px',
         height: style.height || '53px',
         hover: backButtonColorStyle.color,
-        line: newTweetButtonColorStyle.backgroundColor,
+        line: selectedTabIndicatorStyle.backgroundColor,
     }
 }
 
@@ -146,7 +150,9 @@ async function hideTwitterActivatedContent() {
         const tabLabel = tab.querySelector<HTMLDivElement>(':scope div > div > span')
         if (tabLabel) tabLabel.style.color = style.color
 
-        const indicator = tab.querySelector<HTMLDivElement>(':scope div > div > div')
+        // The selected tab has an extra wrapper around its label. Keep every combinator anchored so
+        // that wrapper is not mistaken for the indicator when X changes the selected tab's markup.
+        const indicator = tab.querySelector<HTMLDivElement>(TWITTER_TAB_INDICATOR_SELECTOR)
         if (indicator) indicator.style.display = 'none'
         tab.addEventListener('click', tab.closest('#open-nft-button') ? nameTagClickHandler : tabClickHandler)
     })
@@ -179,7 +185,7 @@ function resetTwitterActivatedContent() {
     tabList.forEach((tab) => {
         const tabLabel = tab.querySelector<HTMLDivElement>(':scope div > div > span')
         if (tabLabel) tabLabel.style.color = ''
-        const indicator = tab.querySelector<HTMLDivElement>(':scope div > div > div')
+        const indicator = tab.querySelector<HTMLDivElement>(TWITTER_TAB_INDICATOR_SELECTOR)
         if (indicator) indicator.style.display = ''
         tab.removeEventListener('click', tab.closest('#open-nft-button') ? nameTagClickHandler : tabClickHandler)
     })


### PR DESCRIPTION
## Description

Fix the injected Web3 profile tab on X/Twitter so that:

- The native selected tab label remains visible while Web3 is active.
- The native tab indicator is hidden and restored reliably with X's current DOM structure.
- The Web3 indicator color is derived from Twitter's selected tab indicator.

Closes # (NO_ISSUE)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Previews

Manually verified on `https://x.com/suji_yan#web3`: the Web3 and native indicators use the same color and height, and switching tabs restores the native label, indicator, and content.

## Testing

- `pnpm exec eslint packages/mask/content-script/site-adaptors/twitter.com/injection/ProfileTab.tsx`
- `pnpm exec tsc --noEmit -p packages/mask/tsconfig.json`
- `git diff --check`
- React Doctor

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s.
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] No user-facing text or i18n changes are included.

This PR does not depend on external APIs.