### PR TITLE
fix: mf-6820 hide robinhood chain from red packet

### DIFF
--- a/packages/plugins/RedPacket/src/SiteAdaptor/components/ConditionSettings.tsx
+++ b/packages/plugins/RedPacket/src/SiteAdaptor/components/ConditionSettings.tsx
@@ -9,6 +9,7 @@ import type { ChainId, SchemaType } from '@masknet/web3-shared-evm'
 import { ClickAwayListener, InputBase, Typography, type PopperProps } from '@mui/material'
 import { useState, type HTMLProps } from 'react'
 import { ConditionType, useRedPacket } from '../contexts/RedPacketContext.js'
+import { useRedPacketSupportedChains } from '../hooks/useRedPacketSupportedChains.js'
 
 const useStyles = makeStyles()((theme) => {
     return {
@@ -137,6 +138,7 @@ export function ConditionSettings(props: HTMLProps<HTMLDivElement>) {
         useRedPacket()
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>()
     const { chainId } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
+    const chains = useRedPacketSupportedChains()
 
     return (
         <ClickAwayListener onClickAway={() => setAnchorEl(null)}>
@@ -259,6 +261,7 @@ export function ConditionSettings(props: HTMLProps<HTMLDivElement>) {
                                                 selectedTokens: requiredTokens,
                                                 pluginID: NetworkPluginID.PLUGIN_EVM,
                                                 chainId,
+                                                chains,
                                                 multiple: true,
                                                 maxTokens: 4,
                                             })

--- a/packages/plugins/RedPacket/src/SiteAdaptor/hooks/useRedPacketSupportedChains.ts
+++ b/packages/plugins/RedPacket/src/SiteAdaptor/hooks/useRedPacketSupportedChains.ts
@@ -1,0 +1,17 @@
+import { NetworkPluginID } from '@masknet/shared-base'
+import { useNetworks } from '@masknet/web3-hooks-base'
+import type { ChainId } from '@masknet/web3-shared-evm'
+import { useMemo } from 'react'
+import { RED_PACKET_UNSUPPORTED_CHAINS } from '../../constants.js'
+
+/** Chain ids offered in the red packet token pickers. */
+export function useRedPacketSupportedChains(): ChainId[] {
+    const networks = useNetworks(NetworkPluginID.PLUGIN_EVM, true)
+    return useMemo(
+        () =>
+            networks
+                .map((network) => network.chainId)
+                .filter((chainId) => !RED_PACKET_UNSUPPORTED_CHAINS.includes(chainId)),
+        [networks],
+    )
+}

--- a/packages/plugins/RedPacket/src/SiteAdaptor/views/CreateTokenRedPacket.tsx
+++ b/packages/plugins/RedPacket/src/SiteAdaptor/views/CreateTokenRedPacket.tsx
@@ -37,6 +37,7 @@ import { PreviewRedPacket } from '../components/PreviewRedPacket.js'
 import { useRedPacket } from '../contexts/RedPacketContext.js'
 import { useCreateParams } from '../hooks/useCreateCallback.js'
 import { useDefaultCreateGas } from '../hooks/useDefaultCreateGas.js'
+import { useRedPacketSupportedChains } from '../hooks/useRedPacketSupportedChains.js'
 import { ThemePicker } from '../components/ThemePicker.js'
 
 const useStyles = makeStyles()((theme) => ({
@@ -168,6 +169,7 @@ export function CreateTokenRedPacket() {
     // context
     const { pluginID } = useEnvironmentContext()
     const { HAPPY_RED_PACKET_ADDRESS_V4 } = useRedPacketConstants(chainId)
+    const chains = useRedPacketSupportedChains()
 
     // #region select token
     const nativeTokenPrice = useNativeTokenPrice(NetworkPluginID.PLUGIN_EVM, { chainId }).data || 0
@@ -178,13 +180,14 @@ export function CreateTokenRedPacket() {
             selectedTokens: token ? [token] : [],
             chainId,
             pluginID: NetworkPluginID.PLUGIN_EVM,
+            chains,
         })
         if (!picked || Array.isArray(picked)) return
         if (chainId !== picked.chainId) {
             setChainId(picked.chainId as ChainId)
         }
         setToken(picked as FungibleToken<ChainId, SchemaType>)
-    }, [token?.address, chainId])
+    }, [token?.address, chainId, chains])
     // #endregion
 
     // shares

--- a/packages/plugins/RedPacket/src/constants.ts
+++ b/packages/plugins/RedPacket/src/constants.ts
@@ -1,5 +1,6 @@
 import { PluginID } from '@masknet/shared-base'
 import { FireflyRedPacketAPI } from '@masknet/web3-providers/types'
+import { ChainId } from '@masknet/web3-shared-evm'
 
 /**
  * !! This ID is used to identify the stored plugin data. Change it will cause data lost.
@@ -12,6 +13,12 @@ export const RED_PACKET_MAX_SHARES = 500
 export const SOL_REDPACKET_MAX_SHARES = 200
 export const SOL_REDPACKET_CREATE_DEFAULT_GAS = '10000000'
 export const DEFAULT_DURATION = 60 * 60 * 24 // 24 hours
+/**
+ * Chains hidden from the red packet token pickers.
+ * The Robinhood chain is not claimable yet (the backend does not support claiming),
+ * so creating a lucky drop there is disabled until it is.
+ */
+export const RED_PACKET_UNSUPPORTED_CHAINS = [ChainId.Robinhood]
 export const enum RoutePaths {
     Create = '/create',
     CreateTokenRedPacket = '/create/token',


### PR DESCRIPTION
## Summary
- MF-6820: the create-red-packet token picker listed the Robinhood chain (4663), but red packets there cannot be claimed yet (the backend does not support claiming on Robinhood), so creating one is blocked until that lands.
- Hide the Robinhood chain from the red packet token pickers instead:
  - `constants.ts`: new `RED_PACKET_UNSUPPORTED_CHAINS = [ChainId.Robinhood]`
  - new `useRedPacketSupportedChains()` hook: `useNetworks` minus the unsupported chains
  - pass `chains` to `SelectFungibleTokenModal` in the create form (`CreateTokenRedPacket.tsx`) and the claim-conditions token picker (`ConditionSettings.tsx`)

Follow-up: once claiming is supported on Robinhood, remove `ChainId.Robinhood` from `RED_PACKET_UNSUPPORTED_CHAINS` and register the V4 contract (see #12473, currently draft, which does exactly that).

## Verification
- `pnpm build` + `pnpm lint` pass.
- Runtime (dev extension on x.com): opened the Lucky Drop token picker — the network rail no longer shows the Robinhood icon (19 → 18 entries), and no Robinhood feather logo is present; all other chains unchanged.

## Notes
- If the wallet is already switched to Robinhood globally, the dialog still opens on it (the picker keeps showing the current chain's native token) — users just can no longer *switch to* Robinhood from the red packet pickers. Auto-forcing a chain switch was avoided since it would prompt an unwanted `wallet_switchEthereumChain` in the connected wallet.