### PR TITLE
fix(tips): stop treating GoPlus contract_address flag as malicious

### DIFF
--- a/packages/plugins/Tips/src/contexts/Tip/useRecipientValidate.ts
+++ b/packages/plugins/Tips/src/contexts/Tip/useRecipientValidate.ts
@@ -2,7 +2,7 @@ import { msg } from '@lingui/core/macro'
 import { useLingui } from '@lingui/react'
 import { NetworkPluginID } from '@masknet/shared-base'
 import { useAddressType, useChainContext } from '@masknet/web3-hooks-base'
-import { GoPlusLabs } from '@masknet/web3-providers'
+import { GoPlusLabs, isMaliciousAddress } from '@masknet/web3-providers'
 import { AddressType, type ChainId } from '@masknet/web3-shared-evm'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
@@ -30,8 +30,8 @@ export function useRecipientValidate(recipientAddress: string): {
         if (!isEvm) return [true]
         if (addressType === AddressType.Contract)
             return [false, _(msg`The receiving address is a contract address. Please check again.`)]
-        const isMaliciousAddress = security && Object.values(security).includes('1')
-        if (isMaliciousAddress) return [false, _(msg`The receiving address may be a malicious address.`)]
+        if (security && isMaliciousAddress(security))
+            return [false, _(msg`The receiving address may be a malicious address.`)]
         return [true]
     }, [isEvm, addressType, security, _])
     return {

--- a/packages/web3-providers/src/GoPlusLabs/index.ts
+++ b/packages/web3-providers/src/GoPlusLabs/index.ts
@@ -10,6 +10,9 @@ import { SecurityMessages } from './rules.js'
 import { getAllMaskDappContractInfo } from '../helpers/getAllMaskDappContractInfo.js'
 import { fetchJSON } from '../helpers/fetchJSON.js'
 import type { AuthorizationAPI, PhishingSiteResponse, SecurityAPI } from '../entry-types.js'
+import { isMaliciousAddress } from './isMaliciousAddress.js'
+
+export { isMaliciousAddress } from './isMaliciousAddress.js'
 
 function checkInWhitelist(chainId: ChainId, address: string) {
     const { WHITE_LISTS } = getGoPlusLabsConstants(chainId)
@@ -127,8 +130,7 @@ export const GoPlusLabs = {
     async checkIfAddressIsScam(chainId: ChainId | 'solana' | 'tron', address: string): Promise<boolean> {
         const security = await GoPlusLabs.getAddressSecurity(chainId, address)
         if (!security) return false
-        const values: string[] = Object.values(security)
-        return values.includes('1')
+        return isMaliciousAddress(security)
     },
 
     async getSupportedChain(): Promise<Array<SecurityAPI.SupportedChain<ChainId>>> {

--- a/packages/web3-providers/src/GoPlusLabs/isMaliciousAddress.ts
+++ b/packages/web3-providers/src/GoPlusLabs/isMaliciousAddress.ts
@@ -1,0 +1,11 @@
+import type { SecurityAPI } from '../entry-types.js'
+
+/**
+ * "is a contract" is not "is malicious" (e.g. EIP-7702 delegated EOAs are
+ * flagged as contracts by GoPlus); contract-ness is judged locally via
+ * getAddressType, which handles 7702 correctly.
+ */
+export function isMaliciousAddress(security: SecurityAPI.AddressSecurity): boolean {
+    const { contract_address: _, data_source: __, ...risks } = security
+    return Object.values(risks).includes('1')
+}

--- a/packages/web3-providers/src/entry.ts
+++ b/packages/web3-providers/src/entry.ts
@@ -53,7 +53,7 @@ export { SOLWeb3 } from './Web3/Solana/apis/ConnectionAPI.js'
 export { Web3Bio } from './Web3Bio/index.js'
 
 // GoPlusLabs
-export { GoPlusLabs } from './GoPlusLabs/index.js'
+export { GoPlusLabs, isMaliciousAddress } from './GoPlusLabs/index.js'
 
 // CoinGecko
 export { CoinGeckoTrending } from './CoinGecko/index.js'

--- a/packages/web3-providers/tests/GoPlusLabs/index.ts
+++ b/packages/web3-providers/tests/GoPlusLabs/index.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import type { SecurityAPI } from '../../src/entry-types.js'
+import { isMaliciousAddress } from '../../src/GoPlusLabs/isMaliciousAddress.js'
+
+function createAddressSecurity(overrides: Partial<SecurityAPI.AddressSecurity> = {}): SecurityAPI.AddressSecurity {
+    return {
+        data_source: 'GoPlus',
+        honeypot_related_address: '0',
+        phishing_activities: '0',
+        blackmail_activities: '0',
+        stealing_attack: '0',
+        fake_kyc: '0',
+        malicious_mining_activities: '0',
+        darkweb_transactions: '0',
+        cybercrime: '0',
+        money_laundering: '0',
+        financial_crime: '0',
+        blacklist_doubt: '0',
+        contract_address: '0',
+        ...overrides,
+    }
+}
+
+describe('isMaliciousAddress', () => {
+    it('should return false when no risk flag is set', () => {
+        expect(isMaliciousAddress(createAddressSecurity())).toBe(false)
+    })
+
+    it('should not treat a contract address as malicious (e.g. EIP-7702 delegated EOAs)', () => {
+        expect(isMaliciousAddress(createAddressSecurity({ contract_address: '1' }))).toBe(false)
+    })
+
+    it('should return true when any malicious risk flag is set', () => {
+        expect(isMaliciousAddress(createAddressSecurity({ phishing_activities: '1' }))).toBe(true)
+        expect(isMaliciousAddress(createAddressSecurity({ honeypot_related_address: '1' }))).toBe(true)
+    })
+})


### PR DESCRIPTION
## Summary

- Tips flagged vitalik.eth (any EIP-7702 delegated EOA) as a "malicious address". Root cause: GoPlus marks any address with code as `contract_address: "1"` — since EIP-7702, delegated EOAs have code — and `useRecipientValidate` scanned **every** field of the security response for `"1"`, conflating "is a contract" with "is malicious".
- Extract `isMaliciousAddress()` into the provider layer (`GoPlusLabs`): it ignores `contract_address` (contract-ness is judged locally via `getAddressType`, which already handles 7702 correctly) and `data_source`, and checks the remaining risk flags.
- `Tips/useRecipientValidate` and `GoPlusLabs.checkIfAddressIsScam` (used by ScamWarning for Solana/Tron) now share it.

## Known limitation (pre-existing, unchanged)

`number_of_malicious_contracts_created` is a count field: values ≥ 2 don't equal the string `'1'` and go undetected; value `'1'` triggers and happens to be semantically correct.

## Verification

- Unit tests for `isMaliciousAddress` (web3-providers vitest): all-`"0"` → false; `contract_address:"1"` alone → false (the 7702 case); `phishing_activities:"1"` → true. 3/3 pass.
- Live: rebuilt dev extension, opened Tips on a @VitalikButerin post (mainnet, recipient vitalik.eth). TanStack query devtools confirm the `["go-plus","address-security",1,0xd8dA…]` query resolved (stale, 1 observer, 20-item data) and the malicious-address warning no longer renders.
- `tsc --noEmit` clean on `web3-providers` and `plugins/Tips`; eslint clean on all changed files.