### PR TITLE
fix: use github.ref instead of github.sha in Compile concurrency group

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Tag pushes and branch pushes for the same commit share the same `github.sha`, so both fall into the same `Compile` workflow concurrency group.
- With `cancel-in-progress: true`, whichever run started later cancels the earlier one before its jobs even start.
- This is what happened for the `v2.36.0` release: the `released`-branch push run started 5s after the `v2.36.0` tag push run and cancelled it, so the release-publish step (`marvinpinto/action-automatic-releases`, gated on `refs/tags/v*`) never ran — no draft/release was created on the [Releases page](https://github.com/DimensionDev/Maskbook/releases).
- Fix: key the concurrency group on `github.ref` instead of `github.sha` for non-PR events, so tag pushes and branch pushes of the same commit no longer collide.

## Test plan
- [ ] Merge and push a version bump again, confirm both the branch-push and tag-push `Compile` runs complete independently (no cancellation) and the tag run publishes a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKMxkCAVGzSyvaCghCNDSq