### PR TITLE
fix: mf-6819 verify web3 identity addresses via MaskX

### DIFF
--- a/packages/web3-providers/src/Firefly/Config.ts
+++ b/packages/web3-providers/src/Firefly/Config.ts
@@ -8,8 +8,6 @@ import { fetchJSON } from '../helpers/fetchJSON.js'
 import { Web3Bio } from '../Web3Bio/index.js'
 import { FIREFLY_BASE_URL } from './constants.js'
 
-const TWITTER_HANDLER_VERIFY_URL = 'https://twitter-handler-proxy.r2d2.to'
-
 function toLensAccount(profile: Web3BioProfile): FireflyConfigAPI.LensAccount {
     return {
         address: profile.address,
@@ -26,17 +24,6 @@ export const FireflyConfig = {
         if (!twitterHandle) return EMPTY_LIST
         const profiles = await Web3Bio.getAllLens(twitterHandle)
         return profiles.map(toLensAccount)
-    },
-
-    async getVerifiedHandles(address: string) {
-        const response = await fetchJSON<FireflyConfigAPI.VerifyTwitterResult>(
-            urlcat(TWITTER_HANDLER_VERIFY_URL, '/v1/relation/handles', {
-                wallet: address.toLowerCase(),
-                isVerified: true,
-            }),
-        )
-        if ('error' in response) return []
-        return response.data
     },
 
     /**

--- a/packages/web3-providers/src/Web3/EVM/state/IdentityService.ts
+++ b/packages/web3-providers/src/Web3/EVM/state/IdentityService.ts
@@ -11,7 +11,6 @@ import { IdentityServiceState } from '../../Base/state/IdentityService.js'
 import { BaseMaskX } from '../../../entry-types.js'
 import defer * as ARBID from '../../../ARBID/index.js'
 import defer * as ENS from '../../../ENS/index.js'
-import defer * as Firefly from '../../../Firefly/index.js'
 import defer * as MaskX from '../../../MaskX/index.js'
 import defer * as RSS3 from '../../../RSS3/index.js'
 import defer * as SpaceID from '../../../SpaceID/index.js'
@@ -182,6 +181,21 @@ export class EVMIdentityService extends IdentityServiceState<ChainId> {
         return compact(allSettled.map((x) => (x.status === 'fulfilled' ? x.value : undefined)))
     }
 
+    /** Collect wallet addresses verified by MaskX under a Twitter identity. */
+    private async getVerifiedAddressesFromMaskX(userId: string) {
+        try {
+            const { records } = await MaskX.MaskX.getIdentitiesExact(userId, BaseMaskX.PlatformType.Twitter)
+            return new Set(
+                records
+                    .filter((x) => x.is_verified && isValidAddress(x.web3_addr) && !isZeroAddress(x.web3_addr))
+                    .map((x) => x.web3_addr.toLowerCase()),
+            )
+        } catch {
+            // degrade to unverified on fetch failure
+            return new Set<string>()
+        }
+    }
+
     override async getFromRemote(identity: SocialIdentity) {
         const socialAddressFromMaskX = this.getSocialAddressesFromMaskX(identity)
         const allSettled = await Promise.allSettled([
@@ -195,30 +209,14 @@ export class EVMIdentityService extends IdentityServiceState<ChainId> {
 
         const identities = uniqBy(mergedIdentities, (x) => [x.type, x.label, x.address.toLowerCase()].join('_'))
 
-        const handle = identity.identifier?.userId
-        if (!handle) return []
-        // Identity is address type, will check if it's verified by Firefly
-        const verifiedHandleMap = new Map<string, string[]>()
-        const verifiedResult = await Promise.allSettled(
-            uniqBy(identities, (x) => x.address.toLowerCase()).map(async (x) => {
-                const address = x.address.toLowerCase()
-                if (x.verified) return address
-                const verifiedHandles = await Firefly.FireflyConfig.getVerifiedHandles(address)
-                verifiedHandleMap.set(address, verifiedHandles)
-                return verifiedHandles.includes(handle) ? address : null
-            }),
-        )
-        const trustedAddresses = compact(verifiedResult.map((x) => (x.status === 'fulfilled' ? x.value : null)))
+        const userId = identity.identifier?.userId
+        if (!userId) return []
+        // MaskX is the source of truth telling if a wallet address is verified by the Twitter identity
+        const verifiedAddresses = await this.getVerifiedAddressesFromMaskX(userId)
 
-        const result = identities.filter((x) => {
-            const address = x.address.toLowerCase()
-            if (trustedAddresses.includes(address)) return true
-            if (x.type === SocialAddressType.Address) {
-                const handles = verifiedHandleMap.get(address) || []
-                return handles.length ? handles.includes(handle) : true
-            }
-            return false
+        return identities.filter((x) => {
+            if (verifiedAddresses.has(x.address.toLowerCase())) return true
+            return x.type === SocialAddressType.Address
         })
-        return result
     }
 }

--- a/packages/web3-providers/src/types/Firefly.ts
+++ b/packages/web3-providers/src/types/Firefly.ts
@@ -29,8 +29,6 @@ export namespace FireflyConfigAPI {
 
     export type LensResult = Result<LensAccount[]>
 
-    export type VerifyTwitterResult = { error: string } | { data: string[] }
-
     export interface UnionProfileOptions {
         twitterId?: string
         walletAddress?: string

--- a/security/content-security-policy.json
+++ b/security/content-security-policy.json
@@ -32,7 +32,6 @@
         "https://debank-proxy.r2d2.to",
         "https://simplehash-proxy.r2d2.to",
         "https://dsearch.mask.r2d2.to/",
-        "https://twitter-handler-proxy.r2d2.to",
         "https://nftscan-proxy.r2d2.to",
         "https://opensea-proxy.r2d2.to",
         // !!! if they don't have a whitelist, our CSP will be bypassed


### PR DESCRIPTION
## Summary

Fixes the QA regression where `GET https://twitter-handler-proxy.r2d2.to/v1/relation/handles` returned HTTP 530. The r2d2 worker is a pass-through to `api.dimension.im`, whose domain has lost DNS delegation (NXDOMAIN at the `.im` TLD servers) — the origin is unrecoverable and no replacement API serves the wallet→handles direction (api.firefly.land, next.id, MaskX, web3.bio were all probed).

- **`EVMIdentityService.getFromRemote`**: drop the dead `getVerifiedHandles` trust step and reverse the query direction — the already-integrated MaskX identity fetch for the current Twitter user now builds the set of `is_verified` wallet addresses (`getVerifiedAddressesFromMaskX`). The second `getIdentitiesExact` call hits the 1-min `fetchCachedJSON` cache, so no extra network traffic.
- **`FireflyConfig.getVerifiedHandles` + `TWITTER_HANDLER_VERIFY_URL` + `VerifyTwitterResult`**: deleted (sole caller removed). Same treatment as mf-6791 (`1e86531ea9`) for the other dead `api.dimension.im` call.
- **CSP**: removed the `twitter-handler-proxy.r2d2.to` connect-src entry.

## Behavior change

Before (live, broken): the 530 HTML body throws in `getFromRemote` → all typed entries (ENS/SpaceID/ARBID/Crossbell/MaskX) dropped from the Web3 avatar wallet list; only raw `Address` twins survive, including MaskX-*verified* wallets.

After: MaskX-verified wallets reappear; typed entries are kept when their address is MaskX-verified, else degrade to the plain `Address` twin (same as today); MaskX fetch failure degrades to the Address-twins-only behavior.

## Note

The `twitter-handler-proxy` Cloudflare worker itself will be removed in the workers repo separately; the live CF route can stay until then — old extension versions get errors either way.

Jira: MF-6819