### PR TITLE
fix: replace dead public RPC presets (MF-6821, MF-6823)

### DIFF
--- a/packages/web3-shared/evm/src/constants/viem-chains.ts
+++ b/packages/web3-shared/evm/src/constants/viem-chains.ts
@@ -64,17 +64,9 @@ const VIEM_CHAINS: Partial<Record<ChainId, Chain>> = {
 // endpoints, or covers a chain viem has no preset for.
 const RPC_URL_OVERRIDES: Partial<Record<ChainId, string[]>> = {
     // viem 2.45's preset (eth.merkle.io) persistently 429s anonymous traffic
-    [ChainId.Mainnet]: [
-        'https://ethereum-rpc.publicnode.com',
-        'https://eth.drpc.org',
-        'https://cloudflare-eth.com',
-    ],
+    [ChainId.Mainnet]: ['https://ethereum-rpc.publicnode.com', 'https://eth.drpc.org', 'https://cloudflare-eth.com'],
     // viem 2.45's preset (polygon-rpc.com) rejects anonymous traffic (401/403)
-    [ChainId.Polygon]: [
-        'https://polygon-bor-rpc.publicnode.com',
-        'https://polygon.drpc.org',
-        'https://1rpc.io/matic',
-    ],
+    [ChainId.Polygon]: ['https://polygon-bor-rpc.publicnode.com', 'https://polygon.drpc.org', 'https://1rpc.io/matic'],
     // viem 2.45's preset is a single thirdweb free-tier endpoint
     [ChainId.BSC]: [
         'https://bsc-rpc.publicnode.com',

--- a/packages/web3-shared/evm/src/constants/viem-chains.ts
+++ b/packages/web3-shared/evm/src/constants/viem-chains.ts
@@ -73,13 +73,13 @@ const RPC_URL_OVERRIDES: Partial<Record<ChainId, string[]>> = {
     // no viem preset; official endpoint first, then a community mirror
     [ChainId.Robinhood]: ['https://rpc.mainnet.chain.robinhood.com', 'https://robinhood-rpc.publicnode.com'],
     // viem's preset mixes in unreachable (hypersync), quota-exhausted (blockeden)
-    // and CORS-less (blastapi) endpoints; keep the browser-working subset
+    // and CORS-less (blastapi) endpoints; keep the browser-working subset.
+    // OnFinality dropped: stale blocks, eth_getLogs needs an api key
     [ChainId.Metis]: [
-        'https://metis-pokt.nodies.app',
-        'https://metis-andromeda.rpc.thirdweb.com',
-        'https://metis-andromeda.gateway.tenderly.co',
-        'https://metis.api.onfinality.io/public',
         'https://andromeda.metis.io/?owner=1088',
+        'https://metis-pokt.nodies.app',
+        'https://metis-andromeda.gateway.tenderly.co',
+        'https://metis-andromeda.rpc.thirdweb.com',
     ],
 }
 

--- a/packages/web3-shared/evm/src/constants/viem-chains.ts
+++ b/packages/web3-shared/evm/src/constants/viem-chains.ts
@@ -63,6 +63,18 @@ const VIEM_CHAINS: Partial<Record<ChainId, Chain>> = {
 // These lists replace viem's preset when it includes dead or browser-unfriendly
 // endpoints, or covers a chain viem has no preset for.
 const RPC_URL_OVERRIDES: Partial<Record<ChainId, string[]>> = {
+    // viem 2.45's preset (eth.merkle.io) persistently 429s anonymous traffic
+    [ChainId.Mainnet]: [
+        'https://ethereum-rpc.publicnode.com',
+        'https://eth.drpc.org',
+        'https://cloudflare-eth.com',
+    ],
+    // viem 2.45's preset (polygon-rpc.com) rejects anonymous traffic (401/403)
+    [ChainId.Polygon]: [
+        'https://polygon-bor-rpc.publicnode.com',
+        'https://polygon.drpc.org',
+        'https://1rpc.io/matic',
+    ],
     // viem 2.45's preset is a single thirdweb free-tier endpoint
     [ChainId.BSC]: [
         'https://bsc-rpc.publicnode.com',

--- a/packages/web3-shared/evm/src/constants/viem-chains.ts
+++ b/packages/web3-shared/evm/src/constants/viem-chains.ts
@@ -63,6 +63,13 @@ const VIEM_CHAINS: Partial<Record<ChainId, Chain>> = {
 // These lists replace viem's preset when it includes dead or browser-unfriendly
 // endpoints, or covers a chain viem has no preset for.
 const RPC_URL_OVERRIDES: Partial<Record<ChainId, string[]>> = {
+    // viem 2.45's preset is a single thirdweb free-tier endpoint
+    [ChainId.BSC]: [
+        'https://bsc-rpc.publicnode.com',
+        'https://bsc-dataseed.bnbchain.org',
+        'https://56.rpc.thirdweb.com',
+    ],
+    [ChainId.Fantom]: ['https://rpc.fantom.network', 'https://fantom.drpc.org', 'https://250.rpc.thirdweb.com'],
     // no viem preset; official endpoint first, then a community mirror
     [ChainId.Robinhood]: ['https://rpc.mainnet.chain.robinhood.com', 'https://robinhood-rpc.publicnode.com'],
     // viem's preset mixes in unreachable (hypersync), quota-exhausted (blockeden)


### PR DESCRIPTION
## Summary

Audited every RPC endpoint reachable through `getPublicRPCUrls()` (viem 2.45 presets + repo overrides) with live probes: HTTP status, CORS headers, chainId correctness, block freshness, and rate-limit behavior under heavier methods (`eth_getLogs`/`eth_call`).

| Chain | Before | After |
|---|---|---|
| Ethereum | sole preset `eth.merkle.io` — persistent 429 (CF 1015) | publicnode / eth.drpc.org / cloudflare-eth.com |
| Polygon | sole preset `polygon-rpc.com` — 401/403 "tenant disabled" | publicnode / polygon.drpc.org / 1rpc.io |
| BSC (MF-6823) | sole preset `56.rpc.thirdweb.com` free tier | publicnode + official `bsc-dataseed.bnbchain.org` + thirdweb |
| Fantom (MF-6823) | sole preset `250.rpc.thirdweb.com` free tier | official `rpc.fantom.network` + drpc + thirdweb |
| Metis (MF-6821) | incl. `metis.api.onfinality.io/public` | dropped OnFinality, official endpoint first |

Every new endpoint verified: 200 + CORS (the MV3 extension has no `host_permissions`, so CORS is mandatory) + correct chainId.

### MF-6821 Metis
`metis.api.onfinality.io/public` now demands an API key for `eth_getLogs` (`-32029 Too Many Requests, Please apply an OnFinality API key`) **and serves blocks ~2.7M behind tip** — stale balances/state for seeded users. Dropped it; official `andromeda.metis.io` moved to first position for `ProviderURL.fromOfficial()`.

### MF-6823 thirdweb
viem 2.45 presets BSC/Fantom to a single thirdweb free-tier URL each (no fallback — the AB-seed picks from a 1-element list). Added operator-diverse endpoints ahead of thirdweb. (`bsc.drpc.org` was tested but throttles anonymous traffic with sustained 429s, so official dataseed was used instead.)

### Ethereum/Polygon (no ticket)
Both chains had a single dead public endpoint each; replaced with three CORS-enabled ones each. viem 2.56 already dropped `eth.merkle.io` upstream, confirming the deprecation.

## Out of scope (flagged, needs separate ticket)
- **XLayer_Testnet**: OKX migrated the testnet 195 → 1952; every endpoint returns the wrong chainId vs our `ChainId.XLayer_Testnet = 195`. Needs an enum migration (5 files), not an RPC swap.
- Gorli/Mumbai presets are dead testnets kept dead by design.

Jira: [MF-6821](https://mask.atlassian.net/browse/MF-6821), [MF-6823](https://mask.atlassian.net/browse/MF-6823)

[MF-6821]: https://mask.atlassian.net/browse/MF-6821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ