### PR TITLE
fix: replace dead cloudflare-eth.com mainnet rpc preset

### DIFF
--- a/packages/plugins/Debugger/src/SiteAdaptor/components/ConnectionContent.tsx
+++ b/packages/plugins/Debugger/src/SiteAdaptor/components/ConnectionContent.tsx
@@ -3,7 +3,7 @@ import { Button, Table, TableBody, TableCell, TableRow, Typography } from '@mui/
 import { makeStyles } from '@masknet/theme'
 import { EVMWeb3, EVMContract, EVMChainResolver } from '@masknet/web3-providers'
 import { NetworkPluginID } from '@masknet/shared-base'
-import { ChainId, NetworkType, ProviderType } from '@masknet/web3-shared-evm'
+import { ChainId, NetworkType, ProviderType, ProviderURL } from '@masknet/web3-shared-evm'
 import { useChainContext, useNetworkContext, useNetworks, useWeb3State } from '@masknet/web3-hooks-base'
 import { Telemetry } from '@masknet/web3-telemetry'
 import { EventType, EventID, ExceptionType, ExceptionID } from '@masknet/web3-telemetry/types'
@@ -35,7 +35,7 @@ export function ConnectionContent() {
             name: 'Mainnet',
             network: 'mainnet',
             nativeCurrency: EVMChainResolver.nativeCurrency(ChainId.Mainnet),
-            rpcUrl: 'https://cloudflare-eth.com',
+            rpcUrl: ProviderURL.fromOfficial(ChainId.Mainnet),
             explorerUrl: {
                 url: 'https://etherscan.io/',
             },

--- a/packages/web3-shared/evm/src/constants/viem-chains.ts
+++ b/packages/web3-shared/evm/src/constants/viem-chains.ts
@@ -64,7 +64,7 @@ const VIEM_CHAINS: Partial<Record<ChainId, Chain>> = {
 // endpoints, or covers a chain viem has no preset for.
 const RPC_URL_OVERRIDES: Partial<Record<ChainId, string[]>> = {
     // viem 2.45's preset (eth.merkle.io) persistently 429s anonymous traffic
-    [ChainId.Mainnet]: ['https://ethereum-rpc.publicnode.com', 'https://eth.drpc.org', 'https://cloudflare-eth.com'],
+    [ChainId.Mainnet]: ['https://ethereum-rpc.publicnode.com', 'https://eth.drpc.org', 'https://rpc.mevblocker.io'],
     // viem 2.45's preset (polygon-rpc.com) rejects anonymous traffic (401/403)
     [ChainId.Polygon]: ['https://polygon-bor-rpc.publicnode.com', 'https://polygon.drpc.org', 'https://1rpc.io/matic'],
     // viem 2.45's preset is a single thirdweb free-tier endpoint


### PR DESCRIPTION
Cloudflare is deprecating the legacy public `cloudflare-eth.com` gateway hostname — JSON-RPC calls now fail with `-32046 Cannot fulfill request`, so every client whose AB-test seed sticks them on that endpoint gets `-32603 Internal error` on all Mainnet read-only calls (there is no failover in `ProviderURL.from`).

## Changes

- `packages/web3-shared/evm/src/constants/viem-chains.ts`: replace the dead third Mainnet RPC entry with `https://rpc.mevblocker.io` (verified working with browser-compatible CORS: reflects any `Origin`, allows `POST` + `Content-Type` on preflight).
- `packages/plugins/Debugger/src/SiteAdaptor/components/ConnectionContent.tsx`: stop hardcoding the dead URL in `onAddNetwork`; use `ProviderURL.fromOfficial(ChainId.Mainnet)` instead.