### PR TITLE
fix: mf-6828 update polygon bridge url

### DIFF
--- a/packages/plugins/CrossChainBridge/src/SiteAdaptor/components/BridgeStack.tsx
+++ b/packages/plugins/CrossChainBridge/src/SiteAdaptor/components/BridgeStack.tsx
@@ -103,7 +103,7 @@ const crossChainBridge = [
         ID: `${PLUGIN_ID}_polygon_bridge`,
         isOfficial: true,
         icon: <PolygonBridgeIcon />,
-        link: 'https://wallet.polygon.technology/polygon/bridge/',
+        link: 'https://portal.polygon.technology/bridge',
     },
     {
         name: 'Rainbow Bridge',


### PR DESCRIPTION
## Summary

Fixes the QA regression in [MF-6828](https://mask.atlassian.net/browse/MF-6828): the Cross-chain plugin's Polygon Bridge entry still linked to the retired `wallet.polygon.technology` Web Wallet, which no longer serves the bridge.

- Updated the hardcoded link in `BridgeStack.tsx` to the official successor, Polygon Portal: `https://portal.polygon.technology/bridge` (verified live, HTTP 200).
- No i18n/test impact — bridge names/links are plain string literals.

[MF-6828]: https://mask.atlassian.net/browse/MF-6828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ