### PR TITLE
fix: mf-6822 migrate okx dex api from v5 to v6

### DIFF
--- a/packages/plugins/Trader/src/SiteAdaptor/trader/contexts/TradeProvider.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/contexts/TradeProvider.tsx
@@ -138,7 +138,7 @@ export function TradeProvider({ children }: PropsWithChildren) {
     } = useQuotes(
         {
             amount,
-            chainId: chainId.toString(),
+            chainIndex: chainId.toString(),
             fromTokenAddress: fromToken?.address,
             dexIds: dexIds?.length ? dexIds.join(',') : undefined,
             toTokenAddress: toToken?.address,
@@ -159,10 +159,10 @@ export function TradeProvider({ children }: PropsWithChildren) {
         refetch: updateBridgeQuote,
     } = useBridgeQuotes(
         {
-            fromChainId: fromToken?.chainId.toString(),
+            fromChainIndex: fromToken?.chainId.toString(),
             fromTokenAddress: fromToken?.address,
             amount,
-            toChainId: toToken?.chainId.toString(),
+            toChainIndex: toToken?.chainId.toString(),
             toTokenAddress: toToken?.address,
             slippage: dividedBy(slippage, 100).toFixed(),
         },

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/helpers.ts
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/helpers.ts
@@ -2,7 +2,7 @@ import type { Web3Helper } from '@masknet/web3-helpers'
 import { formatCompact, leftShift, TokenType, trimZero } from '@masknet/web3-shared-base'
 import type { Token } from '../../types/trader.js'
 import { SchemaType } from '@masknet/web3-shared-evm'
-import type { RouterListItem } from '@masknet/web3-providers/types'
+import type { OKXBridgeQuote } from '@masknet/web3-providers/types'
 import { BigNumber } from 'bignumber.js'
 
 const MINIMUM_AMOUNT_RE = /((?:Minimum|Maximum) amount is\s+)(\d+)/u
@@ -31,12 +31,16 @@ export function okxTokenToFungibleToken(token: Token): Web3Helper.FungibleTokenA
     }
 }
 
-export function getBridgeLeftSideToken(bridge: RouterListItem) {
-    return bridge.fromDexRouterList.at(-1)?.subRouterList.at(-1)?.toToken
+// The v6 bridge quote API no longer exposes per-segment dex route details,
+// so the side tokens are derived from the quote tokens directly.
+export function getBridgeLeftSideToken(quote: OKXBridgeQuote | undefined) {
+    if (!quote?.fromToken) return
+    return { ...quote.fromToken, chainId: quote.fromChainIndex }
 }
 
-export function getBridgeRightSideToken(bridge: RouterListItem) {
-    return bridge.toDexRouterList[0]?.subRouterList[0]?.toToken
+export function getBridgeRightSideToken(quote: OKXBridgeQuote | undefined) {
+    if (!quote?.toToken) return
+    return { ...quote.toToken, chainId: quote.toChainIndex }
 }
 
 export function formatTokenBalance(raw: BigNumber.Value, decimals = 0) {

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useApprove.ts
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useApprove.ts
@@ -20,7 +20,7 @@ export function useApprove() {
             if (!tokenAddress || isZero(amount)) return null
             if (isNativeTokenAddress(tokenAddress)) return null
             const approveInfo = await OKX.getApproveTx({
-                chainId,
+                chainIndex: chainId,
                 tokenContractAddress: tokenAddress,
                 approveAmount: amount,
             })

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useBridgeData.ts
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useBridgeData.ts
@@ -4,8 +4,8 @@ import { skipToken, useQuery } from '@tanstack/react-query'
 
 export function useBridgeData(opts: Partial<BridgeOptions>) {
     const enabled =
-        opts.fromChainId &&
-        opts.toChainId &&
+        opts.fromChainIndex &&
+        opts.toChainIndex &&
         opts.fromTokenAddress &&
         opts.toTokenAddress &&
         opts.amount &&

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useBridgeQuotes.ts
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useBridgeQuotes.ts
@@ -5,9 +5,9 @@ import { QUOTE_STALE_DURATION, REFETCH_INTERVAL } from '../../constants.js'
 
 export function useBridgeQuotes(options: Partial<GetBridgeQuoteOptions>, enabled = true) {
     const valid =
-        options.fromChainId &&
-        options.toChainId &&
-        options.fromChainId !== options.toChainId &&
+        options.fromChainIndex &&
+        options.toChainIndex &&
+        options.fromChainIndex !== options.toChainIndex &&
         options.amount &&
         options.amount !== '0' &&
         options.fromTokenAddress &&

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useQuotes.ts
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useQuotes.ts
@@ -6,7 +6,10 @@ import { QUOTE_STALE_DURATION, REFETCH_INTERVAL } from '../../constants.js'
 
 export function useQuotes(options: Partial<GetQuotesOptions>, enabled = true) {
     const valid =
-        options.chainId && options.fromTokenAddress && options.toTokenAddress && isGreaterThan(options.amount ?? 0, 0)
+        options.chainIndex &&
+        options.fromTokenAddress &&
+        options.toTokenAddress &&
+        isGreaterThan(options.amount ?? 0, 0)
     return useQuery({
         enabled: !!valid && enabled,
         queryKey: ['okx-swap', 'get-quotes', options],

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useSwapData.ts
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/hooks/useSwapData.ts
@@ -4,11 +4,11 @@ import { skipToken, useQuery } from '@tanstack/react-query'
 
 export function useSwapData(opts: Partial<SwapOptions>) {
     const enabled =
-        opts.chainId &&
+        opts.chainIndex &&
         opts.amount &&
         opts.fromTokenAddress &&
         opts.toTokenAddress &&
-        opts.slippage !== undefined &&
+        opts.slippagePercent !== undefined &&
         opts.userWalletAddress &&
         (!opts.dexIds || opts.dexIds.length > 0)
 

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
@@ -10,14 +10,7 @@ import {
 } from '@masknet/shared'
 import { NetworkPluginID, Sniffings } from '@masknet/shared-base'
 import { ActionButton, LoadingBase, makeStyles, ShadowRootTooltip, useSnackbar } from '@masknet/theme'
-import {
-    useAccount,
-    useNativeTokenPrice,
-    useNetwork,
-    useReverseAddress,
-    useWeb3Connection,
-    useWeb3Utils,
-} from '@masknet/web3-hooks-base'
+import { useAccount, useNetwork, useReverseAddress, useWeb3Connection, useWeb3Utils } from '@masknet/web3-hooks-base'
 import {
     dividedBy,
     formatBalance,
@@ -217,8 +210,8 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
         [inputAmount, decimals],
     )
     const { data: bridgeData, isLoading } = useBridgeData({
-        fromChainId,
-        toChainId,
+        fromChainIndex: fromChainId,
+        toChainIndex: toChainId,
         amount,
         fromTokenAddress: fromToken?.address,
         toTokenAddress: toToken?.address,
@@ -292,19 +285,11 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
     const isApproving = approveMutation.isPending
     const isCheckingApprove = isLoadingApproveInfo || isLoadingSpender || isLoadingAllowance
 
-    const { data: toChainNativeTokenPrice } = useNativeTokenPrice(NetworkPluginID.PLUGIN_EVM, {
-        chainId: toChainId,
-    })
-    const toChainNetworkFee = quote?.routerList[0]?.toChainNetworkFee
-    const toNetworkFeeValue = leftShift(toChainNetworkFee ?? 0, toNetwork?.nativeCurrency.decimals ?? 0)
-        .times(toChainNativeTokenPrice ?? 0)
-        .toFixed(2)
     const bridge = quote?.routerList[0]
 
-    const router = bridge?.router
-    const bridgeFee = router?.crossChainFee
-    const bridgeFeeToken = useToken(fromChainId, router?.crossChainFeeTokenAddress)
-    const { data: bridgeFeeTokenPrice } = useTokenPrice(fromChainId, router?.crossChainFeeTokenAddress)
+    const bridgeFee = bridge?.crossChainFee
+    const bridgeFeeToken = useToken(fromChainId, bridge?.crossChainFeeTokenAddress)
+    const { data: bridgeFeeTokenPrice } = useTokenPrice(fromChainId, bridge?.crossChainFeeTokenAddress)
     const bridgeFeeValue = multipliedBy(bridgeFee ?? 0, bridgeFeeTokenPrice ?? 0).toFixed(2)
 
     const showStale = isQuoteStale && !isSending && !isApproving
@@ -386,10 +371,10 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
                 estimatedTime: bridge?.estimateTime ? +bridge.estimateTime : 0,
                 gasLimit: gas!,
                 gasPrice: gasConfig.gasPrice || '0',
-                leftSideToken: getBridgeLeftSideToken(bridge),
-                rightSideToken: getBridgeRightSideToken(bridge),
-                bridgeId: router?.bridgeId,
-                bridgeName: router?.bridgeName,
+                leftSideToken: getBridgeLeftSideToken(quote),
+                rightSideToken: getBridgeRightSideToken(quote),
+                bridgeId: bridge?.bridgeId,
+                bridgeName: bridge?.bridgeName,
             })
             if (unmountedRef.current) return
             const url = urlcat(basePath, RoutePaths.Transaction, {
@@ -420,7 +405,6 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
         toChainId,
         gasFee,
         gasConfig.gasPrice,
-        router,
         mode,
         Web3,
     ])
@@ -428,9 +412,6 @@ export const BridgeConfirm = memo(function BridgeConfirm() {
     const loading = isSending || isCheckingApprove || isApproving || submitting
     const disabled = !isBridgable || loading
     const fromNetworkFeeTooltip = t`This fee is used to pay miners and isn't collected by us. The actual cost may be less than estimated, and the unused fee won't be deducted from your account.`
-    const toNetworkFeeTooltip = t`In cross-chain transactions, this fee includes the estimated network fee and the cross-chain bridge's network fee which is $0.00 (0 OP_ETH). The network fees are paid to the miners and aren't charged by our platform.
-The actual cost may be lower
-than estimated, and any unused funds will remain in the original address.`
     const bridgeNetworkFeeTooltip = t`In cross-chain transactions, this fee includes the estimated network fee and the cross-chain bridge's network fee which is $0.00 (0 OP_ETH). The network fees are paid to the miners and aren't charged by our platform.
 The actual cost may be lower
 than estimated, and any unused funds will remain in the original address.`
@@ -537,33 +518,7 @@ than estimated, and any unused funds will remain in the original address.`
                     </div>
                     <div className={classes.infoRow}>
                         <Typography className={classes.rowName}>
-                            <Trans>{toNetwork?.name} Network fee</Trans>
-                            <ShadowRootTooltip placement="top" title={toNetworkFeeTooltip}>
-                                <Icons.Questions
-                                    size={16}
-                                    onClick={() => {
-                                        showToolTip({
-                                            title: t`Network fee`,
-                                            message: toNetworkFeeTooltip,
-                                        })
-                                    }}
-                                />
-                            </ShadowRootTooltip>
-                        </Typography>
-                        <Typography className={classes.rowValue} sx={{ textAlign: 'right' }}>
-                            {toChainNetworkFee ?
-                                <>
-                                    {formatBalance(toChainNetworkFee, toNetwork?.nativeCurrency.decimals)}{' '}
-                                    {toNetwork?.nativeCurrency.symbol ?? 'ETH'}
-                                    <br />
-                                    (${toNetworkFeeValue})
-                                </>
-                            :   '--'}
-                        </Typography>
-                    </div>
-                    <div className={classes.infoRow}>
-                        <Typography className={classes.rowName}>
-                            <Trans>{bridge?.router.bridgeName} Bridge Network fee</Trans>
+                            <Trans>{bridge?.bridgeName} Bridge Network fee</Trans>
                             <ShadowRootTooltip placement="top" title={bridgeNetworkFeeTooltip}>
                                 <Icons.Questions
                                     size={16}
@@ -577,7 +532,7 @@ than estimated, and any unused funds will remain in the original address.`
                             </ShadowRootTooltip>
                         </Typography>
                         <Typography className={classes.rowValue} sx={{ textAlign: 'right' }}>
-                            {router?.crossChainFee} {bridgeFeeToken?.symbol ?? '--'}
+                            {bridge?.crossChainFee} {bridgeFeeToken?.symbol ?? '--'}
                             <br />
                             (${bridgeFeeValue})
                         </Typography>

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeQuoteRoute.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeQuoteRoute.tsx
@@ -109,7 +109,7 @@ export const BridgeQuoteRoute = memo(function BridgeQuoteRoute() {
     const { classes, theme, cx } = useStyles()
     const { basePath } = useRuntime()
     const { bridgeQuote, fromToken, toToken, mode } = useTrade()
-    const [bridgeId = bridgeQuote?.routerList[0].router.bridgeId, setBridgeId] = useState<number>()
+    const [bridgeId = bridgeQuote?.routerList[0]?.bridgeId, setBridgeId] = useState<number>()
     const chainId = fromToken?.chainId as ChainId
     const price = useNativeTokenPrice(NetworkPluginID.PLUGIN_EVM, { chainId }).data || 0
     const { data: nativeToken } = useNativeToken(NetworkPluginID.PLUGIN_EVM, { chainId })
@@ -126,22 +126,25 @@ export const BridgeQuoteRoute = memo(function BridgeQuoteRoute() {
     return (
         <div className={classes.container}>
             {bridgeQuote.routerList.map((router) => {
-                const currBridgeId = router.router.bridgeId
+                const currBridgeId = router.bridgeId
                 const logoUrl = bridges.find((x) => x.id === currBridgeId)?.logoUrl
 
-                const gasValue = leftShift(router.fromChainNetworkFee, nativeToken?.decimals || 18)
+                const gasValue = leftShift(
+                    router.otherNativeFee || router.estimateGasFee || '0',
+                    nativeToken?.decimals || 18,
+                )
                     .times(price)
                     .toFixed(2)
                 return (
                     <div
                         className={cx(classes.box, bridgeId === currBridgeId ? classes.active : null)}
-                        key={router.router.bridgeId}
+                        key={router.bridgeId}
                         onClick={() => {
                             setBridgeId(currBridgeId)
                         }}>
                         <Typography className={classes.boxTitle}>
                             <img src={logoUrl} width={16} height={16} />
-                            {router.router.bridgeName}
+                            {router.bridgeName}
                             <Radio
                                 className={classes.radio}
                                 classes={{ root: classes.control }}

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/Confirm.tsx
@@ -16,7 +16,6 @@ import {
 import { addGasMargin, ChainId, formatWeiToEther } from '@masknet/web3-shared-evm'
 import { Box, Link as MuiLink, Typography } from '@mui/material'
 import { useQueryClient } from '@tanstack/react-query'
-import { BigNumber } from 'bignumber.js'
 import { memo, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useAsyncFn } from 'react-use'
@@ -196,11 +195,11 @@ export const Confirm = memo(function Confirm() {
         disabledDexIds.length ? liquidityList.filter((x) => !disabledDexIds.includes(x.id)) : liquidityList
     const dexIdsCount = remainLiquidityList.length
     const { data: swap, isLoading } = useSwapData({
-        chainId: chainId.toString(),
+        chainIndex: chainId.toString(),
         amount,
         fromTokenAddress: fromToken?.address,
         toTokenAddress: toToken?.address,
-        slippage: new BigNumber(isAutoSlippage || !slippage ? DEFAULT_SLIPPAGE : slippage).div(100).toString(),
+        slippagePercent: isAutoSlippage || !slippage ? DEFAULT_SLIPPAGE : slippage,
         userWalletAddress: account,
         dexIds: remainLiquidityList === liquidityList ? undefined : remainLiquidityList.map((x) => x.id).join(','),
     })

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/QuoteRoute.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/QuoteRoute.tsx
@@ -2,9 +2,8 @@ import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { Icons } from '@masknet/icons'
 import { EmptyStatus } from '@masknet/shared'
-import { EMPTY_LIST, NetworkPluginID } from '@masknet/shared-base'
+import { EMPTY_LIST } from '@masknet/shared-base'
 import { makeStyles, ShadowRootTooltip } from '@masknet/theme'
-import { useGasPrice, useNativeToken } from '@masknet/web3-hooks-base'
 import type { OKXSwapQuote } from '@masknet/web3-providers/types'
 import { isZero, multipliedBy, ZERO } from '@masknet/web3-shared-base'
 import { type ChainId, formatAmount } from '@masknet/web3-shared-evm'
@@ -108,32 +107,37 @@ const useStyles = makeStyles()((theme) => ({
     },
 }))
 
-const calcValue = (compare: OKXSwapQuote['quoteCompareList'][number], tokenPrice: string) => {
+interface CompareItem {
+    amountOut: string
+    dexLogo: string
+    dexName: string
+    /** Estimated network fee (USD) of the quote route */
+    tradeFee: string
+}
+
+const calcValue = (compare: CompareItem, tokenPrice: string) => {
     return multipliedBy(compare.amountOut, tokenPrice).minus(compare.tradeFee)
 }
 
 /**
- * QuoteCompareList might be missed.
+ * The v6 quote API removed quoteCompareList, we synthesize it from the quote route.
  */
 function useCompareList(quote: OKXSwapQuote | undefined, chainId: ChainId) {
-    const { data: dexes = EMPTY_LIST } = useLiquidityResources(chainId, quote?.quoteCompareList?.length === 0)
-    const [gasPrice] = useGasPrice(NetworkPluginID.PLUGIN_EVM, { chainId })
-    const { data: nativeToken } = useNativeToken(NetworkPluginID.PLUGIN_EVM, { chainId })
+    const { data: dexes = EMPTY_LIST } = useLiquidityResources(chainId)
 
     const compareList = useMemo(() => {
         if (!quote) return EMPTY_LIST
-        if (quote.quoteCompareList.length) return quote.quoteCompareList
-        const firstSubRouterDex = quote.dexRouterList[0].subRouterList[0].dexProtocol[0].dexName
-        const compareList: OKXSwapQuote['quoteCompareList'] = [
+        const dexName = quote.dexRouterList[0]?.dexProtocol.dexName || 'OKX DEX'
+        const compareList: CompareItem[] = [
             {
                 amountOut: formatAmount(quote.toTokenAmount, -quote.toToken.decimals),
-                dexLogo: dexes.find((x) => x.name === firstSubRouterDex)?.logo || '',
-                dexName: firstSubRouterDex,
-                tradeFee: '0',
+                dexLogo: dexes.find((x) => x.name === dexName)?.logo || '',
+                dexName,
+                tradeFee: quote.tradeFee || '0',
             },
         ]
         return compareList
-    }, [quote, dexes, gasPrice, nativeToken])
+    }, [quote, dexes])
     return compareList
 }
 

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/Trade/Quote.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/Trade/Quote.tsx
@@ -103,10 +103,10 @@ export function Quote({ quote, ...props }: QuoteProps) {
     )
 
     const bestRouter = isSwap ? undefined : bridgeQuote?.routerList[0]
-    const { data: crossChainFeeTokenPrice } = useTokenPrice(chainId, bestRouter?.router.crossChainFeeTokenAddress)
+    const { data: crossChainFeeTokenPrice } = useTokenPrice(chainId, bestRouter?.crossChainFeeTokenAddress)
     const totalNetworkFee = useMemo(() => {
         if (!bestRouter || !crossChainFeeTokenPrice) return gasCost
-        return multipliedBy(bestRouter.router.crossChainFee, crossChainFeeTokenPrice).plus(gasCost).toFixed(2)
+        return multipliedBy(bestRouter.crossChainFee, crossChainFeeTokenPrice).plus(gasCost).toFixed(2)
     }, [gasCost, bestRouter, crossChainFeeTokenPrice])
     const { t } = useLingui()
 
@@ -211,12 +211,12 @@ export function Quote({ quote, ...props }: QuoteProps) {
                             {!isSwap && bestRouter ?
                                 <span className={classes.bestRoute}>
                                     <img
-                                        src={bridges.find((x) => x.id === bestRouter.router.bridgeId)?.logoUrl}
+                                        src={bridges.find((x) => x.id === bestRouter.bridgeId)?.logoUrl}
                                         width={16}
                                         height={16}
                                     />
                                     <Typography component="span" className={classes.bridgeName}>
-                                        {bestRouter.router.bridgeName}
+                                        {bestRouter.bridgeName}
                                     </Typography>
                                     <Typography component="span" className={classes.bestTag}>
                                         <Trans>Overall Best</Trans>

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
@@ -1,19 +1,14 @@
-import { t } from '@lingui/core/macro'
 import { Icons } from '@masknet/icons'
 import { EmptyStatus } from '@masknet/shared'
-import { EMPTY_LIST, NetworkPluginID } from '@masknet/shared-base'
 import { makeStyles } from '@masknet/theme'
-import { useNetwork } from '@masknet/web3-hooks-base'
-import type { SwapToken } from '@masknet/web3-providers/types'
+import type { Web3Helper } from '@masknet/web3-helpers'
+import type { DexRouter, SwapToken } from '@masknet/web3-providers/types'
 import type { ChainId } from '@masknet/web3-shared-evm'
 import { Typography } from '@mui/material'
-import { produce } from 'immer'
-import { Fragment, memo, useMemo, useState, type ReactNode } from 'react'
+import { memo, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { BridgeNode } from '../../components/BridgeNode.js'
 import { CoinIcon } from '../../components/CoinIcon.js'
 import { useTrade } from '../contexts/index.js'
-import { getBridgeLeftSideToken, getBridgeRightSideToken } from '../helpers.js'
 
 const useStyles = makeStyles()((theme) => ({
     container: {
@@ -61,23 +56,20 @@ const useStyles = makeStyles()((theme) => ({
         overflow: 'hidden',
         whiteSpace: 'nowrap',
     },
-    nodes: {
-        display: 'flex',
-        alignItems: 'center',
-        gap: theme.spacing(0.5),
-    },
-    node: {
-        flexGrow: 1,
-        minWidth: 0,
-        cursor: 'pointer',
-    },
 }))
 
-enum BridgeStep {
-    FromSide = 'from-side',
-    Bridge = 'bridge',
-    ToSide = 'to-side',
+function toSwapToken(token: Web3Helper.FungibleTokenAll | undefined, chainId: ChainId): SwapToken | undefined {
+    if (!token) return undefined
+    return {
+        chainId,
+        tokenContractAddress: token.address,
+        tokenSymbol: token.symbol,
+        decimal: token.decimals.toString(),
+        decimals: token.decimals,
+        tokenUnitPrice: '0',
+    }
 }
+
 export const TradingRoute = memo(function TradingRoute() {
     const { classes } = useStyles()
     const { quote: swapQuote, bridgeQuote, fromToken, toToken, mode } = useTrade()
@@ -90,207 +82,48 @@ export const TradingRoute = memo(function TradingRoute() {
     const fromChainId = fromToken?.chainId as ChainId
     const toChainId = toToken?.chainId as ChainId
 
-    const fromNetwork = useNetwork(NetworkPluginID.PLUGIN_EVM, fromChainId)
-    const toNetwork = useNetwork(NetworkPluginID.PLUGIN_EVM, toChainId)
-
-    const bridgeRoute =
-        bridgeQuote?.routerList.find((x) => x.router.bridgeId === bridgeId) || bridgeQuote?.routerList[0]
-
-    const [
-        bridgeStep = bridgeRoute?.fromDexRouterList.length ? BridgeStep.FromSide : BridgeStep.Bridge,
-        setBridgeStep,
-    ] = useState<BridgeStep>()
-    const { bridgeNodes, leftSideToken, rightSideToken } = useMemo(() => {
-        if (isSwap || !bridgeRoute) return { bridgeNodes: EMPTY_LIST }
-        const nodes: ReactNode[] = []
-        let leftSideToken: SwapToken | undefined =
-            fromToken ?
-                {
-                    chainId: fromChainId,
-                    tokenContractAddress: fromToken.address,
-                    tokenSymbol: fromToken.symbol,
-                    decimal: fromToken.decimals.toString(),
-                    decimals: fromToken.decimals,
-                    tokenUnitPrice: '0',
-                }
-            :   undefined
-
-        let rightSideToken: SwapToken | undefined =
-            toToken ?
-                {
-                    chainId: toChainId,
-                    tokenContractAddress: toToken.address,
-                    tokenSymbol: toToken.symbol,
-                    decimal: toToken.decimals.toString(),
-                    decimals: toToken.decimals,
-                    tokenUnitPrice: '0',
-                }
-            :   undefined
-        if (bridgeRoute.fromDexRouterList.length) {
-            nodes.push(
-                <BridgeNode
-                    key="from-side"
-                    className={classes.node}
-                    label={fromNetwork?.name}
-                    chainId={fromChainId}
-                    address={fromToken?.address}
-                    symbol={fromToken?.symbol}
-                    step={nodes.length + 1}
-                    active={bridgeStep === BridgeStep.FromSide}
-                    onClick={() => {
-                        setBridgeStep(BridgeStep.FromSide)
-                    }}
-                />,
-            )
-            const lastFromToken = getBridgeLeftSideToken(bridgeRoute)
-            if (lastFromToken) {
-                leftSideToken = {
-                    ...lastFromToken,
-                    chainId: fromChainId,
-                }
-            }
-        }
-        nodes.push(
-            <Icons.ArrowDrop key="bridge-arrow" className={classes.arrow} size={20} />,
-            <BridgeNode
-                key="bridge"
-                className={classes.node}
-                label={t`Bridge`}
-                chainId={leftSideToken?.chainId || fromChainId}
-                address={leftSideToken?.tokenContractAddress}
-                symbol={leftSideToken?.tokenSymbol}
-                step={Math.ceil(nodes.length / 2) + 1}
-                active={bridgeStep === BridgeStep.Bridge}
-                disableBadge
-                onClick={() => {
-                    setBridgeStep(BridgeStep.Bridge)
-                }}
-            />,
-        )
-        if (bridgeRoute.toDexRouterList.length) {
-            nodes.push(
-                <Icons.ArrowDrop key="to-side-arrow" className={classes.arrow} size={20} />,
-                <BridgeNode
-                    key="to-side"
-                    className={classes.node}
-                    label={toNetwork?.name}
-                    chainId={toChainId}
-                    address={toToken?.address}
-                    symbol={toToken?.symbol}
-                    step={Math.ceil(nodes.length / 2) + 1}
-                    active={bridgeStep === BridgeStep.ToSide}
-                    onClick={() => {
-                        setBridgeStep(BridgeStep.ToSide)
-                    }}
-                />,
-            )
-            rightSideToken = { ...getBridgeRightSideToken(bridgeRoute), chainId: toChainId }
-        }
-        return { bridgeNodes: nodes, leftSideToken, rightSideToken }
-    }, [isSwap, fromNetwork, fromToken, toToken, fromChainId, toChainId, bridgeStep])
+    const bridgeRoute = bridgeQuote?.routerList.find((x) => x.bridgeId === bridgeId) || bridgeQuote?.routerList[0]
 
     const dexRouterList = useMemo(() => {
         // Dex router list for swapping
         if (isSwap) return swapQuote?.dexRouterList
 
-        // Dex router list for bridging
-        if (bridgeStep === BridgeStep.FromSide) {
-            return produce(bridgeRoute?.fromDexRouterList || EMPTY_LIST, (list) => {
-                list.forEach((dexRouter) => {
-                    dexRouter.subRouterList.forEach((subRouter) => {
-                        subRouter.fromToken.chainId = fromChainId
-                        subRouter.toToken.chainId = fromChainId
-                    })
-                })
-            })
-        } else if (bridgeStep === BridgeStep.Bridge) {
-            // Fake token for bridge
-            const fakeToken = {
-                chainId: 0,
-                decimals: 10,
-                tokenContractAddress: '0x',
-                tokenSymbol: '--',
-            }
-            return [
-                {
-                    router: '--BRIDGE--',
-                    routerPercent: '100',
-                    subRouterList: [
-                        {
-                            dexProtocol: [
-                                {
-                                    dexName: t`${fromNetwork?.name || ''} Pool`,
-                                    percent: '100',
-                                },
-                            ],
-                            fromToken: leftSideToken,
-                            toToken: fakeToken,
-                        },
-                        {
-                            dexProtocol: [
-                                {
-                                    dexName: t`${toNetwork?.name || ''} Pool`,
-                                    percent: '100',
-                                },
-                            ],
-                            fromToken: fakeToken,
-                            toToken: rightSideToken,
-                        },
-                    ],
-                },
-            ]
-        } else {
-            return produce(bridgeRoute?.toDexRouterList || EMPTY_LIST, (list) => {
-                list.forEach((dexRouter) => {
-                    dexRouter.subRouterList.forEach((subRouter) => {
-                        subRouter.fromToken.chainId = toChainId
-                        subRouter.toToken.chainId = toChainId
-                    })
-                })
-            })
+        // The v6 bridge quote API no longer exposes dex route details, show the bridge as a single hop
+        const fromRouteToken = toSwapToken(fromToken, fromChainId)
+        const toRouteToken = toSwapToken(toToken, toChainId)
+        if (!bridgeRoute || !fromRouteToken || !toRouteToken) return
+        const bridgeRoute_: DexRouter = {
+            dexProtocol: {
+                dexName: bridgeRoute.bridgeName,
+                percent: '100',
+            },
+            fromToken: fromRouteToken,
+            toToken: toRouteToken,
+            fromTokenIndex: '0',
+            toTokenIndex: '1',
         }
-    }, [
-        isSwap,
-        bridgeStep,
-        swapQuote?.dexRouterList,
-        fromNetwork,
-        toNetwork,
-        fromChainId,
-        toChainId,
-        leftSideToken,
-        rightSideToken,
-    ])
+        return [bridgeRoute_]
+    }, [isSwap, swapQuote, bridgeRoute, fromToken, toToken, fromChainId, toChainId])
 
     if (!quote) return <EmptyStatus />
 
     return (
         <div className={classes.container}>
-            {mode === 'bridge' && bridgeNodes.length > 2 ?
-                <div className={classes.nodes}>{bridgeNodes}</div>
-            :   null}
-            {dexRouterList?.map((route) => {
-                const { subRouterList } = route
-                const startToken = subRouterList[0].fromToken
-                const endToken = subRouterList.at(-1)?.toToken
-                const startPool = subRouterList[0].dexProtocol
+            {dexRouterList?.map((route, index) => {
+                const startToken = route.fromToken
+                const endToken = route.toToken
                 return (
-                    <div key={route.router} className={classes.route}>
+                    <div key={index} className={classes.route}>
                         <Typography className={classes.token} component="div">
                             <CoinIcon
                                 className={classes.tokenIcon}
                                 chainId={isSwap ? fromChainId : startToken?.chainId}
                                 address={startToken?.tokenContractAddress}
                             />
-                            {startPool[0].percent}%
+                            {route.dexProtocol.percent}%
                         </Typography>
-                        {subRouterList.map((subRouter, i) => {
-                            return (
-                                <Fragment key={i}>
-                                    <Icons.ArrowDrop className={classes.arrow} size={20} />
-                                    <Typography className={classes.pool}>{subRouter.dexProtocol[0].dexName}</Typography>
-                                </Fragment>
-                            )
-                        })}
+                        <Icons.ArrowDrop className={classes.arrow} size={20} />
+                        <Typography className={classes.pool}>{route.dexProtocol.dexName}</Typography>
                         <Icons.ArrowDrop className={classes.arrow} size={20} />
                         <div className={classes.token}>
                             <CoinIcon

--- a/packages/plugins/Trader/src/SiteAdaptor/trader/views/Transaction.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trader/views/Transaction.tsx
@@ -263,9 +263,14 @@ export const Transaction = memo(function Transaction() {
         refetchInterval: 5000,
     })
 
+    const bridgeId = tx?.kind === 'bridge' ? tx.bridgeId : undefined
     const { data: bridgeStatus } = useQuery({
-        queryKey: ['okx-bridge', 'transaction-status', chainId, hash],
-        queryFn: hash && tx?.kind === 'bridge' ? () => OKX.getBridgeStatus({ chainId, hash }) : skipToken,
+        queryKey: ['okx-bridge', 'transaction-status', chainId, hash, bridgeId],
+        // The v6 status API requires chainIndex/hash/bridgeId, legacy bridge records without a bridgeId fall back to the on-chain status
+        queryFn:
+            hash && bridgeId && chainId ?
+                () => OKX.getBridgeStatus({ chainIndex: chainId, hash, bridgeId })
+            :   skipToken,
         refetchInterval: 10_000,
     })
     const detailStatus = bridgeStatus?.detailStatus

--- a/packages/shared-base-ui/src/locale/en-US.po
+++ b/packages/shared-base-ui/src/locale/en-US.po
@@ -129,7 +129,7 @@ msgstr ""
 msgid "{0} available"
 msgstr ""
 
-#. placeholder {0}: bridge?.router.bridgeName
+#. placeholder {0}: bridge?.bridgeName
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Bridge Network fee"
 msgstr ""
@@ -170,7 +170,6 @@ msgstr ""
 #~ msgstr ""
 
 #. placeholder {0}: fromNetwork?.name
-#. placeholder {0}: toNetwork?.name
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Network fee"
 msgstr ""
@@ -212,8 +211,8 @@ msgstr ""
 #. placeholder {0}: fromNetwork?.name || ''
 #. placeholder {0}: toNetwork?.name || ''
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
-msgid "{0} Pool"
-msgstr ""
+#~ msgid "{0} Pool"
+#~ msgstr ""
 
 #. placeholder {0}: riskyFactors.toString()
 #: packages/plugins/GoPlusSecurity/src/SiteAdaptor/components/SecurityPanel.tsx
@@ -1130,7 +1129,6 @@ msgstr ""
 #: packages/plugins/Trader/src/SiteAdaptor/trader/ExchangeDialog.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Trade/index.tsx
-#: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Transaction.tsx
 msgid "Bridge"
 msgstr ""

--- a/packages/shared-base-ui/src/locale/ja-JP.po
+++ b/packages/shared-base-ui/src/locale/ja-JP.po
@@ -134,7 +134,7 @@ msgstr "{0} 注意要因"
 msgid "{0} available"
 msgstr "{0} 利用可能です"
 
-#. placeholder {0}: bridge?.router.bridgeName
+#. placeholder {0}: bridge?.bridgeName
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Bridge Network fee"
 msgstr ""
@@ -175,7 +175,6 @@ msgstr "{0} メンバー"
 #~ msgstr "{0} 分"
 
 #. placeholder {0}: fromNetwork?.name
-#. placeholder {0}: toNetwork?.name
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Network fee"
 msgstr ""
@@ -217,8 +216,8 @@ msgstr ""
 #. placeholder {0}: fromNetwork?.name || ''
 #. placeholder {0}: toNetwork?.name || ''
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
-msgid "{0} Pool"
-msgstr ""
+#~ msgid "{0} Pool"
+#~ msgstr ""
 
 #. placeholder {0}: riskyFactors.toString()
 #: packages/plugins/GoPlusSecurity/src/SiteAdaptor/components/SecurityPanel.tsx
@@ -1135,7 +1134,6 @@ msgstr "Blocto は Flow チェーンのみを対応します。"
 #: packages/plugins/Trader/src/SiteAdaptor/trader/ExchangeDialog.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Trade/index.tsx
-#: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Transaction.tsx
 msgid "Bridge"
 msgstr "ブリッジ"

--- a/packages/shared-base-ui/src/locale/ko-KR.po
+++ b/packages/shared-base-ui/src/locale/ko-KR.po
@@ -134,7 +134,7 @@ msgstr "{0} 주의 인자"
 msgid "{0} available"
 msgstr "{0} 이용가능"
 
-#. placeholder {0}: bridge?.router.bridgeName
+#. placeholder {0}: bridge?.bridgeName
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Bridge Network fee"
 msgstr ""
@@ -175,7 +175,6 @@ msgstr "{0} 맴버"
 #~ msgstr "{0} 분"
 
 #. placeholder {0}: fromNetwork?.name
-#. placeholder {0}: toNetwork?.name
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Network fee"
 msgstr ""
@@ -217,8 +216,8 @@ msgstr ""
 #. placeholder {0}: fromNetwork?.name || ''
 #. placeholder {0}: toNetwork?.name || ''
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
-msgid "{0} Pool"
-msgstr ""
+#~ msgid "{0} Pool"
+#~ msgstr ""
 
 #. placeholder {0}: riskyFactors.toString()
 #: packages/plugins/GoPlusSecurity/src/SiteAdaptor/components/SecurityPanel.tsx
@@ -1135,7 +1134,6 @@ msgstr "Blocto는 Flow에만 지원합니다."
 #: packages/plugins/Trader/src/SiteAdaptor/trader/ExchangeDialog.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Trade/index.tsx
-#: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Transaction.tsx
 msgid "Bridge"
 msgstr ""

--- a/packages/shared-base-ui/src/locale/zh-CN.po
+++ b/packages/shared-base-ui/src/locale/zh-CN.po
@@ -134,7 +134,7 @@ msgstr "{0} 个需要关注的因素"
 msgid "{0} available"
 msgstr "{0} 可用"
 
-#. placeholder {0}: bridge?.router.bridgeName
+#. placeholder {0}: bridge?.bridgeName
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Bridge Network fee"
 msgstr ""
@@ -175,7 +175,6 @@ msgstr "{0} 位成员"
 #~ msgstr "{0} 分钟"
 
 #. placeholder {0}: fromNetwork?.name
-#. placeholder {0}: toNetwork?.name
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Network fee"
 msgstr ""
@@ -217,8 +216,8 @@ msgstr ""
 #. placeholder {0}: fromNetwork?.name || ''
 #. placeholder {0}: toNetwork?.name || ''
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
-msgid "{0} Pool"
-msgstr ""
+#~ msgid "{0} Pool"
+#~ msgstr ""
 
 #. placeholder {0}: riskyFactors.toString()
 #: packages/plugins/GoPlusSecurity/src/SiteAdaptor/components/SecurityPanel.tsx
@@ -1135,7 +1134,6 @@ msgstr "Blocto 只支持 Flow 链。"
 #: packages/plugins/Trader/src/SiteAdaptor/trader/ExchangeDialog.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Trade/index.tsx
-#: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Transaction.tsx
 msgid "Bridge"
 msgstr ""

--- a/packages/shared-base-ui/src/locale/zh-TW.po
+++ b/packages/shared-base-ui/src/locale/zh-TW.po
@@ -134,7 +134,7 @@ msgstr ""
 msgid "{0} available"
 msgstr ""
 
-#. placeholder {0}: bridge?.router.bridgeName
+#. placeholder {0}: bridge?.bridgeName
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Bridge Network fee"
 msgstr ""
@@ -175,7 +175,6 @@ msgstr ""
 #~ msgstr ""
 
 #. placeholder {0}: fromNetwork?.name
-#. placeholder {0}: toNetwork?.name
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 msgid "{0} Network fee"
 msgstr ""
@@ -217,8 +216,8 @@ msgstr ""
 #. placeholder {0}: fromNetwork?.name || ''
 #. placeholder {0}: toNetwork?.name || ''
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
-msgid "{0} Pool"
-msgstr ""
+#~ msgid "{0} Pool"
+#~ msgstr ""
 
 #. placeholder {0}: riskyFactors.toString()
 #: packages/plugins/GoPlusSecurity/src/SiteAdaptor/components/SecurityPanel.tsx
@@ -1135,7 +1134,6 @@ msgstr ""
 #: packages/plugins/Trader/src/SiteAdaptor/trader/ExchangeDialog.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/BridgeConfirm.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Trade/index.tsx
-#: packages/plugins/Trader/src/SiteAdaptor/trader/views/TradingRoute.tsx
 #: packages/plugins/Trader/src/SiteAdaptor/trader/views/Transaction.tsx
 msgid "Bridge"
 msgstr ""

--- a/packages/web3-providers/src/OKX/index.ts
+++ b/packages/web3-providers/src/OKX/index.ts
@@ -36,7 +36,7 @@ export const OKX = {
      * @docs https://www.okx.com/web3/build/docs/waas/dex-get-aggregator-supported-chains
      */
     async getSupportedChains() {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/aggregator/supported/chain')
+        const url = urlcat(OKX_HOST, '/api/v6/dex/aggregator/supported/chain')
         const res = await fetchFromOKX<SupportedChainResponse>(url)
         if (res.code === 0) return res.data
         throw new Error('Failed to get supported chains')
@@ -45,7 +45,7 @@ export const OKX = {
     async baseGetTokens(chainId: ChainId, apiRoute: string) {
         if (!chainId) return null
         const url = urlcat(OKX_HOST, apiRoute, {
-            chainId,
+            chainIndex: chainId,
         })
         const res = await fetchFromOKX<GetTokensResponse>(url)
         if (res.code !== 0) throw new Error('Failed to get tokens')
@@ -66,7 +66,7 @@ export const OKX = {
                         chainId,
                         name: x.tokenName,
                         symbol: x.tokenSymbol,
-                        // string to number for /api/v5/dex/aggregator/all-tokens
+                        // string to number for /api/v6/dex/aggregator/all-tokens
                         decimals: +x.decimals,
                         logoURL: x.tokenLogoUrl,
                         address,
@@ -78,36 +78,27 @@ export const OKX = {
     },
 
     async getTokens(chainId: ChainId): Promise<Array<FungibleToken<ChainId, SchemaType>> | null> {
-        return OKX.baseGetTokens(chainId, '/api/v5/dex/aggregator/all-tokens')
+        return OKX.baseGetTokens(chainId, '/api/v6/dex/aggregator/all-tokens')
     },
 
     async getLiquidity(chainId: string) {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/aggregator/get-liquidity', {
-            chainId,
+        const url = urlcat(OKX_HOST, '/api/v6/dex/aggregator/get-liquidity', {
+            chainIndex: chainId,
         })
-        // XXX Suspect this is private API of OKX, according to `pri(vate)api`, which provides dex logo
-        const privateUrl = urlcat('https://www.okx.com/priapi/v1/dx/trade/multi/liquidityList', { chainId })
-        const [res, resWithLogo] = await Promise.all([
-            fetchFromOKX<GetLiquidityResponse>(url),
-            fetchJSON<GetLiquidityResponse>(privateUrl),
-        ])
-        if (res.code !== 0 || resWithLogo.code !== 0) throw new Error('Failed to get liquidity')
-        const dexLogoMap = new Map(resWithLogo.data.map((x) => [x.id, x.logo]))
-        return {
-            ...res,
-            data: res.data.map((dex) => ({ ...dex, logo: dexLogoMap.get(dex.id) })),
-        }
+        const res = await fetchFromOKX<GetLiquidityResponse>(url)
+        if (res.code !== 0) throw new Error('Failed to get liquidity')
+        return res
     },
 
     async getApproveTx(options: ApproveTransactionOptions) {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/aggregator/approve-transaction', options)
+        const url = urlcat(OKX_HOST, '/api/v6/dex/aggregator/approve-transaction', options)
         const res = await fetchFromOKX<ApproveTransactionResponse>(url)
         if (res.code === 0) return res.data[0]
         throw new Error('Failed to get approve transaction')
     },
 
     async getQuotes(options: GetQuotesOptions) {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/aggregator/quote', {
+        const url = urlcat(OKX_HOST, '/api/v6/dex/aggregator/quote', {
             ...options,
             fromTokenAddress: toOkxNativeAddress(options.fromTokenAddress),
             toTokenAddress: toOkxNativeAddress(options.toTokenAddress),
@@ -120,10 +111,8 @@ export const OKX = {
                 quote.fromToken = fixToken(quote.fromToken)
                 quote.toToken = fixToken(quote.toToken)
                 quote.dexRouterList.forEach((router) => {
-                    router.subRouterList.forEach((subRouter) => {
-                        subRouter.fromToken = fixToken(subRouter.fromToken)
-                        subRouter.toToken = fixToken(subRouter.toToken)
-                    })
+                    router.fromToken = fixToken(router.fromToken)
+                    router.toToken = fixToken(router.toToken)
                 })
             })
         }
@@ -136,7 +125,7 @@ export const OKX = {
      * @returns The response from the swap API.
      */
     async getSwap(options: SwapOptions): Promise<SwapResponse> {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/aggregator/swap', {
+        const url = urlcat(OKX_HOST, '/api/v6/dex/aggregator/swap', {
             ...options,
             fromTokenAddress: toOkxNativeAddress(options.fromTokenAddress),
             toTokenAddress: toOkxNativeAddress(options.toTokenAddress),
@@ -149,7 +138,7 @@ export const OKX = {
         const intChainId = +chainId
         const tokens = await queryClient.fetchQuery({
             queryKey: ['okx-tokens', intChainId],
-            queryFn: () => OKX.baseGetTokens(intChainId, '/api/v5/dex/aggregator/all-tokens'),
+            queryFn: () => OKX.baseGetTokens(intChainId, '/api/v6/dex/aggregator/all-tokens'),
         })
         if (!tokens?.length) return
         const isNativeToken = isNativeTokenAddress(fromOkxNativeAddress(address))
@@ -164,7 +153,7 @@ export const OKX = {
         const options = {
             amount: rightShift(1, fromToken?.decimals ?? 18).toFixed(),
             fromTokenAddress: fromToken?.address ?? NATIVE_TOKEN_ADDRESS,
-            chainId,
+            chainIndex: chainId,
             toTokenAddress: toOkxNativeAddress(address),
         }
         const quoteRes = await queryClient.fetchQuery({
@@ -177,7 +166,7 @@ export const OKX = {
     },
 
     async getBridgeQuote(options: GetBridgeQuoteOptions) {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/cross-chain/quote', {
+        const url = urlcat(OKX_HOST, '/api/v6/dex/cross-chain/quote', {
             ...options,
             fromTokenAddress: toOkxNativeAddress(options.fromTokenAddress),
             toTokenAddress: toOkxNativeAddress(options.toTokenAddress),
@@ -185,34 +174,27 @@ export const OKX = {
         const res = await fetchFromOKX<GetBridgeQuoteResponse>(url)
         if (res.code !== 0) throw new Error('Failed to get bridge quote')
         const [fromTokenPrice = '0', toTokenPrice = '0'] = await Promise.all([
-            OKX.getTokenPrice(options.fromTokenAddress, options.fromChainId),
-            OKX.getTokenPrice(options.toTokenAddress, options.toChainId),
+            OKX.getTokenPrice(options.fromTokenAddress, options.fromChainIndex),
+            OKX.getTokenPrice(options.toTokenAddress, options.toChainIndex),
         ])
         // Patch data
         res.data.forEach((quote) => {
             quote.fromToken.tokenUnitPrice = fromTokenPrice
             quote.toToken.tokenUnitPrice = toTokenPrice
             quote.toTokenAmount = quote.routerList[0]?.toTokenAmount
-            quote.fromChainId = +quote.fromChainId
-            quote.toChainId = +quote.toChainId
+            quote.fromChainIndex = +quote.fromChainIndex
+            quote.toChainIndex = +quote.toChainIndex
             quote.routerList.forEach((router) => {
-                router.router.crossChainFeeTokenAddress = fromOkxNativeAddress(router.router.crossChainFeeTokenAddress)
-                ;[...router.fromDexRouterList, ...router.toDexRouterList].forEach((dexRouter) => {
-                    dexRouter.subRouterList.forEach((subRouter) => {
-                        subRouter.fromToken.tokenContractAddress = fromOkxNativeAddress(
-                            subRouter.fromToken.tokenContractAddress,
-                        )
-                    })
-                })
+                router.crossChainFeeTokenAddress = fromOkxNativeAddress(router.crossChainFeeTokenAddress)
             })
         })
         return res
     },
 
-    async getBridgeSupportedChains(chainId?: number) {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/cross-chain/supported/chain', {
-            chainId,
-        })
+    async getBridgeSupportedChains() {
+        // The dedicated cross-chain supported chains endpoint was removed in v6,
+        // the aggregator supported chains serve both swap and bridge modes now.
+        const url = urlcat(OKX_HOST, '/api/v6/dex/aggregator/supported/chain')
         const res = await fetchFromOKX<SupportedChainResponse>(url)
         if (res.code === 0) {
             res.data.forEach((item) => {
@@ -224,7 +206,7 @@ export const OKX = {
     },
 
     async bridge(options: BridgeOptions) {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/cross-chain/build-tx', {
+        const url = urlcat(OKX_HOST, '/api/v6/dex/cross-chain/swap', {
             ...options,
             fromTokenAddress: toOkxNativeAddress(options.fromTokenAddress),
             toTokenAddress: toOkxNativeAddress(options.toTokenAddress),
@@ -234,21 +216,29 @@ export const OKX = {
     },
 
     async getBridgeStatus(options: GetBridgeStatusOptions) {
-        const url = urlcat(OKX_HOST, '/api/v5/dex/cross-chain/status', options)
+        const url = urlcat(OKX_HOST, '/api/v6/dex/cross-chain/status', options)
         const res = await fetchFromOKX<GetBridgeStatusResponse>(url)
         if (res.code !== 0) throw new Error('Failed to get bridge status')
         // Patch data
         if (res.data.length) {
-            res.data.forEach((record) => {
-                record.fromChainId = +record.fromChainId
-                record.toChainId = record.toChainId ? +record.toChainId : 0
-            })
-            return res.data[0]
+            const record = res.data[0]
+            // The v6 states differ from v5 (e.g. NOT_FOUND for orders not indexed yet),
+            // normalize them to the v5-style states the UI relies on, any non-final state is PENDING
+            const rawStatus = record.status as string
+            const failureStates = ['FAIL', 'FAILED', 'FAILURE', 'REFUND', 'FROM_FAILURE']
+            record.status =
+                rawStatus === 'SUCCESS' ? 'SUCCESS'
+                : failureStates.includes(rawStatus) ? 'FAILURE'
+                : 'PENDING'
+            // v6 renamed fromTxHash to txHash, keep the v5-style field for the UI
+            record.fromTxHash ??= record.txHash
+            return record
         }
         return
     },
 
     async getUserTokenBalances(chainId: ChainId | ChainId[], account: string) {
+        // The wallet APIs are still served by v5, which is not affected by the dex v5 sunset.
         const url = urlcat(OKX_HOST, '/api/v5/wallet/asset/all-token-balances-by-address', {
             chains: chainId,
             address: account,

--- a/packages/web3-providers/src/OKX/types.ts
+++ b/packages/web3-providers/src/OKX/types.ts
@@ -12,8 +12,9 @@ interface OKXResponse<T> {
 }
 
 export interface ChainDex {
-    /** API response string, we convert to number */
     chainId: number
+    /** Unique chain index, equals to chainId for most chains */
+    chainIndex: number
     chainName: string
     /** would be empty string for non-ethereum chains */
     dexTokenApproveAddress: string
@@ -25,9 +26,8 @@ export type GetTokensResponse = OKXResponse<
     Array<{
         /**
          * @example "18"
-         * /api/v5/dex/aggregator/all-tokens responses decimals in string,
-         * but we will convert it to number as
-         * /api/v5/dex/cross-chain/supported/tokens responses in number
+         * /api/v6/dex/aggregator/all-tokens responses decimals in string,
+         * but we will convert it to number as the bridge APIs respond in number
          * */
         decimals: number
         /** @example "0x382bb369d343125bfb2117af9c149795c6c65c50" */
@@ -53,7 +53,7 @@ export type GetLiquidityResponse = OKXResponse<
 >
 
 export interface ApproveTransactionOptions {
-    chainId: number
+    chainIndex: number
     tokenContractAddress: string
     approveAmount: string
 }
@@ -75,8 +75,8 @@ export type ApproveTransactionResponse = OKXResponse<
 >
 
 export interface GetQuotesOptions {
-    /** Chain ID (e.g., 1 for Ethereum) */
-    chainId: string
+    /** Chain index (e.g., 1 for Ethereum) */
+    chainIndex: string
     /** The input amount of a token to be sold (in minimal divisible units) */
     amount: string
     /** The contract address of a token to be sold */
@@ -119,41 +119,73 @@ export interface SwapToken {
      * Bridge quote API has no tokenUnitPrice, we get it in favor of swap quote API, see OKX.getTokenPrice
      * */
     tokenUnitPrice: string
+    /** Whether the token is a honeypot, swap quote API only */
+    isHoneyPot?: boolean
+    /** Swap quote API only */
+    latestMultiplier?: string
+    /** Swap quote API only */
+    taxRate?: string
+}
+
+interface DexProtocol {
+    /** @example "Uniswap V3" */
+    dexName: string
+    percent: string
+}
+
+/** A hop of the quote path */
+export interface DexRouter {
+    /** Liquidity protocol used on the hop */
+    dexProtocol: DexProtocol
+    /** The information of a token to be sold */
+    fromToken: SwapToken
+    /** The information of a token to be bought */
+    toToken: SwapToken
+    fromTokenIndex: string
+    toTokenIndex: string
 }
 
 export interface OKXSwapQuote {
-    chainId: string
+    chainIndex: string
     dexRouterList: DexRouter[]
     /** It's gas limit actually */
     estimateGasFee: string
     fromToken: SwapToken
     /** Amount of fromToken */
     fromTokenAmount: string
-    quoteCompareList: Array<{
-        amountOut: string
-        dexLogo: string
-        dexName: string
-        /** Estimated network fee (USD) of the quote route */
-        tradeFee: string
-    }>
     toToken: SwapToken
     /** Amount of toToken */
     toTokenAmount: string
+    /** Estimated network fee (USD) of the quote route */
+    tradeFee: string
+    /** Percentage difference between the received value and the paid value */
+    priceImpactPercent: string
+    /** Main path for the token swap */
+    router: string
+    /** A unique identifier for this quote */
+    quoteId?: string
+    /** The routing mode used for this quote (dex, intent, auto) */
+    mode?: string
+    swapMode: string
+    /** The blockchain slot number at the time the quote was generated, Solana only */
+    contextSlot?: number
+    /** Signing data required for intent orders */
+    signData?: unknown
 }
 
 export type GetQuotesResponse = OKXResponse<OKXSwapQuote[]>
 
 export interface SwapOptions {
-    /** Chain ID */
-    chainId: string
+    /** Chain index */
+    chainIndex: string
     /** The input amount of a token to be sold */
     amount: string
     /** The contract address of a token you want to send */
     fromTokenAddress: string
     /** The contract address of a token you want to receive */
     toTokenAddress: string
-    /** The slippage you are willing to accept */
-    slippage: string
+    /** The slippage percentage you are willing to accept (e.g., 0.5 for 0.5%) */
+    slippagePercent: string
     /** The user's wallet address */
     userWalletAddress: string
     /** The referrer's address (optional) */
@@ -187,49 +219,15 @@ export interface OkxTx {
     value: string
     minReceiveAmount: string
     data: string
-}
-interface DexProtocol {
-    /** @example "Uniswap V3" */
-    dexName: string
-    percent: string
+    maxSpendAmount?: string
+    /** Solana only */
+    signatureData?: unknown
+    slippagePercent?: string
 }
 
 export type SwapResponse = OKXResponse<
     Array<{
-        routerResult: {
-            chainId: string
-            /** the input amount of a token to be sold */
-            fromTokenAmount: string
-            /** the output amount of a token to be received */
-            toTokenAmount: string
-            /** It's gas limit actually */
-            estimateGasFee: string
-            /** The list of DEX routers */
-            dexRouterList: Array<{
-                /** The router address */
-                router: string
-                /**
-                 * The percentage of assets handled by the main path
-                 * @example "5"
-                 */
-                routerPercent: string
-                /** Quote path sub data set */
-                subRouterList: Array<{
-                    /** Liquidity protocols used on the main path */
-                    dexProtocol: DexProtocol[]
-                    fromToken: SwapToken
-                    toToken: SwapToken
-                }>
-            }>
-            fromToken: SwapToken
-            toToken: SwapToken
-            quoteCompareList: Array<{
-                dexName: string
-                dexLogo: string
-                tradeFee: string
-                receiveAmount: string
-            }>
-        }
+        routerResult: OKXSwapQuote
         tx: OkxTx
     }>
 >
@@ -238,11 +236,11 @@ export type SwapResponse = OKXResponse<
  * Options for getting a cross-chain quote
  */
 export interface GetBridgeQuoteOptions {
-    /** Source chain ID (e.g., '1' for Ethereum) */
-    fromChainId: string
+    /** Source chain index (e.g., '1' for Ethereum) */
+    fromChainIndex: string
 
-    /** Destination chain ID (e.g., '1' for Ethereum) */
-    toChainId: string
+    /** Destination chain index (e.g., '1' for Ethereum) */
+    toChainIndex: string
 
     /** The contract address of the token to be sold */
     fromTokenAddress: string
@@ -291,8 +289,8 @@ export interface GetBridgeQuoteOptions {
     priceImpactProtectionPercentage?: string
 }
 
-/** Represents bridge information */
-interface Router {
+/** Represents an item in the router list, v6 flattened the nested `router` and dex router lists */
+export interface RouterListItem {
     /** Bridge ID (e.g., 211) */
     bridgeId: number
     /** Name of bridge (e.g., cBridge) */
@@ -303,56 +301,29 @@ interface Router {
     crossChainFee: string
     /** The cross-chain bridge fee token information */
     crossChainFeeTokenAddress: string
-}
-
-/** Represents DEX Router information */
-export interface SubRouter {
-    /** The information of a token to be sold */
-    fromToken: SwapToken
-    /** The information of a token to be bought */
-    toToken: SwapToken
-    dexProtocol: DexProtocol[]
-}
-
-/** Represents a DEX router with sub-routers */
-interface DexRouter {
-    /** One of the main paths for the token swap */
-    router: string
-    /** The percentage of assets handled by the protocol */
-    routerPercent: string
-    /** DEX Router information */
-    subRouterList: SubRouter[]
-}
-
-/** Represents an item in the router list */
-export interface RouterListItem {
     /** The recommended gas limit for calling the contract */
     estimateGasFee: string
     /** time in seconds (It's wrongly wrote as estimatedTime) */
     estimateTime: string
-    fromChainNetworkFee: string
+    /** The minimum amount of a token to buy when the price reaches maximum slippage */
     minimumReceived: string
-    needApprove: number
-    /** Bridge information */
-    router: Router
-    /** Source chain swap information */
-    fromDexRouterList: DexRouter[]
-    toChainNetworkFee: string
-    /** Destination chain's swap route information */
-    toDexRouterList: DexRouter[]
+    needApprove: boolean
+    needCancelApprove: boolean
+    priceImpactPercentage: string
     toTokenAmount: string
+    warningMessage: string
 }
 export interface OKXBridgeQuote {
     /**
-     * Destination chain ID (e.g., 1 for Ethereum)
+     * Source chain index (e.g., 1 for Ethereum)
      * API response string, we convert to number
      */
-    fromChainId: number
+    fromChainIndex: number
     /**
-     * Destination chain ID (e.g., 1 for Ethereum)
+     * Destination chain index (e.g., 1 for Ethereum)
      * API response string, we convert to number
      */
-    toChainId: number
+    toChainIndex: number
     /** The input amount of a token to be sold */
     fromTokenAmount: string
     /** The information of a token to be sold */
@@ -361,18 +332,18 @@ export interface OKXBridgeQuote {
     toToken: SwapToken
     /** Quote path data set */
     routerList: RouterListItem[]
-    /** The resulting amount of a token to be bought */
+    /** The resulting amount of a token to be bought, we patch it from the first router */
     toTokenAmount: string
 }
 /** Response type for getting a cross-chain quote */
 export type GetBridgeQuoteResponse = OKXResponse<OKXBridgeQuote[]>
 
 export interface BridgeOptions {
-    /** Source chain ID (e.g., `1` for Ethereum) */
-    fromChainId: ChainId
+    /** Source chain index (e.g., `1` for Ethereum) */
+    fromChainIndex: ChainId
 
-    /** Destination chain ID (e.g., `1` for Ethereum) */
-    toChainId: ChainId
+    /** Destination chain index (e.g., `1` for Ethereum) */
+    toChainIndex: ChainId
 
     /** The contract address of a token to be sold */
     fromTokenAddress: string
@@ -403,7 +374,7 @@ export interface BridgeOptions {
     /** Specify bridges that should be included in routes */
     allowBridge?: number[]
 
-    /** Specify bridges that should be excluded in routes */
+    /** Specify bridges that should be excluded from routes */
     denyBridge?: number[]
 
     /**
@@ -434,7 +405,7 @@ export interface BridgeOptions {
     onlyBridge?: boolean
 
     /**
-     * Custom parameters carried in /build-tx (128-character 64-byte hexadecimal string)
+     * Custom parameters carried in the swap API (128-character 64-byte hexadecimal string)
      */
     memo?: string
 }
@@ -470,6 +441,8 @@ interface Transaction {
     /** EIP-1559: Recommended priority cost of gas per unit (e.g., 500000000) */
     maxPriorityFeePerGas: string
     randomKeyAccount: any[]
+    /** Solana only */
+    signatureData?: unknown
 }
 
 /** Response type for getting a cross-chain swap */
@@ -480,7 +453,7 @@ export type GetBridgeResponse = OKXResponse<
         /** The resulting amount of a token to be bought (Quantity needs to include accuracy. e.g., 1.00 USDT set as 1000000) */
         toTokenAmount: string
         /** The minimum amount of a token to buy when the price reaches maximum slippage */
-        minmumReceive: string
+        minimumReceived: string
         /** Bridge information */
         router: BridgeRouter
         /** On chain transaction data */
@@ -495,48 +468,46 @@ export type GetBridgeResponse = OKXResponse<
 >
 
 export interface GetBridgeStatusOptions {
-    chainId?: number
+    chainIndex: number
     hash: string
+    /** Bridge ID used for the cross-chain swap */
+    bridgeId: number
 }
 
+/** The v6 status response, verified against the live API */
 export interface BridgeStatus {
-    bridgeHash: string
-    crossChainFee: {
-        symbol: string
-        address: string
-        amount: string
-    } | null
-    crossChainInfo: {
-        memo?: string
-    } | null
+    /** e.g. 639 */
+    bridgeId: number
+    /** Source chain index */
+    chainIndex: string
+    /**
+     * PENDING (Order pending)
+     * SUCCESS (Order success)
+     * FAILURE (Order failure)
+     *
+     * The raw v6 states differ from v5 (e.g. NOT_FOUND for unindexed orders),
+     * the provider normalizes them to the v5-style states above.
+     */
+    status: 'PENDING' | 'SUCCESS' | 'FAILURE'
+    toAmount: string
+    /** Destination chain index, could be empty string */
+    toChainIndex: string
+    toTokenAddress: string
+    /** Destination chain tx hash, empty until the destination leg completes */
+    toTxHash: string
+    /** Source chain tx hash */
+    txHash: string
+    /** Source chain tx hash, kept for v5-style richer states if the API still returns it */
+    fromTxHash?: string
     /**
      * WAITING (Order processing)
      * FROM_SUCCESS (Source swap success)
      * FROM_FAILURE (Source swap failure)
      * BRIDGE_PENDING (Bridge pending)
-     * BRIDGE_SUCCESS (Bridge success)
      * SUCCESS (Order success)
      * REFUND (Order failure, refund)
      */
-    detailStatus: 'WAITING' | 'FROM_SUCCESS' | 'FROM_FAILURE' | 'BRIDGE_PENDING' | 'SUCCESS' | 'REFUND'
-    errorMsg: string
-    fromAmount: string
-    /** API response string, we convert to number */
-    fromChainId: number
-    fromTokenAddress: string
-    fromTxHash: string
-    refundTokenAddress: string
-    /**
-     * PENDING (Order pending)
-     * SUCCESS (Order success)
-     * FAILURE (Order failure)
-     */
-    status: 'PENDING' | 'SUCCESS' | 'FAILURE'
-    toAmount: string
-    /** API response string(could be empty string), we convert to number */
-    toChainId: number
-    toTokenAddress: string
-    toTxHash: string
+    detailStatus?: 'WAITING' | 'FROM_SUCCESS' | 'FROM_FAILURE' | 'BRIDGE_PENDING' | 'SUCCESS' | 'REFUND'
 }
 
 export type GetBridgeStatusResponse = OKXResponse<BridgeStatus[]>


### PR DESCRIPTION
## Summary

OKX sunset the v5 DEX API (`50050 "V5 API is being deprecated"`), breaking the whole Trader (swap/bridge) feature. This migrates the OKX provider and the Trader plugin to the v6 DEX API. All traffic keeps going through `okx-proxy.r2d2.to` (pure path-passthrough worker, no worker change).

- **Provider (`packages/web3-providers/src/OKX`)**: all `/api/v5/dex/*` routes → `/api/v6/dex/*`; `build-tx` renamed to `cross-chain/swap`; `chainId` → `chainIndex` params everywhere; `slippage` → `slippagePercent` (percent units) on aggregator swap; dropped the private `priapi` liquidity logo fetch (v6 returns logos natively); `cross-chain/supported/chain` is gone — bridge mode now uses the aggregator chain list; v6 `cross-chain/status` requires `chainIndex`/`hash`/`bridgeId` and returns a new shape (`txHash` instead of `fromTxHash`), which the provider normalizes to the states the UI relies on.
- **Types**: rewritten to the v6 schema — flat `dexRouterList` hops (no `subRouterList`), flat bridge `routerList` (no nested `router`/`fromDexRouterList`/`toDexRouterList`), `quoteCompareList` removed (synthesized from the quote in `QuoteRoute`), `minmumReceive` → `minimumReceived`, + v6 fields (`priceImpactPercent`, `tradeFee`, `router`, `quoteId`, `isHoneyPot`…).
- **Trader plugin**: option-field renames at all call sites; `TradingRoute` renders the flat hop list (bridge shown as a single hop since v6 hides dex-route details); `QuoteRoute` always synthesizes the compare list; bridge fee display uses `otherNativeFee`/`estimateGasFee` (v6 dropped per-chain network fee fields, so the "To network fee" row was removed); `getBridgeStatus` passes `{ chainIndex, hash, bridgeId }` from the stored `bridgeId`.
- The v5 wallet balances endpoint (`/api/v5/wallet/asset/all-token-balances-by-address`) is still served by OKX and is unchanged.

## Notes for reviewers

- v6 `cross-chain/status` response schema was verified only for the `NOT_FOUND` state (no live bridge tx available); the UI reads `status`/`toTxHash` which the provider normalizes, and unknown non-final states are treated as `PENDING`.
- New EVM router contracts are server-driven (`approve-transaction` / `tx.to`), so users may need to re-approve token allowances after this ships.

## Verification

- All v6 endpoints smoke-tested live through the proxy (quote/swap/bridge build-tx/approve/liquidity/all-tokens incl. chainIndex=196 from the Jira repro).
- A temporary vitest harness ran the real provider code against the live proxy: 8/8 passed (params, patch code, decimals fixes, token prices).
- `gulp typescript` (repo-wide) and eslint/prettier clean; production MV3 build succeeds.
- Loaded the new build in the dev extension on x.com: the Cross-chain dialog renders real v6 bridge quotes (STARGATE V2 / ACROSS options with times and fees) and the Swap dialog opens.

Closes MF-6822