### PR TITLE
fix: mf-6829 read aave savings apr and balance on-chain

### DIFF
--- a/packages/plugins/Savings/src/protocols/AAVEProtocol.ts
+++ b/packages/plugins/Savings/src/protocols/AAVEProtocol.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from 'bignumber.js'
 import { AaveLendingPoolAbi } from '@masknet/web3-contracts/types/AaveLendingPool.js'
 import { AaveLendingPoolAddressProviderAbi } from '@masknet/web3-contracts/types/AaveLendingPoolAddressProvider.js'
+import { AaveProtocolDataProviderAbi } from '@masknet/web3-contracts/types/AaveProtocolDataProvider.js'
 import { ERC20Abi } from '@masknet/web3-contracts/types/ERC20.js'
-import { fetchJSON } from '@masknet/web3-providers/helpers'
 import { EVMContract, EVMWeb3 } from '@masknet/web3-providers'
 import { ZERO, pow10, type FungibleToken } from '@masknet/web3-shared-base'
 import { type ChainId, type SchemaType, getAaveConstant } from '@masknet/web3-shared-evm'
@@ -34,49 +34,24 @@ export class AAVEProtocol implements SavingsProtocol {
 
     public async getApr(chainId: ChainId) {
         try {
-            const subgraphUrl = getAaveConstant(chainId, 'AAVE_SUBGRAPHS')
-            if (!subgraphUrl) {
+            const contract = this.getDataProviderContract(chainId)
+            if (!contract) {
                 return '0.00'
             }
 
-            const body = JSON.stringify({
-                query: /* GraphQL */ `
-                    query GET_APR($address: String, $pool: String) {
-                        reserves(where: { underlyingAsset: $address, pool: $pool }) {
-                            id
-                            name
-                            underlyingAsset
-                            liquidityRate
-                        }
-                    }
-                `,
-                variables: {
-                    address: this.bareToken.address,
-                    pool: '0xb53c1a33016b2dc2ff3653530bff1848a515c8c5',
-                },
+            const data = await EVMContract.readContract(contract, 'getReserveData', [this.bareToken.address as Address], {
+                chainId,
             })
-            const response = await fetchJSON<{
-                data: {
-                    reserves: Array<{
-                        id: string
-                        name: string
-                        decimals: number
-                        underlyingAsset: string
-                        liquidityRate: number
-                    }>
-                }
-            }>(subgraphUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body,
-            })
+            if (!data) return '0.00'
 
-            const liquidityRate = +response.data.reserves[0].liquidityRate
+            // viem returns multi-output reads as positional arrays,
+            // the 4th output of getReserveData is the liquidity rate in RAY
+            const liquidityRate = data[3]
 
             const RAY = pow10(27) // 10 to the power 27
 
             // APY and APR are returned here as decimals, multiply by 100 to get the percents
-            return new BigNumber(liquidityRate).times(100).div(RAY).toFixed(2)
+            return new BigNumber(liquidityRate.toString()).times(100).div(RAY).toFixed(2)
         } catch (error) {
             console.error('AAVE: Apr Error:', error)
             return AAVEProtocol.DEFAULT_APR
@@ -85,48 +60,25 @@ export class AAVEProtocol implements SavingsProtocol {
 
     public async getBalance(chainId: ChainId, account: string) {
         try {
-            const subgraphUrl = getAaveConstant(chainId, 'AAVE_SUBGRAPHS')
-
-            if (!subgraphUrl) {
+            const contract = this.getDataProviderContract(chainId)
+            if (!contract) {
                 return ZERO
             }
 
-            const body = JSON.stringify({
-                query: /* GraphQL */ `
-                    query GET_BALANCE($address: String, $pool: String) {
-                        reserves(where: { underlyingAsset: $address, pool: $pool }) {
-                            id
-                            aToken {
-                                id
-                            }
-                        }
-                    }
-                `,
-                variables: {
-                    address: this.bareToken.address,
-                    pool: '0xb53c1a33016b2dc2ff3653530bff1848a515c8c5',
-                },
-            })
+            const tokens = await EVMContract.readContract(
+                contract,
+                'getReserveTokensAddresses',
+                [this.bareToken.address as Address],
+                { chainId },
+            )
+            if (!tokens) return ZERO
 
-            const response = await fetchJSON<{
-                data: {
-                    reserves: Array<{
-                        aToken: {
-                            id: string
-                        }
-                    }>
-                }
-            }>(subgraphUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body,
-            })
-
-            const aTokenId = response.data.reserves[0].aToken.id
-            const contract = EVMContract.getContract(aTokenId, ERC20Abi)
+            // the 1st output of getReserveTokensAddresses is the aToken address
+            const [aTokenAddress] = tokens
+            const aTokenContract = EVMContract.getContract(aTokenAddress, ERC20Abi)
             return new BigNumber(
                 (
-                    await EVMContract.readContract(contract, 'balanceOf', [account as Address], { chainId })
+                    await EVMContract.readContract(aTokenContract, 'balanceOf', [account as Address], { chainId })
                 )?.toString() ?? '0',
             )
         } catch (error) {
@@ -166,6 +118,11 @@ export class AAVEProtocol implements SavingsProtocol {
         return EVMContract.readContract(lPoolAddressProviderContract, 'getLendingPool', [], {
             chainId,
         })
+    }
+
+    private getDataProviderContract(chainId: ChainId) {
+        const address = getAaveConstant(chainId, 'AAVE_PROTOCOL_DATA_PROVIDER_CONTRACT_ADDRESS')
+        return EVMContract.getContract(address, AaveProtocolDataProviderAbi)
     }
 
     public async deposit(account: string, chainId: ChainId, value: BigNumber.Value) {

--- a/packages/plugins/Savings/src/protocols/AAVEProtocol.ts
+++ b/packages/plugins/Savings/src/protocols/AAVEProtocol.ts
@@ -39,9 +39,14 @@ export class AAVEProtocol implements SavingsProtocol {
                 return '0.00'
             }
 
-            const data = await EVMContract.readContract(contract, 'getReserveData', [this.bareToken.address as Address], {
-                chainId,
-            })
+            const data = await EVMContract.readContract(
+                contract,
+                'getReserveData',
+                [this.bareToken.address as Address],
+                {
+                    chainId,
+                },
+            )
             if (!data) return '0.00'
 
             // viem returns multi-output reads as positional arrays,

--- a/packages/web3-constants/evm/aave.json
+++ b/packages/web3-constants/evm/aave.json
@@ -1,8 +1,4 @@
 {
-    "AAVE_SUBGRAPHS": {
-        "Mainnet": "https://api.thegraph.com/subgraphs/name/aave/protocol-v2",
-        "Kovan": "https://api.thegraph.com/subgraphs/name/aave/protocol-v2-kovan"
-    },
     "AAVE_LENDING_POOL_ADDRESSES_PROVIDER_CONTRACT_ADDRESS": {
         "Mainnet": "0xb53c1a33016b2dc2ff3653530bff1848a515c8c5",
         "Kovan": "0x88757f2f99175387ab4c6a4b3067c77a695b0349"


### PR DESCRIPTION
## Summary
- The Graph's legacy hosted service is sunset; `https://api.thegraph.com/subgraphs/name/aave/protocol-v2` now redirects (301 → error.thegraph.com), which fails the Savings plugin's content-script fetches with a CORS error (MF-6829). Both `AAVEProtocol` subgraph queries were dead: APR fell back to the hardcoded stale `DEFAULT_APR = '0.17'` and balances read as ZERO (withdraw tab hides rows).
- Replace both queries with direct on-chain reads from `AaveProtocolDataProvider` (constant already in `aave.json`): `getReserveData(asset)` → `liquidityRate` (4th output, RAY math unchanged) for APR, and `getReserveTokensAddresses(asset)` → `aTokenAddress` (1st output) before the existing ERC20 `balanceOf` for balances.
- Remove the now-unreferenced `AAVE_SUBGRAPHS` block from `web3-constants/evm/aave.json`. No API keys, proxies, or CSP changes needed — removes the extension's last live `api.thegraph.com` consumer from this code path.

## Verification
- `tsc -b` clean on the Savings package graph; eslint clean; viem 2.x returns multi-output reads as positional arrays (indexed accordingly).
- Runtime (dev extension on x.com): Savings deposit tab renders live on-chain APRs (USDT 0.12%, WETH 0.15%, WBTC 0.01%) — cross-checked equal to on-chain `getReserveData` values via public RPC; `getReserveTokensAddresses` returns canonical aToken addresses (aUSDT `0x3Ed3B47Dd13EC9a98b44e6204A523E766B225811`, aWETH `0x030bA81f1c18d280636F32af80b9AAd02Cf0854e`, aWBTC `0x9ff58f4fFB29fA2266Ab25e75e2A8b3503311656`). No CORS errors and zero requests to `api.thegraph.com`.
