### PR TITLE
fix: mf-6820 support red packet on robinhood chain

### DIFF
--- a/packages/plugins/RedPacket/src/base.ts
+++ b/packages/plugins/RedPacket/src/base.ts
@@ -44,6 +44,7 @@ export const base = {
                     ChainId.Metis,
                     ChainId.XLayer,
                     ChainId.Sei,
+                    ChainId.Robinhood,
                 ],
             },
             [NetworkPluginID.PLUGIN_FLOW]: { supportedChainIds: [] },

--- a/packages/web3-constants/evm/red-packet.json
+++ b/packages/web3-constants/evm/red-packet.json
@@ -40,7 +40,8 @@
         "Metis": "0x2cf91AD8C175305EBe6970Bd8f81231585EFbd77",
         "Sei": "0xB349AC5E5C037C2ecb2AE9fCDc8F122b5f384620",
         "XLayer": "0xDb847f1D8099C5b15519ECfd0b0C981d719bccE6",
-        "XLayer_Testnet": "0x977baB5f7e2cEd0C91fDA890Ed1DBDfD3Ee9AE81"
+        "XLayer_Testnet": "0x977baB5f7e2cEd0C91fDA890Ed1DBDfD3Ee9AE81",
+        "Robinhood": "0x16f61cb37169523635B6761f3C946892fb3c18fB"
     },
     "HAPPY_RED_PACKET_ADDRESS_V4_BLOCK_HEIGHT": {
         "Mainnet": 12939427,
@@ -72,6 +73,7 @@
         "Metis": 1702860,
         "Sei": 81152032,
         "XLayer": 0,
-        "XLayer_Testnet": 7320220
+        "XLayer_Testnet": 7320220,
+        "Robinhood": 5036643
     }
 }


### PR DESCRIPTION
## Summary
- MF-6820: the create-red-packet token picker listed the new Robinhood chain (4663), but no V4 contract was registered there, so `HAPPY_RED_PACKET_ADDRESS_V4` resolved to `undefined` → contract hook returned `null` → the confirm screen silently closed / creation aborted on gas estimation.
- Register the HappyRedPacket V4 contract on Robinhood (deployed by upstream DimensionDev/RedPacket#77) and enable the chain for the plugin:
  - `packages/web3-constants/evm/red-packet.json`: `HAPPY_RED_PACKET_ADDRESS_V4` → `0x16f61cb37169523635B6761f3C946892fb3c18fB`, `HAPPY_RED_PACKET_ADDRESS_V4_BLOCK_HEIGHT` → `5036643`
  - `packages/plugins/RedPacket/src/base.ts`: append `ChainId.Robinhood` to supported chain ids

## Verification
- `pnpm build` + `pnpm lint` pass.
- On-chain via `rpc.mainnet.chain.robinhood.com`: encoded the plugin's `create_red_packet` calldata and `eth_estimateGas`'d it against the registered address — the call executes inside the contract (reverts only on the contract's own `#tokens > #packets` validation for a zero total), confirming address + encoding; with real value it stops only at the wallet's zero balance, matching the UI's disabled state.
- Runtime: Lucky Drop dialog renders on Robinhood in the dev extension, picker defaults to the Robinhood network (robinhoodchain.blockscout.com links) and lists native ETH (token list URL 404s, as expected on a new chain).