### PR TITLE
fix: mf-6835 keep external wallet connected after done and show provider icon

### DIFF
--- a/packages/mask/popups/components/WalletAvatar/index.tsx
+++ b/packages/mask/popups/components/WalletAvatar/index.tsx
@@ -1,9 +1,10 @@
 import { Icons } from '@masknet/icons'
 import { Image } from '@masknet/shared'
-import { PersistentStorages } from '@masknet/shared-base'
+import { NetworkPluginID, PersistentStorages } from '@masknet/shared-base'
 import { makeStyles } from '@masknet/theme'
 import { isSameAddress } from '@masknet/web3-shared-base'
-import { useFireflyEmbeddedWallets } from '@masknet/web3-hooks-base'
+import { useChainContext, useFireflyEmbeddedWallets } from '@masknet/web3-hooks-base'
+import { getRegisteredWeb3Providers } from '@masknet/web3-providers'
 import { memo, useMemo, type HTMLProps } from 'react'
 import { useSubscription } from 'use-subscription'
 
@@ -28,12 +29,18 @@ interface Props extends HTMLProps<HTMLDivElement> {
 export const WalletAvatar = memo<Props>(function WalletAvatar({ size = 30, address, badgeSize = 12, ...rest }) {
     const { classes, cx } = useStyles()
     const { wallets: fireflyWallets } = useFireflyEmbeddedWallets()
+    const { providerType } = useChainContext<NetworkPluginID.PLUGIN_EVM>()
 
     const isFireflyWallet = useMemo(
         () => fireflyWallets.some((w) => isSameAddress(w.address, address)),
         [fireflyWallets, address],
     )
     const fireflyAccount = useSubscription(PersistentStorages.Settings.storage.firefly_account.subscription)
+
+    const providerIcon = useMemo(
+        () => getRegisteredWeb3Providers(NetworkPluginID.PLUGIN_EVM).find((x) => x.type === providerType)?.icon,
+        [providerType],
+    )
 
     if (isFireflyWallet && fireflyAccount)
         return (
@@ -42,5 +49,6 @@ export const WalletAvatar = memo<Props>(function WalletAvatar({ size = 30, addre
                 <Icons.Firefly className={classes.badgeIcon} size={badgeSize} />
             </div>
         )
+    if (providerIcon) return <img src={providerIcon} width={size} height={size} className={rest.className} />
     return <Icons.MaskBlue size={size} className={rest.className} />
 })

--- a/packages/mask/popups/pages/Personas/ConnectWallet/index.tsx
+++ b/packages/mask/popups/pages/Personas/ConnectWallet/index.tsx
@@ -3,7 +3,7 @@ import { FormattedAddress, PopupHomeTabType } from '@masknet/shared'
 import { PopupModalRoutes, PopupRoutes, type NetworkPluginID } from '@masknet/shared-base'
 import { ActionButton, makeStyles } from '@masknet/theme'
 import { useChainContext, useNetworkContext, useReverseAddress } from '@masknet/web3-hooks-base'
-import { EVMExplorerResolver, EVMProviderResolver, EVMWeb3 } from '@masknet/web3-providers'
+import { EVMExplorerResolver, EVMProviderResolver } from '@masknet/web3-providers'
 import { formatDomainName, formatEthereumAddress, ProviderType } from '@masknet/web3-shared-evm'
 import { Box, Button, Link, Typography } from '@mui/material'
 import { memo, useCallback } from 'react'
@@ -77,7 +77,6 @@ export const Component = memo(function ConnectWalletPage() {
     }, [modalNavigate])
 
     const handleDone = useCallback(async () => {
-        await EVMWeb3.disconnect({ providerType })
         if (providerType === ProviderType.WalletConnect) {
             navigate(urlcat(PopupRoutes.Personas, { tab: PopupHomeTabType.ConnectedWallets }), {
                 replace: true,

--- a/packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
+++ b/packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
@@ -105,8 +105,8 @@ const useStyles = makeStyles<{ disabled: boolean }>()((theme, { disabled }) => {
             height: 7,
             borderRadius: 99,
         },
-        unconnectedDot: {
-            backgroundColor: theme.vars.palette.maskColor.third,
+        connectedDot: {
+            backgroundColor: theme.vars.palette.maskColor.success,
         },
         balance: {
             fontSize: 36,
@@ -176,18 +176,12 @@ export const WalletHeaderUI = memo<WalletHeaderUIProps>(function WalletHeaderUI(
                                     {networkName}
                                 </Typography>
                             </TextOverflowTooltip>
-                            {disabled ? null : (
-                                <Icons.ArrowDrop
-                                    size={20}
-                                    className={classes.arrow}
-                                    style={{ transform: status ? 'rotate(-180deg)' : undefined }}
-                                />
-                            )}
+                            {disabled ? null : <Icons.ArrowDrop size={20} className={classes.arrow} />}
                         </Box>
                         <Typography className={classes.connected}>
-                            <span className={cx(classes.dot, classes.unconnectedDot)} />
+                            <span className={cx(classes.dot, classes.connectedDot)} />
                             <span>
-                                <Trans>Not Connected</Trans>
+                                <Trans>Connected</Trans>
                             </span>
                         </Typography>
                     </Box>

--- a/packages/shared-base-ui/src/locale/en-US.po
+++ b/packages/shared-base-ui/src/locale/en-US.po
@@ -1722,8 +1722,8 @@ msgstr ""
 #~ msgstr ""
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-#~ msgid "Connected"
-#~ msgstr ""
+msgid "Connected"
+msgstr ""
 
 #: packages/mask/popups/pages/Personas/ConnectWallet/index.tsx
 #~ msgid "Connected {0} with {walletName}."
@@ -4313,8 +4313,8 @@ msgid "Not connected"
 msgstr ""
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-msgid "Not Connected"
-msgstr ""
+#~ msgid "Not Connected"
+#~ msgstr ""
 
 #: packages/plugins/Avatar/src/Application/PersonaItem.tsx
 #~ msgid "Not current account. Please switch to this account to set up NFTs Profile."

--- a/packages/shared-base-ui/src/locale/ja-JP.po
+++ b/packages/shared-base-ui/src/locale/ja-JP.po
@@ -1727,8 +1727,8 @@ msgstr "ソーシャルプラットフォームのアカウントに接続しま
 #~ msgstr "ウォレットを接続します"
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-#~ msgid "Connected"
-#~ msgstr ""
+msgid "Connected"
+msgstr ""
 
 #: packages/mask/popups/pages/Personas/ConnectWallet/index.tsx
 #~ msgid "Connected {0} with {walletName}."
@@ -4318,8 +4318,8 @@ msgid "Not connected"
 msgstr "接続されていません"
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-msgid "Not Connected"
-msgstr ""
+#~ msgid "Not Connected"
+#~ msgstr ""
 
 #: packages/plugins/Avatar/src/Application/PersonaItem.tsx
 #~ msgid "Not current account. Please switch to this account to set up NFTs Profile."

--- a/packages/shared-base-ui/src/locale/ko-KR.po
+++ b/packages/shared-base-ui/src/locale/ko-KR.po
@@ -1727,8 +1727,8 @@ msgstr "소셜 미디어 계정을 연결하기"
 #~ msgstr "월렛 연결"
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-#~ msgid "Connected"
-#~ msgstr ""
+msgid "Connected"
+msgstr ""
 
 #: packages/mask/popups/pages/Personas/ConnectWallet/index.tsx
 #~ msgid "Connected {0} with {walletName}."
@@ -4318,8 +4318,8 @@ msgid "Not connected"
 msgstr "연결되지 않았습니다"
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-msgid "Not Connected"
-msgstr ""
+#~ msgid "Not Connected"
+#~ msgstr ""
 
 #: packages/plugins/Avatar/src/Application/PersonaItem.tsx
 #~ msgid "Not current account. Please switch to this account to set up NFTs Profile."

--- a/packages/shared-base-ui/src/locale/zh-CN.po
+++ b/packages/shared-base-ui/src/locale/zh-CN.po
@@ -1727,8 +1727,8 @@ msgstr "连接您的社交媒体帐户。"
 #~ msgstr "连接您的钱包"
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-#~ msgid "Connected"
-#~ msgstr ""
+msgid "Connected"
+msgstr ""
 
 #: packages/mask/popups/pages/Personas/ConnectWallet/index.tsx
 #~ msgid "Connected {0} with {walletName}."
@@ -4318,8 +4318,8 @@ msgid "Not connected"
 msgstr "未连接"
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-msgid "Not Connected"
-msgstr ""
+#~ msgid "Not Connected"
+#~ msgstr ""
 
 #: packages/plugins/Avatar/src/Application/PersonaItem.tsx
 #~ msgid "Not current account. Please switch to this account to set up NFTs Profile."

--- a/packages/shared-base-ui/src/locale/zh-TW.po
+++ b/packages/shared-base-ui/src/locale/zh-TW.po
@@ -1727,8 +1727,8 @@ msgstr ""
 #~ msgstr ""
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-#~ msgid "Connected"
-#~ msgstr ""
+msgid "Connected"
+msgstr ""
 
 #: packages/mask/popups/pages/Personas/ConnectWallet/index.tsx
 #~ msgid "Connected {0} with {walletName}."
@@ -4318,8 +4318,8 @@ msgid "Not connected"
 msgstr ""
 
 #: packages/mask/popups/pages/Wallet/components/WalletHeader/UI.tsx
-msgid "Not Connected"
-msgstr ""
+#~ msgid "Not Connected"
+#~ msgstr ""
 
 #: packages/plugins/Avatar/src/Application/PersonaItem.tsx
 #~ msgid "Not current account. Please switch to this account to set up NFTs Profile."


### PR DESCRIPTION
## Summary

Fixes the MF-6835 regression from #12433/#12435 (built-in Mask wallet removal): connecting an external wallet from the popup appeared to work but never stuck, and every external wallet showed Mask's own logo.

- **ConnectWallet `handleDone`**: no longer calls `EVMWeb3.disconnect({ providerType })` — "Done" keeps the connection and just closes the popup window. Pre-removal, Done intentionally fell back to the built-in Mask wallet; with that gone, the disconnect tore down the connection the user just made. Persistence already works because non-background contexts proxy KV writes to the background, which broadcasts to all open contexts.
- **`WalletAvatar`**: for non-Firefly wallets, render the current EVM provider's icon (from `getRegisteredWeb3Providers` descriptor) instead of always falling back to `Icons.MaskBlue`. MaskBlue remains the fallback when no descriptor matches.
- **`WalletHeaderUI`**: the header only renders when an account exists, so show the green dot + `Connected` instead of the hardcoded grey "Not Connected" (leftover from the `useConnected` removal); drop the dead `status` transform on the network arrow.

## Test Plan

- [x] `tsc --noEmit -p packages/mask` clean
- [x] `pnpm lint` clean
- [x] Manual verification in Chrome-for-Testing with MetaMask: connect via popup → ConnectWallet page shows MetaMask icon/name/address → Done → popup Wallet tab shows connected (green dot + Connected) → reopen popup still connected

Closes MF-6835