### PR TITLE
fix: mf-6831 fix dark mode text colors on web3 profile and red packet cards

### DIFF
--- a/packages/mask/content-script/components/InjectedComponents/ProfileTabContent.tsx
+++ b/packages/mask/content-script/components/InjectedComponents/ProfileTabContent.tsx
@@ -326,7 +326,7 @@ function Content(props: ProfileTabContentProps) {
             <MaskThemeProvider palette="light">
                 <div className={classes.root}>
                     <PluginCardFrameMini>
-                        <LoadingStatus iconSize={24} color={theme.vars.palette.maskColor.main}>
+                        <LoadingStatus iconSize={24} color={theme.vars.palette.maskColor.publicMain}>
                             <Trans>Loading account information...</Trans>
                         </LoadingStatus>
                     </PluginCardFrameMini>

--- a/packages/plugins/Trader/src/SiteAdaptor/trending/PluginDescriptor.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trending/PluginDescriptor.tsx
@@ -32,8 +32,7 @@ export function PluginDescriptor({ children, isProfilePage, isTokenTagPopper }: 
                     sx={{
                         fontWeight: 'bolder',
                         fontSize: 16,
-                        color: (theme) =>
-                            isTokenTagPopper ? theme.vars.palette.maskColor.main : theme.vars.palette.maskColor.dark,
+                        color: (theme) => theme.vars.palette.maskColor.publicMain,
                     }}>
                     {isTokenTagPopper ?
                         <Trans>Web3 Profile Card</Trans>

--- a/packages/plugins/Trader/src/SiteAdaptor/trending/TrendingViewDescriptor.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trending/TrendingViewDescriptor.tsx
@@ -9,9 +9,7 @@ import { TrendingViewContext } from './context.js'
 import { PluginDescriptor } from './PluginDescriptor.js'
 import { Trans } from '@lingui/react/macro'
 
-const useStyles = makeStyles<{
-    isTokenTagPopper: boolean
-}>()((theme, props) => {
+const useStyles = makeStyles()((theme) => {
     return {
         source: {
             display: 'flex',
@@ -28,10 +26,10 @@ const useStyles = makeStyles<{
         },
         selectedOption: {
             fontWeight: 700,
-            color: props.isTokenTagPopper ? theme.vars.palette.maskColor.main : theme.vars.palette.maskColor.dark,
+            color: theme.vars.palette.maskColor.publicMain,
         },
         arrowDropIcon: {
-            color: props.isTokenTagPopper ? theme.vars.palette.maskColor.main : theme.vars.palette.maskColor.dark,
+            color: theme.vars.palette.maskColor.publicMain,
         },
     }
 })
@@ -46,7 +44,7 @@ export function TrendingViewDescriptor(props: TrendingViewDescriptorProps) {
     const { result, resultList, setResult } = props
     const { isProfilePage, isTokenTagPopper } = useContext(TrendingViewContext)
 
-    const { classes } = useStyles({ isTokenTagPopper })
+    const { classes } = useStyles()
 
     const displayList = uniqBy(
         resultList.filter((x) => x.type === result.type),

--- a/packages/shared/src/UI/components/CoinMetadataTable/ContractItem.tsx
+++ b/packages/shared/src/UI/components/CoinMetadataTable/ContractItem.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles()((theme) => ({
         flexDirection: 'row',
         alignItems: 'center',
         height: theme.spacing(4),
-        padding: theme.spacing(0.5, 0),
+        padding: theme.spacing(0.5, 1.5),
         boxSizing: 'border-box',
         ':not(:last-of-type)': {
             borderBottom: `1px solid ${theme.vars.palette.maskColor.line}`,

--- a/packages/shared/src/UI/components/CoinMetadataTable/index.tsx
+++ b/packages/shared/src/UI/components/CoinMetadataTable/index.tsx
@@ -70,11 +70,6 @@ const useStyles = makeStyles()((theme) => ({
         boxShadow: theme.vars.palette.maskColor.bottomBg,
         backdropFilter: 'blur(8px)',
     },
-    item: {
-        '& > *': {
-            padding: theme.spacing(0, 1.5),
-        },
-    },
     list: {
         padding: 0,
     },
@@ -132,7 +127,6 @@ export const CoinMetadataTable = memo(function CoinMetadataTable({ trending }: C
                 horizontal: 'right',
             },
             classes: { paper: classes.menu, list: classes.list },
-            slotProps: { list: { classes: { root: classes.item } } },
         },
     )
 

--- a/packages/shared/src/UI/components/MaskPluginWrapper/index.tsx
+++ b/packages/shared/src/UI/components/MaskPluginWrapper/index.tsx
@@ -75,7 +75,7 @@ const useStyles = makeStyles<{
             marginRight: theme.spacing(0.5),
             fontSize: 14,
             fontWeight: 700,
-            color: theme.vars.palette.maskColor.second,
+            color: theme.vars.palette.maskColor.publicSecond,
         },
     }
 })
@@ -131,7 +131,12 @@ export function MaskPostExtraInfoWrapper(props: PluginWrapperProps) {
                 )}
                 <Typography
                     variant="body1"
-                    sx={{ color: theme.vars.palette.maskColor.main, fontSize: 16, fontWeight: 700, marginLeft: 0.5 }}
+                    sx={{
+                        color: theme.vars.palette.maskColor.publicMain,
+                        fontSize: 16,
+                        fontWeight: 700,
+                        marginLeft: 0.5,
+                    }}
                     component="div">
                     {wrapperProps?.title ?? title ?? <Trans>Default</Trans>}
                 </Typography>

--- a/packages/shared/src/UI/components/PluginCardFrame/index.tsx
+++ b/packages/shared/src/UI/components/PluginCardFrame/index.tsx
@@ -9,14 +9,14 @@ const useStyles = makeStyles()((theme) => ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        color: theme.vars.palette.maskColor.main,
+        color: theme.vars.palette.maskColor.publicMain,
     },
     container: {
         background:
             'linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.8) 100%), linear-gradient(90deg, rgba(28, 104, 243, 0.2) 0%, rgba(45, 41, 253, 0.2) 100%), #FFFFFF;',
         minHeight: '196px',
         justifyContent: 'space-between',
-        color: theme.vars.palette.maskColor.main,
+        color: theme.vars.palette.maskColor.publicMain,
     },
     web3Icon: {
         marginRight: 6,
@@ -52,7 +52,7 @@ export function PluginCardFrameMini({ icon, title, provider, providerLink, child
     const PluginName = (
         <Stack className={classes.title} direction="row">
             {icon ?? <Icons.Web3Profile className={classes.web3Icon} />}
-            <Typography sx={{ color: theme.vars.palette.maskColor.main, fontSize: 16, fontWeight: 700 }}>
+            <Typography sx={{ color: theme.vars.palette.maskColor.publicMain, fontSize: 16, fontWeight: 700 }}>
                 {title ?? <Trans>Web3 Profile</Trans>}
             </Typography>
         </Stack>
@@ -85,7 +85,7 @@ export function PluginCardFrameMini({ icon, title, provider, providerLink, child
             </Stack>
             <Stack sx={{ flex: 1, justifyContent: 'center', alignItems: 'center', p: 1.5 }}>
                 {children ?? (
-                    <LoadingStatus iconSize={24} color={theme.vars.palette.maskColor.main}>
+                    <LoadingStatus iconSize={24} color={theme.vars.palette.maskColor.publicMain}>
                         <Trans>Loading....</Trans>
                     </LoadingStatus>
                 )}

--- a/packages/shared/src/UI/components/SourceSwitcher/index.tsx
+++ b/packages/shared/src/UI/components/SourceSwitcher/index.tsx
@@ -7,7 +7,7 @@ import { Box } from '@mui/system'
 import { FootnoteMenu } from '../FootnoteMenu/index.js'
 import { SourceProviderIcon } from '../SourceProviderIcon/index.js'
 
-const useStyles = makeStyles()((theme) => {
+const useStyles = makeStyles()(() => {
     return {
         source: {
             justifyContent: 'space-between',
@@ -18,8 +18,6 @@ const useStyles = makeStyles()((theme) => {
         },
         sourceName: {
             fontWeight: 700,
-            color: theme.vars.palette.maskColor.publicMain,
-            ...theme.applyStyles('dark', { color: '' }),
         },
     }
 })


### PR DESCRIPTION
## Summary
Fixes two dark-mode regressions from the MUI upgrade (#12424), which moved theming to CSS vars resolved per shadow root:

- **Red packet card**: "Lucky Drop" title and "Powered by" rendered white-on-white in dark mode. The card background is always light (hardcoded gradient), so these texts now use the mode-independent `publicMain` / `publicSecond` tokens (established pattern on branded white cards).
- **Web3 Profile card / token trending card**: "CoinGecko" source label and related texts rendered black-on-dark on theme-following surfaces. These now use theme-reactive `maskColor.main`, and a broken `applyStyles('dark', { color: '' })` (invalid CSS) in `SourceSwitcher` is removed.

Also fixes the same white-on-white class on the shared plugin card header (`MaskPluginWrapper`) and `PluginCardFrameMini` loading/permission states.

Light mode is pixel-unchanged: `publicMain`/`publicSecond` equal `main`/`second`/`dark` values in the light palette.

## Changes
- `MaskPluginWrapper`: title → `publicMain`, "Powered by" → `publicSecond`
- `PluginCardFrame`: title/container/LoadingStatus → `publicMain`
- `ProfileTabContent`: loading-state LoadingStatus → `publicMain`
- `TrendingViewDescriptor` / `PluginDescriptor`: drop `isTokenTagPopper ? main : dark` ternary → `main`
- `SourceSwitcher`: `publicMain` + broken dark-override → `main`

Closes MF-6831