### PR TITLE
fix: mf-6840 drop discontinued polygon rpc 1rpc.io/matic

### DIFF
--- a/packages/web3-shared/evm/src/constants/viem-chains.ts
+++ b/packages/web3-shared/evm/src/constants/viem-chains.ts
@@ -66,7 +66,7 @@ const RPC_URL_OVERRIDES: Partial<Record<ChainId, string[]>> = {
     // viem 2.45's preset (eth.merkle.io) persistently 429s anonymous traffic
     [ChainId.Mainnet]: ['https://ethereum-rpc.publicnode.com', 'https://eth.drpc.org', 'https://cloudflare-eth.com'],
     // viem 2.45's preset (polygon-rpc.com) rejects anonymous traffic (401/403)
-    [ChainId.Polygon]: ['https://polygon-bor-rpc.publicnode.com', 'https://polygon.drpc.org', 'https://1rpc.io/matic'],
+    [ChainId.Polygon]: ['https://polygon-bor-rpc.publicnode.com', 'https://polygon.drpc.org'],
     // viem 2.45's preset is a single thirdweb free-tier endpoint
     [ChainId.BSC]: [
         'https://bsc-rpc.publicnode.com',


### PR DESCRIPTION
## Summary
- Polygon RPC `https://1rpc.io/matic` has been discontinued by Lava (`This endpoint has been discontinued.`), breaking all Polygon readonly calls for the ~⅓ of devices whose AB-test seed pins it as primary (`urls[getABTestSeed() % urls.length]` in `ProviderURL.ts`).
- Drop the dead endpoint from `RPC_URL_OVERRIDES` in `packages/web3-shared/evm/src/constants/viem-chains.ts`, leaving the two verified-live CORS-enabled fallbacks (publicnode, drpc). A 2-endpoint list has precedent (Robinhood).
- Surveyed replacements: thirdweb 429s without CORS headers, llamarpc/blastapi/blockpi/meowrpc/nodies dead, onfinality/ankr/lavanet/polygon-rpc.com key-gated — none suitable.

MF-6840