### PR TITLE
fix: mf-6839 decode red packet transactions with 0x-prefixed calldata

### DIFF
--- a/packages/web3-providers/src/Web3/EVM/state/TransactionFormatter/descriptors/RedPacket.ts
+++ b/packages/web3-providers/src/Web3/EVM/state/TransactionFormatter/descriptors/RedPacket.ts
@@ -106,7 +106,7 @@ export class RedPacketDescriptor extends DescriptorWithTransactionDecodedReceipt
                         method: method.name,
                     },
                 }
-            } else {
+            } else if (method?.name === 'refund') {
                 const tokenAmountDescription = await this.getRefundTokenInfo(context.chainId, context.to, context.hash)
                 return {
                     chainId: context.chainId,

--- a/packages/web3-shared/evm/src/libs/AccountTransaction.ts
+++ b/packages/web3-shared/evm/src/libs/AccountTransaction.ts
@@ -39,7 +39,8 @@ export class AccountTransaction {
     }
 
     get functionParameters() {
-        return this.data?.slice(10)
+        const data = this.data
+        return data ? `0x${data.slice(10)}` : undefined
     }
 
     fill(overrides?: Transaction): Transaction {


### PR DESCRIPTION
## Summary

Fixes [MF-6839](https://mask.atlassian.net/browse/MF-6839). ERC20 red packet creation on Polygon failed with a misleading toast: **"Refund Lucky drop — Failed to refund Lucky Drop."** while the dialog stayed stuck at the Confirm step.

### Root cause

`AccountTransaction.functionParameters` returned calldata **without the `0x` prefix** (`data.slice(10)`). `EVMTransactionFormatter.createTransactionContext` feeds it to viem's `decodeAbiParameters`, whose `hexToBytes` does `hex.slice(2)` unconditionally, dropping one byte and misaligning the decode → throws. The `try/catch` swallows it → `methods: undefined`, so `RedPacketDescriptor.compute` misses the `create_red_packet` branch and falls into the catch-all `else` = "Refund Lucky drop". Every create/claim outcome (success included) was announced as a refund.

Regression introduced by 9bff15f231 (migrate TransactionFormatter from abiCoder to viem): web3.js `decodeParameters` accepted unprefixed hex, viem requires `0x`.

Verified with the repo's own viem (`decodeAbiParameters` over a real `create_red_packet` calldata, same call path as the formatter):
- unprefixed (as shipped): throws `Bytes value "1,0" is not a valid boolean`
- `0x`-prefixed (fixed): decodes all 10 parameters

Note: this mislabels toasts/popup copy; it does not itself break the transaction. The corrected toast will surface the true underlying error for QA's ERC20 case if anything remains.

## Changes

1. `AccountTransaction.functionParameters` now returns `0x`-prefixed hex (symmetric with `functionSignature`). Its only consumer is the formatter call site.
2. `RedPacketDescriptor`: the bare `else` becomes `else if (method?.name === 'refund')`, so any future undecodable tx to the red packet contract falls through to the generic contract-interaction label instead of claiming "Refund".

## Test Plan

- [x] Node repro against the repo's viem: old path throws, new path decodes all params (selector `0x5db05aba`, 10 inputs incl. `_token_addr` / `_total_tokens`)
- [x] `pnpm lint` clean
- [ ] Manual: create a lucky drop on Polygon (native POL) — success toast should read "Lucky drop with … POL created." instead of refund copy
- [ ] Manual: ERC20 create on Polygon — if the tx still fails, the toast now reports "Failed to create Lucky Drop." with the real error surfaced (RPC replay of the exact `create_red_packet` calldata via `eth_estimateGas` on publicnode + drpc both return valid results, so the RPC is not the culprit)

[MF-6839]: https://mask.atlassian.net/browse/MF-6839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ