### PR TITLE
fix: mf-6831 use palette-adaptive text colors for token tag popper footer

### DIFF
--- a/packages/plugins/Trader/src/SiteAdaptor/trending/PluginDescriptor.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trending/PluginDescriptor.tsx
@@ -32,7 +32,10 @@ export function PluginDescriptor({ children, isProfilePage, isTokenTagPopper }: 
                     sx={{
                         fontWeight: 'bolder',
                         fontSize: 16,
-                        color: (theme) => theme.vars.palette.maskColor.publicMain,
+                        color: (theme) =>
+                            isTokenTagPopper ?
+                                theme.vars.palette.maskColor.main
+                            :   theme.vars.palette.maskColor.publicMain,
                     }}>
                     {isTokenTagPopper ?
                         <Trans>Web3 Profile Card</Trans>

--- a/packages/plugins/Trader/src/SiteAdaptor/trending/TrendingViewDescriptor.tsx
+++ b/packages/plugins/Trader/src/SiteAdaptor/trending/TrendingViewDescriptor.tsx
@@ -9,7 +9,9 @@ import { TrendingViewContext } from './context.js'
 import { PluginDescriptor } from './PluginDescriptor.js'
 import { Trans } from '@lingui/react/macro'
 
-const useStyles = makeStyles()((theme) => {
+const useStyles = makeStyles<{
+    isTokenTagPopper: boolean
+}>()((theme, props) => {
     return {
         source: {
             display: 'flex',
@@ -26,10 +28,10 @@ const useStyles = makeStyles()((theme) => {
         },
         selectedOption: {
             fontWeight: 700,
-            color: theme.vars.palette.maskColor.publicMain,
+            color: props.isTokenTagPopper ? theme.vars.palette.maskColor.main : theme.vars.palette.maskColor.publicMain,
         },
         arrowDropIcon: {
-            color: theme.vars.palette.maskColor.publicMain,
+            color: props.isTokenTagPopper ? theme.vars.palette.maskColor.main : theme.vars.palette.maskColor.publicMain,
         },
     }
 })
@@ -44,7 +46,7 @@ export function TrendingViewDescriptor(props: TrendingViewDescriptorProps) {
     const { result, resultList, setResult } = props
     const { isProfilePage, isTokenTagPopper } = useContext(TrendingViewContext)
 
-    const { classes } = useStyles()
+    const { classes } = useStyles({ isTokenTagPopper })
 
     const displayList = uniqBy(
         resultList.filter((x) => x.type === result.type),


### PR DESCRIPTION
## Summary

Follow-up to #12478 (MF-6831 round 1). The red packet part is confirmed fixed; on dark x.com the Web3 profile ($TAG hover) card footer text was still unreadable.

Design intent (confirmed): the card follows the site palette — in dark mode the body/footer are dark by design, and only the **text** needs to adapt. Round 1 switched the descriptor texts to `maskColor.publicMain` (fixed `#07101B`), invisible on the popper's dark footer.

Fix: pick the color token per surface, since the descriptor row renders on different backgrounds:

- **$TAG popper** (`isTokenTagPopper=true`) — the row is the card **footer**, which follows the site palette → palette-adaptive `maskColor.main` (`#07101B` light / `#F5F5F5` dark)
- **DSearch inspector** (`isTokenTagPopper=false`) — the row sits in the card's **light header** (hardcoded white gradient) → fixed `maskColor.publicMain` (`#07101B`)

Touched: `PluginDescriptor` (title "Web3 Profile Card" / "DSearch"), `TrendingViewDescriptor` (selected data source + arrow icon). Card backgrounds/surfaces untouched.

## Test plan

- [x] `pnpm dev` build, bundle verified (conditional compiled into the SiteAdaptor chunk)
- [x] Dark-mode x.com: hover `$BTC` → popper keeps white header + dark body/footer, "Web3 Profile Card" / "Powered by CoinGecko" now near-white and readable; tabs and stats readable
- [x] Dark-mode x.com: DSearch card (`$MASK` search) header — "DSearch" and "CoinGecko" render dark on the light header (computed `rgb(7,16,27)`)
- [x] Light-mode x.com: popper card unchanged
- [ ] CI green