### PR TITLE
fix: mf-6830 replace dead nftapi exchange-rates with coingecko proxy

### DIFF
--- a/packages/web3-providers/src/FiatCurrencyRate/index.ts
+++ b/packages/web3-providers/src/FiatCurrencyRate/index.ts
@@ -1,22 +1,40 @@
 import { CurrencyType } from '@masknet/web3-shared-base'
-import { fetchJSON } from '../entry-helpers.js'
+import { COINGECKO_URL_BASE } from '../CoinGecko/constants.js'
+import { fetchCachedJSON } from '../helpers/fetchJSON.js'
 
-const BASE_URL = 'https://nftapi.firefly.land/exchange-rates?base=USD'
+// CoinGecko exchange rates are BTC-based; convert them to USD-based to keep the old shape.
+interface CoinGeckoExchangeRates {
+    rates: {
+        [currency: string]: {
+            value: number
+        }
+    }
+}
+
+const BASE_URL = `${COINGECKO_URL_BASE}/exchange_rates`
 
 export namespace FiatCurrencyRateBaseAPI {
     export interface Result {
         rates: { [currency: string]: number }
     }
 }
+
+async function getExchangeRates(): Promise<FiatCurrencyRateBaseAPI.Result['rates']> {
+    const result = await fetchCachedJSON<CoinGeckoExchangeRates>(BASE_URL)
+    const usdValue = result.rates.usd?.value || 1
+    return Object.fromEntries(
+        Object.entries(result.rates).map(([code, rate]) => [code.toUpperCase(), rate.value / usdValue]),
+    )
+}
+
 export const FiatCurrencyRate = {
     async getRate(type?: CurrencyType): Promise<number> {
         if (!type || type === CurrencyType.USD) return 1
-        const result = await fetchJSON<FiatCurrencyRateBaseAPI.Result>(BASE_URL)
-        return result.rates[type.toUpperCase()]
+        const rates = await getExchangeRates()
+        return rates[type.toUpperCase()]
     },
 
     async getRates() {
-        const result = await fetchJSON<FiatCurrencyRateBaseAPI.Result>(BASE_URL)
-        return result.rates
+        return getExchangeRates()
     },
 }

--- a/security/content-security-policy.json
+++ b/security/content-security-policy.json
@@ -23,6 +23,7 @@
         "https://service.r2d2.to/arweave-remote-signing",
         "https://vcent-agent.r2d2.to/data/tweet-txn",
         "https://gitcoin-agent.r2d2.to/grants/v1/api/grant/",
+        "https://coingecko-agent.r2d2.to",
         "https://gun.r2d2.to",
         "https://kv.r2d2.to/api/",
         "https://mixpanel.r2d2.to/import",
@@ -49,7 +50,6 @@
         "https://arql3twjl4.execute-api.us-east-1.amazonaws.com/prod/records",
         "https://a8fq5hs9nk.execute-api.us-east-1.amazonaws.com",
 
-        "https://nftapi.firefly.land/",
         "https://store.firefly.land",
         "https://mask-network-dev.firefly.land",
         "https://api.firefly.land",


### PR DESCRIPTION
## Summary

- `nftapi.firefly.land` is dead (HTTP 530 / Cloudflare error 1016 on every route — the legacy AWS ELB backend was decommissioned), so `FiatCurrencyRate` (the sole remaining consumer of `/exchange-rates`) fails once the persisted react-query cache (24h) expires, breaking fiat conversion in wallet totals, token detail trending charts, and the trader coin-market table.
- Switch `FiatCurrencyRate` to the Mask-operated CoinGecko proxy `https://coingecko-agent.r2d2.to/api/v3/exchange_rates` (already used by the CoinGecko provider) via `fetchCachedJSON` (1-min cache + 1s squash), converting the BTC-based CoinGecko rates into the old flat USD-based shape with uppercase keys — `Result` interface and `getRate()`/`getRates()` signatures unchanged, so the hook and consumers are untouched.
- CSP: drop the dead `https://nftapi.firefly.land/` entry and add `https://coingecko-agent.r2d2.to` (the CoinGecko provider already uses this host but it was never listed; dev CSP builds only).

Follow-up of #12213, which migrated the other nftapi consumer to a live backend.

## Issue

- [MF-6830](https://mask.atlassian.net/browse/MF-6830) (Bug, Mask Frontend)

## Verification done

- `GET https://coingecko-agent.r2d2.to/api/v3/exchange_rates` → 200; conversion math sanity-checked against the live payload (USD=1, EUR≈0.86, CNY≈6.71, JPY≈153, HKD≈7.84).
- `tsc -b packages/web3-providers` clean; eslint clean on the touched file.
- Runtime extension verification in progress (wallet popup fiat conversion + network check) — will report in PR.


[MF-6830]: https://mask.atlassian.net/browse/MF-6830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ