### PR TITLE
fix: mf-6842 replace dead Solana RPC and token list endpoints

### DIFF
--- a/packages/web3-hooks/base/src/useFungibleToken.ts
+++ b/packages/web3-hooks/base/src/useFungibleToken.ts
@@ -3,10 +3,11 @@ import type { Web3Helper } from '@masknet/web3-helpers'
 import { getHub } from '@masknet/web3-providers'
 import type { HubOptions } from '@masknet/web3-providers/types'
 import { attemptUntil } from '@masknet/web3-shared-base'
-import { isNativeTokenAddress, isValidAddress } from '@masknet/web3-shared-evm'
+import { isNativeTokenAddress } from '@masknet/web3-shared-evm'
 import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { useChainContext, useNetworkContext } from './useContext.js'
 import { useNetworks } from './useNetworks.js'
+import { useWeb3Utils } from './useWeb3Utils.js'
 
 export function useFungibleToken<S extends 'all' | void = void, T extends NetworkPluginID = NetworkPluginID>(
     pluginID?: T,
@@ -17,10 +18,13 @@ export function useFungibleToken<S extends 'all' | void = void, T extends Networ
     const { chainId } = useChainContext({ chainId: options?.chainId })
     const { pluginID: contextPluginID } = useNetworkContext(pluginID)
     const networks = useNetworks(contextPluginID)
+    const Utils = useWeb3Utils(pluginID)
 
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     return useQuery({
-        enabled: !!address && isValidAddress(address),
+        // the EVM isAddress gate rejects Solana base58 addresses and disabled the
+        // query forever, so validate with the utils of the actual network plugin
+        enabled: !!address && Utils.isValidAddress(address),
         queryKey: ['fungible-token', contextPluginID, address, chainId, options],
         queryFn: async (): Promise<Web3Helper.FungibleTokenScope<S, T> | null> => {
             return (

--- a/packages/web3-providers/src/Web3/Solana/apis/FungibleTokenAPI.ts
+++ b/packages/web3-providers/src/Web3/Solana/apis/FungibleTokenAPI.ts
@@ -1,13 +1,6 @@
 import { memoize, uniqBy } from 'lodash-es'
 import { memoizePromise } from '@masknet/kit'
-import {
-    type PageIndicator,
-    type Pageable,
-    createPageable,
-    createIndicator,
-    EMPTY_LIST,
-    NetworkPluginID,
-} from '@masknet/shared-base'
+import { type PageIndicator, type Pageable, createPageable, createIndicator, EMPTY_LIST } from '@masknet/shared-base'
 import {
     type FungibleAsset,
     TokenType,
@@ -26,7 +19,7 @@ import {
 } from '@masknet/web3-shared-solana'
 import { SolanaChainResolver } from './ResolverAPI.js'
 import defer * as CoinGeckoPriceSolana from '../../../CoinGecko/index.js'
-import { JUP_TOKEN_LIST, RAYDIUM_TOKEN_LIST, SPL_TOKEN_PROGRAM_ID } from '../constants/index.js'
+import { RAYDIUM_TOKEN_LIST, SPL_TOKEN_PROGRAM_ID } from '../constants/index.js'
 import { createFungibleAsset, createFungibleToken, requestRPC } from '../helpers/index.js'
 import type {
     GetBalanceResponse,
@@ -37,22 +30,6 @@ import type {
 } from '../types/index.js'
 import { fetchJSON } from '../../../helpers/fetchJSON.js'
 import type { FungibleTokenAPI, TokenListAPI } from '../../../entry-types.js'
-
-interface JupToken {
-    address: string
-    name: string
-    symbol: string
-    decimals: number
-    logoURI: string
-    tags: string[]
-    daily_volume: number
-    /** @example '2024-04-26T10:56:58.893768Z' */
-    created_at: string
-    freeze_authority: null
-    mint_authority: null
-    permanent_delegate: null
-    minted_at: null
-}
 
 const fetchRaydiumTokenList = memoizePromise(
     memoize,
@@ -74,28 +51,6 @@ const fetchRaydiumTokenList = memoizePromise(
             }
         })
         return tokens
-    },
-    (url) => url,
-)
-
-const fetchJupTokenList = memoizePromise(
-    memoize,
-    async (url: string): Promise<Array<FungibleToken<ChainId, SchemaType>>> => {
-        const tokens = await fetchJSON<JupToken[]>(url, {
-            cache: 'force-cache',
-        })
-        return tokens.map((token) => ({
-            id: token.address,
-            runtime: NetworkPluginID.PLUGIN_SOLANA,
-            chainId: ChainId.Mainnet,
-            type: TokenType.Fungible,
-            schema: SchemaType.Fungible,
-            address: token.address,
-            name: token.name,
-            symbol: token.symbol,
-            decimals: token.decimals,
-            logoURL: token.logoURI,
-        }))
     },
     (url) => url,
 )
@@ -206,15 +161,17 @@ class SolanaFungibleTokenAPI
 
     async getFungibleTokenList(chainId: ChainId): Promise<Array<FungibleToken<ChainId, SchemaType>>> {
         const { FUNGIBLE_TOKEN_LISTS = EMPTY_LIST } = getTokenListConstants(chainId)
-        const [maskTokenList, jupTokenList, raydiumTokenList] = await Promise.all([
+        // token list sources are best-effort: one dead feed must not take down every
+        // Solana balance/token fetch (tokens.jup.ag was cut off by Jupiter in 2025)
+        const allSettled = await Promise.allSettled([
             fetchMaskTokenList(FUNGIBLE_TOKEN_LISTS[0]),
-            fetchJupTokenList(JUP_TOKEN_LIST),
             fetchRaydiumTokenList(RAYDIUM_TOKEN_LIST),
         ])
+        const [maskResult, raydiumResult] = allSettled
+        const maskTokenList = maskResult.status === 'fulfilled' ? maskResult.value : []
+        const raydiumTokenList = raydiumResult.status === 'fulfilled' ? raydiumResult.value : []
 
-        return uniqBy([...jupTokenList, ...maskTokenList, ...raydiumTokenList], (x) => x.address).filter(
-            (x) => x.name && x.symbol,
-        )
+        return uniqBy([...maskTokenList, ...raydiumTokenList], (x) => x.address).filter((x) => x.name && x.symbol)
     }
 
     async getNonFungibleTokenList(

--- a/packages/web3-providers/src/Web3/Solana/constants/index.ts
+++ b/packages/web3-providers/src/Web3/Solana/constants/index.ts
@@ -1,5 +1,4 @@
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 
 export const RAYDIUM_TOKEN_LIST = 'https://api-v3.raydium.io/mint/list'
-export const JUP_TOKEN_LIST = 'https://tokens.jup.ag/tokens?tags=verified'
 export const SPL_TOKEN_PROGRAM_ID = TOKEN_PROGRAM_ID.toBase58()

--- a/packages/web3-providers/src/Web3/Solana/helpers/index.ts
+++ b/packages/web3-providers/src/Web3/Solana/helpers/index.ts
@@ -6,11 +6,11 @@ import {
     multipliedBy,
     TokenType,
 } from '@masknet/web3-shared-base'
-import { type ChainId, createClientEndpoint, SchemaType } from '@masknet/web3-shared-solana'
+import { type ChainId, fetchWithFailover, SchemaType } from '@masknet/web3-shared-solana'
 import type { RpcOptions } from '../types/index.js'
 
 export async function requestRPC<T = unknown>(chainId: ChainId, options: RpcOptions): Promise<T> {
-    const response = await globalThis.fetch(createClientEndpoint(chainId), {
+    const response = await fetchWithFailover(chainId, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
@@ -23,7 +23,7 @@ export async function requestRPC<T = unknown>(chainId: ChainId, options: RpcOpti
         }),
     })
     const json = await response.json()
-    if (json.error) throw new Error(json.message || 'Fails in requesting RPC')
+    if (json.error) throw new Error(json.error?.message || 'Fails in requesting RPC')
     return json
 }
 

--- a/packages/web3-shared/solana/src/sdk/index.ts
+++ b/packages/web3-shared/solana/src/sdk/index.ts
@@ -1,19 +1,47 @@
 import defer * as SolanaWeb3 from '@solana/web3.js'
 import { ChainId } from '../types.js'
 
-const Endpoints: Record<ChainId, string> = {
-    [ChainId.Mainnet]: 'https://solana-mainnet.phantom.app/YBPpkkN4g91xDiAnTE9r0RcMkjg0sKUIWvAfoFVJ',
-    [ChainId.Testnet]: 'https://api.testnet.solana.com',
-    [ChainId.Devnet]: 'https://api.devnet.solana.com',
-    [ChainId.Invalid]: '',
+// Vibe Station is the only public endpoint serving indexed requests (filtered getProgramAccounts),
+// which the SPL token list and the SNS domain lookups rely on, so it must stay first.
+// The others reject indexed requests and are kept as failover backups for plain calls only.
+const Endpoints: Record<ChainId, string[]> = {
+    [ChainId.Mainnet]: [
+        'https://public.rpc.solanavibestation.com',
+        'https://solana-rpc.publicnode.com',
+        'https://solana.api.pocket.network',
+        'https://solana.leorpc.com/?api_key=FREE',
+    ],
+    [ChainId.Testnet]: ['https://api.testnet.solana.com'],
+    [ChainId.Devnet]: ['https://api.devnet.solana.com'],
+    [ChainId.Invalid]: [],
+}
+
+export function createClientEndpoints(chainId = ChainId.Mainnet) {
+    return Endpoints[chainId]
 }
 
 export function createClientEndpoint(chainId = ChainId.Mainnet) {
-    return Endpoints[chainId]
+    return Endpoints[chainId][0] ?? ''
+}
+
+export async function fetchWithFailover(chainId: ChainId, init?: RequestInit) {
+    let lastError: unknown
+    for (const endpoint of createClientEndpoints(chainId)) {
+        try {
+            const response = await globalThis.fetch(endpoint, init)
+            if (response.ok) return response
+            lastError = new Error(`Solana RPC ${endpoint} responded with HTTP ${response.status}`)
+        } catch (error) {
+            lastError = error
+        }
+    }
+    throw lastError instanceof Error ? lastError : new Error('No Solana RPC endpoint is available')
 }
 
 export function createClient(chainId = ChainId.Mainnet) {
     return new SolanaWeb3.Connection(createClientEndpoint(chainId), {
         commitment: 'confirmed',
+        // replay the request against the backup endpoints when the primary one fails
+        fetch: (_info, init) => fetchWithFailover(chainId, init),
     })
 }

--- a/security/content-security-policy.json
+++ b/security/content-security-policy.json
@@ -65,7 +65,10 @@
         "https://api.thegraph.com",
         "https://mainnet.infura.io",
         "https://polygon-mainnet.infura.io",
-        "https://solana-mainnet.phantom.app",
+        "https://public.rpc.solanavibestation.com",
+        "https://solana-rpc.publicnode.com",
+        "https://solana.api.pocket.network",
+        "https://solana.leorpc.com",
         "https://api.testnet.solana.com",
         "https://api.devnet.solana.com",
         "https://li.quest"


### PR DESCRIPTION
## Summary
Three issues were breaking Solana balance display; all verified against the live extension:

### 1. RPC endpoint (CORS preflight 403)
The Phantom app-key RPC (`solana-mainnet.phantom.app`, in use since mf-2236) returns **403** on the CORS preflight, so every Solana mainnet RPC request was blocked by the browser.

Replaced with an **ordered failover chain** — every Solana RPC call (raw `requestRPC` fetches and `@solana/web3.js` `Connection` calls, via the `fetch` option of `ConnectionConfig`) retries the next endpoint on HTTP-level failure:

| Endpoint | preflight | `getBalance` | filtered `getProgramAccounts` (SPL token list, SNS domains) |
|---|---|---|---|
| `public.rpc.solanavibestation.com` | 204 `*` | ✅ | ✅ **only endpoint that allows indexed requests** → primary |
| `solana-rpc.publicnode.com` | 204 `*` | ✅ | ❌ "Indexed requests require a personal token" |
| `solana.api.pocket.network` | 200 | ✅ | ❌ program excluded from account scan |
| `solana.leorpc.com/?api_key=FREE` | 200 | ✅ | ❌ scan-size limit |

Testnet/Devnet official endpoints still work and are unchanged.

### 2. Token list endpoint (dead domain)
`getFungibleTokenList` fetched three remote lists with `Promise.all`, one of which (`tokens.jup.ag/tokens?tags=verified`) was **cut off by Jupiter in 2025** (domain no longer resolves). One dead feed rejected the whole `Promise.all`, so token-list-dependent queries never settled.

- Removed the dead Jupiter source (its replacement `lite-api.jup.ag/tokens/v2/recent` only serves 30 recent tokens, no lookup value)
- `Promise.all` → `Promise.allSettled` so a dead feed degrades gracefully instead of taking down every Solana balance fetch
- Remaining sources: Mask r2d2 curated list + Raydium full mint list (both verified live)

### 3. Shared hook disabled for non-EVM addresses (the `-` in the wallet account dialog)
`useFungibleToken` gated its react-query with the **EVM** `isValidAddress`, so Solana base58 addresses (e.g. the native `So1111…112`) always failed the check → the query was permanently `enabled: false` → `useNativeToken` stayed `isPending` forever → the wallet status box rendered `-` even though the balance query itself had resolved. Validate with the **plugin-scoped** `useWeb3Utils().isValidAddress` instead (EVM behavior unchanged).

Also fixes `requestRPC` error propagation (`json.message` → `json.error.message`) and updates `security/content-security-policy.json` (dev `--csp` builds) for the new RPC hosts.

## Verification
- All 4 RPC endpoints live-tested (preflight + `getBalance` + filtered `getProgramAccounts`); matrix above
- From the extension's own MV3 service worker context: `getBalance` on the new primary → HTTP 200 with balance; old Phantom URL → `TypeError: Failed to fetch` (reproduces QA's report in-context)
- Token list sources curl-verified (r2d2 200, Raydium 200, tokens.jup.ag dead)
- Hook fix verified in the dev extension: with the EVM gate, the `fungible-token` query never appeared in the react-query cache; balance query resolved (`640008010`) while the dialog still showed `-`

## Related Issue
Closes MF-6842