### PR TITLE
fix(web3): chunk balance-checker queries and isolate reverting tokens

### DIFF
--- a/packages/web3-providers/src/Web3/EVM/apis/ConnectionReadonlyAPI.ts
+++ b/packages/web3-providers/src/Web3/EVM/apis/ConnectionReadonlyAPI.ts
@@ -284,20 +284,57 @@ export class EVMConnectionReadonlyAPI
         const listOfNonNativeAddress = listOfAddress.filter((x) => !isNativeTokenAddress(x))
 
         if (listOfNonNativeAddress.length) {
-            const contract = this.Contract.getBalanceCheckerContract(BALANCE_CHECKER_ADDRESS)
-            const balances = (await this.Contract.readContract(
-                contract,
-                'balances',
-                [[options.account as Address], listOfNonNativeAddress as Address[]],
-                // cannot check the sender's balance in the same contract
-                { ...options, from: undefined },
-            )) as readonly bigint[] | undefined
-
+            const balances = await this.getBalancesInChunks(
+                BALANCE_CHECKER_ADDRESS,
+                options.account as Address,
+                listOfNonNativeAddress as Address[],
+                options,
+            )
             listOfNonNativeAddress.forEach((x, i) => {
-                entities.push([x, balances?.[i]?.toString() ?? '0'])
+                entities.push([x, balances[i]?.toString() ?? '0'])
             })
         }
         return Object.fromEntries(entities)
+    }
+
+    /**
+     * The balance checker reverts as a whole when a single token reverts (dead
+     * contracts are common on long token lists), and oversized batches can hit
+     * the node's eth_call gas cap. Query in chunks and bisect failing chunks,
+     * zeroing out individually reverting tokens.
+     */
+    private async getBalancesInChunks(
+        balanceCheckerAddress: string,
+        account: Address,
+        tokens: Address[],
+        options: EVMConnectionOptions,
+    ): Promise<readonly bigint[]> {
+        const contract = this.Contract.getBalanceCheckerContract(balanceCheckerAddress)
+        const readBalances = async (chunk: Address[]): Promise<readonly bigint[]> => {
+            if (!chunk.length) return []
+            try {
+                return ((await this.Contract.readContract(
+                    contract,
+                    'balances',
+                    [[account], chunk],
+                    // cannot check the sender's balance in the same contract
+                    { ...options, from: undefined },
+                )) ?? []) as readonly bigint[]
+            } catch {
+                if (chunk.length === 1) return [0n]
+                const mid = Math.floor(chunk.length / 2)
+                const [left, right] = await Promise.all([
+                    readBalances(chunk.slice(0, mid)),
+                    readBalances(chunk.slice(mid)),
+                ])
+                return [...left, ...right]
+            }
+        }
+        const CHUNK_SIZE = 100
+        const chunks = Array.from({ length: Math.ceil(tokens.length / CHUNK_SIZE) }, (_, i) =>
+            tokens.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE),
+        )
+        return (await Promise.all(chunks.map(readBalances))).flat()
     }
 
     getNativeToken(initial?: EVMConnectionOptions): Promise<FungibleToken<ChainId, SchemaType>> {


### PR DESCRIPTION
Stacked on #12465 — retarget to `develop` once it merges.

## Problem

`getFungibleTokensBalance` sent the entire token list to the balance checker in a single `eth_call`. On BNB Chain the list is ~1700 addresses, and the call always reverted, so SelectFungibleTokenDialog / the wallet kept spinning with no balances. Two independent failure modes:

1. **A single reverting token poisons the batch.** The checker does not isolate per-token failures — 29 tokens in the current `tokens.r2d2.to` BSC list revert `balanceOf` (dead contracts: Multichain, Oikos, Peri, agEUR, Wrapped Binance Beacon ETH, …). Any batch containing one reverts wholesale.
2. **Oversized batches can hit the node's eth_call gas cap.**

Reproduced with the real list: prefix of 200 known-good tokens → OK; ≥203 (first dead token at index 202) → `execution reverted: 0x`. Same revert on `56.rpc.thirdweb.com` and `bsc-dataseed.binance.org`, i.e. this predates the public-RPC switch.

## Fix

Query in chunks of 100; when a chunk fails, bisect it recursively and zero out individually reverting tokens.

Verified against the full 1735-token BSC list: 1735/1735 balances resolved in 62 requests (~3.4s, parallel) where the single call previously reverted.