### PR TITLE
fix: restore medium input height

### DIFF
--- a/packages/theme/src/Theme/component-changes.tsx
+++ b/packages/theme/src/Theme/component-changes.tsx
@@ -786,6 +786,7 @@ export const InputBase = {
                     },
                     style: {
                         fontSize: 14,
+                        minHeight: 40,
                         [`& .${inputBaseClasses.input}`]: {
                             padding: '11px 12px',
                             height: 18,


### PR DESCRIPTION
## Summary

- restore the global medium InputBase minimum height to 40px
- keep existing typography and padding behavior intact
- allow multiline inputs to continue growing beyond the minimum

## Tests

- pnpm exec eslint packages/theme/src/Theme/component-changes.tsx --max-warnings=0
- pnpm exec prettier --check packages/theme/src/Theme/component-changes.tsx
- pnpm exec tsc -p packages/theme/tsconfig.json --noEmit
- npx -y react-doctor@latest . --verbose --diff (100/100)
- pnpm build