### PR TITLE
fix: mf-6833 strip lens suffix from firefly profile links

### DIFF
--- a/packages/mask/popups/pages/Friends/ContactCard/Account/index.tsx
+++ b/packages/mask/popups/pages/Friends/ContactCard/Account/index.tsx
@@ -4,7 +4,7 @@ import { Icons } from '@masknet/icons'
 import { makeStyles, TextOverflowTooltip } from '@masknet/theme'
 import { NextIDPlatform } from '@masknet/shared-base'
 import { formatEthereumAddress } from '@masknet/web3-shared-evm'
-import { PlatformIconMap, PlatformUrlMap, type SupportedPlatforms } from '../../common.js'
+import { PlatformIconMap, getPlatformProfileUrl, type SupportedPlatforms } from '../../common.js'
 
 interface AccountProps {
     platform: SupportedPlatforms
@@ -56,7 +56,7 @@ export const Account = memo<AccountProps>(function Account({ userId, displayName
                     underline="none"
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={PlatformUrlMap[platform] + userId}
+                    href={getPlatformProfileUrl(platform, userId)}
                     className={classes.iconBlack}>
                     <Icons.LinkOut size={16} />
                 </Link>

--- a/packages/mask/popups/pages/Friends/Detail/Account/index.tsx
+++ b/packages/mask/popups/pages/Friends/Detail/Account/index.tsx
@@ -4,7 +4,7 @@ import { Icons } from '@masknet/icons'
 import { makeStyles, TextOverflowTooltip } from '@masknet/theme'
 import { NextIDPlatform, formatPersonaName } from '@masknet/shared-base'
 import { formatEthereumAddress } from '@masknet/web3-shared-evm'
-import { PlatformIconMap, PlatformUrlMap, type SupportedPlatforms } from '../../common.js'
+import { PlatformIconMap, getPlatformProfileUrl, type SupportedPlatforms } from '../../common.js'
 
 interface AccountProps {
     platform: SupportedPlatforms
@@ -70,7 +70,7 @@ export const Account = memo<AccountProps>(function Account({ userId, displayName
                     underline="none"
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={PlatformUrlMap[platform] + userId}
+                    href={getPlatformProfileUrl(platform, userId)}
                     className={classes.iconBlack}>
                     <Icons.LinkOut size={16} />
                 </Link>

--- a/packages/mask/popups/pages/Friends/common.tsx
+++ b/packages/mask/popups/pages/Friends/common.tsx
@@ -28,6 +28,11 @@ export const PlatformUrlMap: Record<SupportedPlatforms, string> = {
     [NextIDPlatform.Keybase]: 'https://keybase.io/',
 }
 
+export function getPlatformProfileUrl(platform: SupportedPlatforms, userId: string) {
+    if (platform === NextIDPlatform.LENS) return `${PlatformUrlMap[platform]}${userId.replace(/\.lens$/u, '')}`
+    return PlatformUrlMap[platform] + userId
+}
+
 export const PlatformIconMap: Record<SupportedPlatforms, GeneratedIcon> = {
     [NextIDPlatform.LENS]: Icons.Lens,
     [NextIDPlatform.Ethereum]: Icons.ETH,

--- a/packages/plugins/Web3Profile/src/utils.ts
+++ b/packages/plugins/Web3Profile/src/utils.ts
@@ -2,7 +2,7 @@ import type { Web3BioProfile } from '@masknet/shared-base'
 import urlcat from 'urlcat'
 
 export function getFireflyLensProfileLink(handle: string) {
-    return urlcat('https://firefly.social/profile/lens/:handle', { handle })
+    return urlcat('https://firefly.social/profile/lens/:handle', { handle: handle.replace(/\.lens$/u, '') })
 }
 
 export function Web3BioProfileToFireflyLens(profile: Web3BioProfile) {

--- a/packages/web3-shared/base/src/helpers/resolver.ts
+++ b/packages/web3-shared/base/src/helpers/resolver.ts
@@ -132,7 +132,7 @@ export const resolveNextIDPlatformLink = (networkPlatform: NextIDPlatform, ident
         case NextIDPlatform.RSS3:
             return `https://rss3.io/result?search=${identifier}`
         case NextIDPlatform.LENS:
-            return `https://firefly.social/profile/lens/${identifier}`
+            return `https://firefly.social/profile/lens/${identifier.replace(/\.lens$/u, '')}`
         case NextIDPlatform.REDDIT:
             return `https://www.reddit.com/user/${identifier}`
         case NextIDPlatform.SYBIL:


### PR DESCRIPTION
## Summary

Lens profile links to firefly.social were built from Web3Bio/NextID identities that carry the full handle (`sujidaily.lens`), but Firefly addresses Lens profiles by bare local name (`https://firefly.social/profile/lens/sujidaily`), so the links 404'd.

Strip the `.lens` suffix at the 3 outbound-link construction sites:

- `packages/web3-shared/base/src/helpers/resolver.ts` — `resolveNextIDPlatformLink` (NextID identity list)
- `packages/plugins/Web3Profile/src/utils.ts` — `getFireflyLensProfileLink` (Web3 profile / follow dialogs)
- `packages/mask/popups/pages/Friends` — new `getPlatformProfileUrl` helper used by both `ContactCard/Account` and `Detail/Account`

Only outbound `href`s change; every visible handle string (e.g. `@sujidaily.lens`) keeps the full form. The anchored `/\\.lens$/u` regex matches the existing idiom in `LensV3/index.ts` / `LensList.tsx` and is a no-op on `0x` addresses. `foo.lens.test` is not touched.

Companion server-side fix (repairs links already emitted by extensions in the field): DimensionDev/firefly-social PR (branch `fix/mf-6833-redirect-lens-profile-urls`).

Fixes [MF-6833](https://mask.atlassian.net/browse/MF-6833)

[MF-6833]: https://mask.atlassian.net/browse/MF-6833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ