### PR TITLE
fix: mf-6834 fix lens following status in dsearch social account list

### DIFF
--- a/packages/shared/src/UI/components/SocialAccountList/SocialListItem.tsx
+++ b/packages/shared/src/UI/components/SocialAccountList/SocialListItem.tsx
@@ -168,12 +168,13 @@ export function SocialAccountListItem({
             const client = new LensV3(account, (message) => EVMWeb3.signMessage('message', message))
             const profile = await client.getAccountByHandle(identity)
             if (!profile?.address) return null
-            const isFollowing = await client.getFollowStatus([
+            const followStatus = await client.getFollowStatus([
                 { account: profile.address, follower: evmAddress(myAccountAddress) },
             ])
+            const status = followStatus[0]?.isFollowing
             return {
                 ownedBy: profile?.username?.ownedBy as string,
-                isFollowing,
+                isFollowing: status?.optimistic || status?.onChain,
             }
         },
     })


### PR DESCRIPTION
## Summary
- MF-6834: in the dsearch results menu, Lens accounts always showed a **"Following"** button, even when the account is not followed (the profile dialog correctly shows "Follow").
- Root cause: `LensV3.getFollowStatus()` returns a `FollowStatusResult[]` array whose element holds `isFollowing: { optimistic, onChain }`. `SocialListItem` stored that raw array and truth-tested it in JSX, so every resolved query (including the API-error path, which returns an empty-but-truthy array) rendered "Following".
- Extract the real boolean in the queryFn: `followStatus[0]?.isFollowing` → `status?.optimistic || status?.onChain`, matching the sibling `LensList.tsx` pattern. Optional chaining guards the empty-array case; steady-state behavior matches the dialog's `onChain` check.

## Verification
- Targeted eslint passes on the changed file.
- Manual check with the dev extension (dsearch panel): a Lens handle the wallet does **not** follow now shows "Follow" in the menu, and the opened dialog also shows "Follow"; followed handles show "Following" in both.