### PR TITLE
fix: mf-6796 follow-up — satisfy unicorn/prefer-minimal-ternary in gas fields

### DIFF
--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
@@ -272,11 +272,10 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
                 value: transaction.value,
                 gasPrice: gasConfig.gasPrice ?? transaction.gasPrice,
                 gas: gas ? addGasMargin(gas, fromChainId === ChainId.Arbitrum ? 1 : 0.3) : undefined,
-                maxFeePerGas: 'maxFeePerGas' in gasConfig ? gasConfig.maxFeePerGas : undefined,
+                maxFeePerGas: ('maxFeePerGas' in gasConfig && gasConfig.maxFeePerGas) || undefined,
                 maxPriorityFeePerGas:
-                    'maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ?
-                        gasConfig.maxPriorityFeePerGas
-                    :   transaction.maxPriorityFeePerGas,
+                    ('maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ? gasConfig : transaction)
+                        .maxPriorityFeePerGas,
                 _disableSnackbar: true,
             },
             {

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
@@ -273,9 +273,10 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
                 gasPrice: gasConfig.gasPrice ?? transaction.gasPrice,
                 gas: gas ? addGasMargin(gas, fromChainId === ChainId.Arbitrum ? 1 : 0.3) : undefined,
                 maxFeePerGas: ('maxFeePerGas' in gasConfig && gasConfig.maxFeePerGas) || undefined,
-                maxPriorityFeePerGas:
-                    ('maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ? gasConfig : transaction)
-                        .maxPriorityFeePerGas,
+                maxPriorityFeePerGas: ('maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ?
+                    gasConfig
+                :   transaction
+                ).maxPriorityFeePerGas,
                 _disableSnackbar: true,
             },
             {

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
@@ -250,9 +250,10 @@ export const Confirm = memo(function Confirm() {
                 gasPrice: gasConfig.gasPrice ?? transaction.gasPrice,
                 gas: gas ? addGasMargin(gas, chainId === ChainId.Arbitrum ? 1 : 0.3) : undefined,
                 maxFeePerGas: ('maxFeePerGas' in gasConfig && gasConfig.maxFeePerGas) || undefined,
-                maxPriorityFeePerGas:
-                    ('maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ? gasConfig : transaction)
-                        .maxPriorityFeePerGas,
+                maxPriorityFeePerGas: ('maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ?
+                    gasConfig
+                :   transaction
+                ).maxPriorityFeePerGas,
                 _disableSnackbar: true,
             },
             {

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
@@ -249,11 +249,10 @@ export const Confirm = memo(function Confirm() {
                 value: transaction.value,
                 gasPrice: gasConfig.gasPrice ?? transaction.gasPrice,
                 gas: gas ? addGasMargin(gas, chainId === ChainId.Arbitrum ? 1 : 0.3) : undefined,
-                maxFeePerGas: 'maxFeePerGas' in gasConfig ? gasConfig.maxFeePerGas : undefined,
+                maxFeePerGas: ('maxFeePerGas' in gasConfig && gasConfig.maxFeePerGas) || undefined,
                 maxPriorityFeePerGas:
-                    'maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ?
-                        gasConfig.maxPriorityFeePerGas
-                    :   transaction.maxPriorityFeePerGas,
+                    ('maxPriorityFeePerGas' in gasConfig && gasConfig.maxPriorityFeePerGas ? gasConfig : transaction)
+                        .maxPriorityFeePerGas,
                 _disableSnackbar: true,
             },
             {


### PR DESCRIPTION
## Summary

Follow-up to #12462 (merged a few seconds before the eslint job finished, so the lint errors below landed on develop).

`unicorn/prefer-minimal-ternary` (2 errors) on the EIP-1559 gas fields introduced in MF-6796:

- `maxFeePerGas: ('maxFeePerGas' in gasConfig && gasConfig.maxFeePerGas) || undefined`
- `maxPriorityFeePerGas: (cond ? gasConfig : transaction).maxPriorityFeePerGas` — branches now share the property name, so the rule wants the ternary minimized

Behavior identical to what was merged; verified eslint + tsc clean locally.

## Test Plan

- [ ] eslint job green