### PR TITLE
feat: add automated release preparation and tagging workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,75 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine base branch
+        id: base
+        run: |
+          if [ "${{ inputs.bump }}" = "patch" ]; then
+            echo "branch=released" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=develop" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.base.outputs.branch }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+
+      - name: Bump version
+        id: version
+        run: |
+          NEW_VERSION=$(npm version "${{ inputs.bump }}" --no-git-tag-version | sed 's/^v//')
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Determine release branch name
+        id: branch
+        run: |
+          if [ "${{ inputs.bump }}" = "patch" ]; then
+            echo "name=hotfix/${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=release/${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.branch.outputs.name }}"
+          git add package.json
+          git commit -m "chore: bump version ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.branch.outputs.name }}"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --base "${{ steps.base.outputs.branch }}" \
+            --head "${{ steps.branch.outputs.name }}" \
+            --title "[Release] New release ${{ steps.version.outputs.version }} (${{ inputs.bump }})" \
+            --body "Automated version bump to \`${{ steps.version.outputs.version }}\` (${{ inputs.bump }}). Merging this into \`${{ steps.base.outputs.branch }}\`$( [ "${{ steps.base.outputs.branch }}" = "released" ] && echo " will automatically tag and publish the release." || echo "; promoting develop to released still needs to be done separately.")"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,39 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Release] New release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: released
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+
+      - name: Read version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" > /dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
Two new workflows to automate the version-bump-and-release flow:

- **`prepare-release.yml`** (`workflow_dispatch`, choose `patch` / `minor` / `major`): bumps `package.json` with `npm version <bump> --no-git-tag-version`, commits `chore: bump version X.Y.Z`, pushes a branch, and opens a PR titled `[Release] New release X.Y.Z (type)`.
  - `patch` → branch `hotfix/X.Y.Z` → PR base `released` (matches the existing hotfix convention, e.g. #12406).
  - `minor`/`major` → branch `release/X.Y.Z` → PR base `develop` (matches the existing release convention, e.g. #12489).
- **`tag-release.yml`**: triggers when a `[Release] New release` PR merges into `released`. Reads the version from `package.json` on `released` and pushes tag `vX.Y.Z`, which fires the `Compile` workflow's tag-triggered release-publish step (`marvinpinto/action-automatic-releases`) — this is safe now that #12490 keys the `Compile` concurrency group on `github.ref` instead of `github.sha`, so the branch-push and tag-push runs no longer race/cancel each other.

Note: for `minor`/`major`, promoting `develop` to `released` (fast-forwarding released + this automation taking over from there) is still a manual step — only the `patch`/hotfix path auto-publishes today. Happy to extend this to also handle the develop→released promotion if wanted.

## Test plan
- [ ] Manually dispatch `Prepare Release` with `bump: patch`, confirm it opens a `hotfix/X.Y.Z` PR into `released` with the right title and single `package.json` diff.
- [ ] Manually dispatch with `bump: minor` (or `major`), confirm it opens a `release/X.Y.Z` PR into `develop`.
- [ ] Merge a patch PR into `released` and confirm `tag-release.yml` pushes the tag and a GitHub Release gets published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKMxkCAVGzSyvaCghCNDSq