### PR TITLE
fix: 5 core bug fixes (MF-6794 ~ MF-6798)

### DIFF
--- a/packages/encryption/src/payload_internal/version-37.parser.ts
+++ b/packages/encryption/src/payload_internal/version-37.parser.ts
@@ -2,7 +2,7 @@ import type { PayloadParserResult } from './index.js'
 import type { PayloadParseResult } from '../payload/index.js'
 import { CryptoException, PayloadException, assertArray, assertUint8Array } from '../types/index.js'
 import { andThenAsync, CheckedError, decompressK256Raw, OptionalResult } from '@masknet/base'
-import { Ok, type Result } from 'ts-results-es'
+import { Ok, Result } from 'ts-results-es'
 import { type EC_Key, EC_KeyCurve } from '../payload/types.js'
 import { decodeMessagePackF, assertIVLengthEq16, importAES, importEC_Key } from '../utils/index.js'
 import { safeUnreachable } from '@masknet/kit'
@@ -95,7 +95,11 @@ function importAsymmetryKey(algr: unknown, key: unknown, name: string) {
     return andThenAsync(assertUint8Array(key, name, CryptoException.InvalidCryptoKey), async (pubKey): T => {
         if (typeof algr === 'number' && algr in EC_KeyCurve) {
             if (algr === EC_KeyCurve.secp256k1) {
-                pubKey = await decompressK256Raw(pubKey)
+                const decompressed = (await Result.wrapAsync(() => decompressK256Raw(pubKey))).mapErr(
+                    (e) => new CheckedError(CryptoException.InvalidCryptoKey, e),
+                )
+                if (decompressed.isErr()) return decompressed
+                pubKey = decompressed.value
             }
             const key = await importEC(pubKey, algr)
             if (key.isErr()) return key

--- a/packages/mask/background/database/persona/web.ts
+++ b/packages/mask/background/database/persona/web.ts
@@ -417,9 +417,10 @@ export async function queryProfilesDB(
         results.forEach((each) => {
             const out = profileOutDB(each)
             if (query.hasLinkedPersona && !out.linkedPersona) return
+            if (query.identifiers && !query.identifiers.includes(out.identifier)) return
             result.push(out)
         })
-    } else if (query.identifiers?.length) {
+    } else if (query.identifiers) {
         for await (const each of t.objectStore('profiles').iterate()) {
             const out = profileOutDB(each.value)
             if (query.hasLinkedPersona && !out.linkedPersona) continue

--- a/packages/plugins/RedPacket/src/SiteAdaptor/SolanaRedPacket/SolanaRedPacketCard.tsx
+++ b/packages/plugins/RedPacket/src/SiteAdaptor/SolanaRedPacket/SolanaRedPacketCard.tsx
@@ -149,7 +149,7 @@ export const SolanaRedPacketCard = memo(function SolanaRedPacketCard({
         token,
         sender: payload.sender.name,
         message: payload.sender.message,
-        claimedAmount: availability?.claimed_amount,
+        claimedAmount: availability ? minus(payload.total, availability.balance).toFixed() : undefined,
         claimed: availability?.claimed,
     })
 

--- a/packages/plugins/RedPacket/src/SiteAdaptor/SolanaRedPacket/hooks/useAvailability.ts
+++ b/packages/plugins/RedPacket/src/SiteAdaptor/SolanaRedPacket/hooks/useAvailability.ts
@@ -62,7 +62,7 @@ export function useSolanaAvailability(payload: SolanaRedPacketJSONPayload, chain
         claimed: data.claimedNumber.toString(),
         expired: isExpired,
         isEmpty,
-        claimed_amount: data.claimedAmount.toString(),
+        claimed_amount: claimRecord?.amount.toString() ?? '0',
         publicKey: data.pubkeyForClaimSignature,
         isClaimed,
     }

--- a/packages/plugins/Tips/src/contexts/Tip/useTokenTip.ts
+++ b/packages/plugins/Tips/src/contexts/Tip/useTokenTip.ts
@@ -22,7 +22,7 @@ export function useTokenTip<T extends NetworkPluginID>(
         if (!token?.address) return
         const totalAmount = rightShift(amount, token.decimals).toFixed()
         return Web3.transferFungibleToken(token.address, recipient, totalAmount, '')
-    }, [account, token?.address, token?.decimals, amount, Web3])
+    }, [account, recipient, token?.address, token?.decimals, amount, Web3])
 
     return [isTransferring, sendTip]
 }

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
@@ -272,9 +272,10 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
                 value: transaction.value,
                 gasPrice: gasConfig.gasPrice ?? transaction.gasPrice,
                 gas: gas ? addGasMargin(gas, fromChainId === ChainId.Arbitrum ? 1 : 0.3) : undefined,
+                maxFeePerGas: 'maxFeePerGas' in gasConfig ? gasConfig.maxFeePerGas : undefined,
                 maxPriorityFeePerGas:
-                    'maxPriorityFeePerGas' in gasConfig && gasConfig.maxFeePerGas ?
-                        gasConfig.maxFeePerGas
+                    'maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ?
+                        gasConfig.maxPriorityFeePerGas
                     :   transaction.maxPriorityFeePerGas,
                 _disableSnackbar: true,
             },

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
@@ -249,9 +249,10 @@ export const Confirm = memo(function Confirm() {
                 value: transaction.value,
                 gasPrice: gasConfig.gasPrice ?? transaction.gasPrice,
                 gas: gas ? addGasMargin(gas, chainId === ChainId.Arbitrum ? 1 : 0.3) : undefined,
+                maxFeePerGas: 'maxFeePerGas' in gasConfig ? gasConfig.maxFeePerGas : undefined,
                 maxPriorityFeePerGas:
-                    'maxPriorityFeePerGas' in gasConfig && gasConfig.maxFeePerGas ?
-                        gasConfig.maxFeePerGas
+                    'maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ?
+                        gasConfig.maxPriorityFeePerGas
                     :   transaction.maxPriorityFeePerGas,
                 _disableSnackbar: true,
             },


### PR DESCRIPTION
## Summary

Five core-functionality bug fixes, one commit per Jira issue:

- **MF-6794** Tips: `useTokenTip` deps were missing `recipient`, so after switching the recipient dropdown the tip was sent to the previously selected address (stale closure).
- **MF-6795** Encryption: v37 parser awaited `decompressK256Raw` without `Result` wrapping, so an invalid secp256k1 public key threw instead of returning `Err` and the decrypt pipeline hung forever. Mirrors the guard already used by the v38 parser.
- **MF-6796** Trader: Swap/Bridge confirm assigned `gasConfig.maxFeePerGas` into `maxPriorityFeePerGas` (tip overpaid ~10-15x) and never sent `maxFeePerGas`, dropping the user's NetworkFee max fee. Both fields now read from the gas config correctly.
- **MF-6797** Persona DB: `queryProfilesDB` used if/else-if so `network` and `identifiers` were mutually exclusive; `queryOwnedProfilesInformation` silently received every cached profile on the network instead of only the user's own. Identifiers are now also applied within the network branch, and an empty identifiers array returns an empty result.
- **MF-6798** Red Packet (Solana): the envelope showed the packet-wide cumulative `claimedAmount` as the current user's claim. `claimed_amount` now comes from the per-user claim record; the cover derives the cumulative value from `total - balance` instead.

## Test Plan

- [ ] CT: Tips — enter amount, switch recipient, send; verify transfer goes to the selected address
- [ ] CT: decrypt a v37 post whose authorPublicKey is garbage; UI should show a decrypt failure instead of hanging
- [ ] CT: Swap/bridge on an EIP-1559 chain; inspect the signed tx: maxPriorityFeePerGas ≈ 1-2 gwei, maxFeePerGas matches NetworkFee setting
- [ ] CT: queryOwnedProfilesInformation returns only profiles linked to personas with private keys
- [ ] CT: Solana red packet — claim partially with multiple accounts; envelope shows your own claimed amount