### PR TITLE
fix(tips): restore spacing between recipient and amount

### DIFF
--- a/packages/plugins/Tips/src/components/TipDialog.tsx
+++ b/packages/plugins/Tips/src/components/TipDialog.tsx
@@ -39,9 +39,8 @@ const useStyles = makeStyles()((theme) => ({
     },
     section: {
         height: '100%',
-        paddingTop: theme.spacing(2),
+        padding: theme.spacing(2, 2, 0),
         boxSizing: 'border-box',
-        padding: theme.spacing(0, 2),
         overflow: 'auto',
     },
 }))


### PR DESCRIPTION
## Description

Restores the vertical spacing between the recipient selector and amount input in the Tips dialog.

The section `paddingTop` was overridden by a later `padding` shorthand declaration. This consolidates the values into one declaration and restores the intended 16px top spacing.

Closes # (NO_ISSUE)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Previews

The amount input now has the intended spacing below the recipient selector instead of touching it.

## Verification

- [x] Targeted ESLint
- [x] Tips package TypeScript build
- [x] React Doctor (no issues found in the changed file)
- [x] `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
  - [x] I have removed all in development `console.log`s
  - [x] I have removed all commented code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have read [Internationalization Guide](https://github.com/DimensionDev/Maskbook/blob/develop/docs/i18n-guide.md) and moved text fields to the i18n JSON file.

External APIs: Not applicable.